### PR TITLE
use docker-client 2.3.0

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.2.1</version>
+      <version>2.3.0</version>
     </dependency>
 
     <!--test deps-->


### PR DESCRIPTION
docker-client 2.3.0 adds interruptibility; using it allows the agent to interrupt task runners.
