### PR TITLE
travis: Export MAVEN_OPTS in before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ before_install:
 
 before_script:
   - . .travis.sh before_script
-
-script: MAVEN_OPTS="-Xmx128m" mvn test
+  - export MAVEN_OPTS="-Xmx128m"


### PR DESCRIPTION
Rather than overriding script section altogether, just set MAVEN_OPTS. This
preserves any options that Travis passes to Maven by default, such as the
"-B" batch mode flag.
