### PR TITLE
cli: hosts: print docker x.yy.zzz version only

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -154,7 +154,7 @@ public class HostListCommand extends ControlCommand {
             loadAvg = format("%.2f", hi.getLoadAvg());
             os = hi.getOsName() + " " + hi.getOsVersion();
             final DockerVersion dv = hi.getDockerVersion();
-            docker = (dv != null) ? format("%s (%s)", dv, dv.getApiVersion()) : "";
+            docker = (dv != null) ? format("%s (%s)", dv.getVersion(), dv.getApiVersion()) : "";
           } else {
             memUsage = cpus = mem = loadAvg = os = docker = "";
           }


### PR DESCRIPTION
The cli currently prints something like:

DockerVersion{apiVersion=1.12, arch=amd64, gitCommit=688b5cf-dirty, 
goVersion=go1.2.1, kernelVersion=3.13.0-24-generic, os=linux, 
version=1.0.0} (1.12)

We want something like: 1.0.0 (1.12)
