### PR TITLE
cli: hosts: fix docker version backwards compat

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -154,7 +154,7 @@ public class HostListCommand extends ControlCommand {
             loadAvg = format("%.2f", hi.getLoadAvg());
             os = hi.getOsName() + " " + hi.getOsVersion();
             final DockerVersion dv = hi.getDockerVersion();
-            docker = format("%s (%s)", dv, dv.getApiVersion());
+            docker = (dv != null) ? format("%s (%s)", dv, dv.getApiVersion()) : "";
           } else {
             memUsage = cpus = mem = loadAvg = os = docker = "";
           }


### PR DESCRIPTION
Helios pre-0.0.28 did not report docker version.
The hosts command thus NPE's on pre-0.0.28 helios
installations.
