### PR TITLE
travis: only build using oracle jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
   - oraclejdk7
-  - openjdk7
 
 cache:
   directories:


### PR DESCRIPTION
Building with openjdk does not give us much. Since java 7, openjdk and
oracle jdk are similar enough that if something runs on the oracle jdk,
it will very likely work on openjdk as well. Also, we do not use
openjdk ourselves.

As such, the build agent that gets consumed by the openjdk can be better
used building other PR's.
