### PR TITLE
master/agent: fast shut down using SIGKILL

### DIFF
--- a/src/deb/helios-agent/upstart
+++ b/src/deb/helios-agent/upstart
@@ -6,6 +6,8 @@ author "Rohan Singh <rohan@spotify.com>"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+kill signal SIGKILL
+
 respawn
 respawn limit unlimited
 

--- a/src/deb/helios-master/upstart
+++ b/src/deb/helios-master/upstart
@@ -6,6 +6,8 @@ author "Rohan Singh <rohan@spotify.com>"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+kill signal SIGKILL
+
 respawn
 respawn limit unlimited
 


### PR DESCRIPTION
- There's no state that must be persisted.
- Let the kernel deal with closing sockets etc.
- Let zookeeper figure out that the agent is gone.
