### PR TITLE
use docker-client 2.3.1

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.3.0</version>
+      <version>2.3.1</version>
     </dependency>
 
     <!--test deps-->


### PR DESCRIPTION
docker-client 2.3.1 contains a fix where
ImageInfo fields would all be null due to
erroneous @JsonProperty annotations. This in turn
made the syslog redirection decorator NPE.
