### PR TITLE
do not run zk updater tests in parallel

### DIFF
--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectoryTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectoryTest.java
@@ -44,7 +44,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.zookeeper.KeeperException.NodeExistsException;
 import static org.junit.Assert.assertArrayEquals;
 
-@RunWith(Parallelized.class)
 public class ZooKeeperUpdatingPersistentDirectoryTest {
 
   private static final String PARENT_PATH = "/foobar";


### PR DESCRIPTION
Avoid concurrently spawning a lot of sub processes, which makes travis sad.
