### PR TITLE
zk: use curator 2.5.0

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/helios-testing-common/pom.xml
+++ b/helios-testing-common/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Curator 2.5.0 contains a PersistentEphemeralNode fix the we might have been hitting when seeing ephemeral node split brain syndrome.

https://github.com/apache/curator/commit/bfdef2ddc1c3f2121256045690b39baafa269151
