### PR TITLE
Add the ability to specify a HELIOS_MASTER environment variable

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -23,7 +23,9 @@ package com.spotify.helios.cli;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Lists;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -32,6 +34,7 @@ import com.spotify.helios.common.Json;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
@@ -41,10 +44,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CliConfig {
 
+  private static final String HTTP_SCHEME = "http";
+  private static final String SITE_SCHEME = "site";
+  private static final String MASTER_ENDPOINTS_KEY = "masterEndpoints";
+  private static final String SITES_KEY = "sites";
+  private static final String SRV_NAME_KEY = "srvName";
   private static final String CONFIG_PATH = ".helios" + File.separator + "config";
   public static final List<String> EMPTY_STRING_LIST = Collections.emptyList();
   public static final TypeReference<Map<String, Object>> OBJECT_TYPE =
       new TypeReference<Map<String, Object>>() {};
+
+  static Map<String, String> environment = System.getenv();
 
   private final String username;
   private final List<String> sites;
@@ -86,9 +96,10 @@ public class CliConfig {
    *
    * If the file is not found, a CliConfig with pre-defined values will be returned.
    *
-   * @throws IOException   If the file exists but could not be read
+   * @throws IOException        If the file exists but could not be read
+   * @throws URISyntaxException If a HELIOS_MASTER env var is present and doesn't parse as a URI
    */
-  public static CliConfig fromUserConfig() throws IOException {
+  public static CliConfig fromUserConfig() throws IOException, URISyntaxException {
     final String userHome = System.getProperty("user.home");
     final String defaults = userHome + File.separator + CONFIG_PATH;
     final File defaultsFile = new File(defaults);
@@ -100,10 +111,11 @@ public class CliConfig {
    *
    * If the file is not found, a CliConfig with pre-defined values will be returned.
    *
-   * @param defaultsFile The file to parse from
-   * @throws IOException   If the file exists but could not be read
+   * @param defaultsFile        The file to parse from
+   * @throws IOException        If the file exists but could not be read
+   * @throws URISyntaxException If a HELIOS_MASTER env var is present and doesn't parse as a URI
    */
-  public static CliConfig fromFile(File defaultsFile) throws IOException {
+  public static CliConfig fromFile(File defaultsFile) throws IOException, URISyntaxException {
     final Map<String, Object> config;
     // TODO: use typesafe config for config file parsing
     if (defaultsFile.exists() && defaultsFile.canRead()) {
@@ -111,7 +123,37 @@ public class CliConfig {
     } else {
       config = ImmutableMap.of();
     }
-    return fromMap(config);
+    return fromEnvVar(config);
+  }
+
+  public static CliConfig fromEnvVar(Map<String, Object> config) throws URISyntaxException {
+    final String master = environment.get("HELIOS_MASTER");
+    if (master == null) {
+      return fromMap(config);
+    }
+
+    // Specifically only include relevant bits according to the env var setting, rather than
+    // strictly overlaying config so that if the config file has a setting for master endpoints, the
+    // file doesn't override the env var if it's a site:// as masterEndpoints takes precedence over
+    // sites.
+    final URI uri = new URI(master);
+    final Builder<String, Object> builder = ImmutableMap.<String, Object>builder();
+    // Always include the srvName bit if it's specified, so it can be specified in the file and
+    // a site flag could be passed on the command line, and it would work as you'd hope.
+    if (config.containsKey(SRV_NAME_KEY)) {
+      builder.put(SRV_NAME_KEY, config.get(SRV_NAME_KEY));
+    }
+
+    final String scheme = uri.getScheme();
+    if (SITE_SCHEME.equals(scheme)) {
+      builder.put(SITES_KEY, ImmutableList.of(uri.getHost())).build();
+    } else if (HTTP_SCHEME.equals(scheme)) {
+      builder.put(MASTER_ENDPOINTS_KEY, ImmutableList.of(master));
+    } else {
+      throw new RuntimeException("Unknown Scheme " + scheme
+          + " in HELIOS_MASTER env variable setting of [" + master + "]");
+    }
+    return fromMap(builder.build());
   }
 
   /**
@@ -121,10 +163,10 @@ public class CliConfig {
    */
   public static CliConfig fromMap(Map<String, Object> config) {
     checkNotNull(config);
-    final List<String> sites = getList(config, "sites", EMPTY_STRING_LIST);
-    final String srvName = getString(config, "srvName", "helios");
+    final List<String> sites = getList(config, SITES_KEY, EMPTY_STRING_LIST);
+    final String srvName = getString(config, SRV_NAME_KEY, "helios");
     final List<URI> masterEndpoints = Lists.newArrayList();
-    for (final String endpoint : getList(config, "masterEndpoints", EMPTY_STRING_LIST)) {
+    for (final String endpoint : getList(config, MASTER_ENDPOINTS_KEY, EMPTY_STRING_LIST)) {
       masterEndpoints.add(URI.create(endpoint));
     }
     return new CliConfig(sites, srvName, masterEndpoints);

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -58,6 +58,7 @@ import net.sourceforge.argparse4j.inf.Subparsers;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -77,10 +78,10 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 public class CliParser {
 
   private static final String NAME_AND_VERSION = "Spotify Helios CLI " + Version.POM_VERSION;
-  private static final String HELP_JIRA =
-      "Report improvements/bugs at https://jira.spotify.net/browse/HEL";
+  private static final String HELP_ISSUES =
+      "Report improvements/bugs at https://github.com/spotify/helios/issues";
   private static final String HELP_WIKI =
-      "For documentation see https://wiki.spotify.net/wiki/Helios";
+      "For documentation see https://github.com/spotify/helios/wiki";
 
   private final Namespace options;
   private final ControlCommand command;
@@ -92,12 +93,12 @@ public class CliParser {
   private boolean json;
 
   public CliParser(final String... args)
-      throws ArgumentParserException, IOException {
+      throws ArgumentParserException, IOException, URISyntaxException {
 
     final ArgumentParser parser = ArgumentParsers.newArgumentParser("helios")
         .defaultHelp(true)
         .version(NAME_AND_VERSION)
-        .description(format("%s%n%n%s%n%s", NAME_AND_VERSION, HELP_JIRA, HELP_WIKI));
+        .description(format("%s%n%n%s%n%s", NAME_AND_VERSION, HELP_ISSUES, HELP_WIKI));
 
     cliConfig = CliConfig.fromUserConfig();
 
@@ -219,7 +220,7 @@ public class CliParser {
    */
   @SuppressWarnings("UseOfSystemOutOrSystemErr")
   private void handleError(ArgumentParser parser, ArgumentParserException e) {
-    System.err.println("# " + HELP_JIRA);
+    System.err.println("# " + HELP_ISSUES);
     System.err.println("# " + HELP_WIKI);
     System.err.println("# ---------------------------------------------------------------");
     parser.handleError(e);

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
@@ -1,0 +1,53 @@
+package com.spotify.helios.cli;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CliConfigTest {
+  private static final String SITE_NAME = "RaNd0m";
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testSite() throws Exception {
+    CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", "site://" + SITE_NAME);
+    final CliConfig config = CliConfig.fromUserConfig();
+    assertEquals(ImmutableList.of(SITE_NAME), config.getSites());
+    assertTrue(config.getMasterEndpoints().isEmpty());
+  }
+
+  @Test
+  public void testHttp() throws Exception {
+    final String uri = "http://localhost:5801";
+    CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", uri);
+    final CliConfig config = CliConfig.fromUserConfig();
+    assertEquals(ImmutableList.of(new URI(uri)), config.getMasterEndpoints());
+    assertTrue(config.getSites().isEmpty());
+  }
+
+  @Test
+  public void testMixtureOfFileAndEnv() throws Exception {
+    final File file = temporaryFolder.newFile();
+    try (final FileOutputStream outFile = new FileOutputStream(file)) {
+      outFile.write(Charsets.UTF_8.encode(
+          "{\"masterEndpoints\":[\"http://localhost:5801\"], \"srvName\":\"foo\"}").array());
+      CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", "site://" + SITE_NAME);
+      final CliConfig config = CliConfig.fromFile(file);
+
+      assertEquals(ImmutableList.of(SITE_NAME), config.getSites());
+      assertTrue(config.getMasterEndpoints().isEmpty());
+      assertEquals("foo", config.getSrvName());
+    }
+  }
+}


### PR DESCRIPTION
It will tell the CLI where to talk to to reach a helios cluster.
It can either be http://location_of_master:port or site://sitename.
If a destination is specified on the commandline, it overrides the
environment variable.
