### PR TITLE
Added Deprecated legacy method to ServiceRegistration

### DIFF
--- a/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
+++ b/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
@@ -49,6 +49,14 @@ public class ServiceRegistration {
 
     private List<Endpoint> endpoints = new ArrayList<>();
 
+    @Deprecated
+    public Builder endpoint(final String name,
+                            final String protocol,
+                            final int port) {
+      endpoints.add(new Endpoint(name, protocol, port, "", ""));
+      return this;
+    }
+
     public Builder endpoint(final String name,
                             final String protocol,
                             final int port,


### PR DESCRIPTION
To keep the nameless registrar plugin tests happy for now.
