### PR TITLE
Explicitly set empty domain for system tests

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/AgentStateDirConflictTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/AgentStateDirConflictTest.java
@@ -70,7 +70,8 @@ public class AgentStateDirConflictTest {
                         "--no-http",
                         "--name=" + name,
                         "--zk=" + zk.connectString(),
-                        "--state-dir", stateDir.toString());
+                        "--state-dir", stateDir.toString(),
+                        "--domain", "");
   }
 
   @After

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -475,6 +475,7 @@ public abstract class SystemTestBase {
                                                "--http", masterEndpoint(),
                                                "--admin=" + masterAdminPort(),
                                                "--name", TEST_MASTER,
+                                               "--domain", "",
                                                "--zk", zk.connectString());
     argsList.addAll(asList(args));
     startMaster(argsList.toArray(new String[argsList.size()]));
@@ -513,6 +514,7 @@ public abstract class SystemTestBase {
                                                      "--zk-session-timeout", "100",
                                                      "--zk-connection-timeout", "100",
                                                      "--state-dir", stateDir,
+                                                     "--domain", "",
                                                      "--port-range=" +
                                                      dockerPortRange.lowerEndpoint() + ":" +
                                                      dockerPortRange.upperEndpoint()


### PR DESCRIPTION
Seting an empty domain skips service registration. We want that to be the
default for the tests since we usually don't want to test service
registration or setup the mocks required to do so.
