### PR TITLE
HELIOS_HOST_FILTER was being ignored by TemporaryJobs

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -43,7 +43,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -100,7 +99,7 @@ public class TemporaryJobs extends ExternalResource {
         fail(format("no hosts matched the filter pattern - %s", hostFilter));
       }
 
-      String chosenHost = hosts.get(new Random().nextInt(hosts.size()));
+      final String chosenHost = filteredHosts.get(new Random().nextInt(filteredHosts.size()));
       return deploy(job, asList(chosenHost), waitPorts);
     }
 


### PR DESCRIPTION
When choosing which host(s) to deploy to, TemporaryJobs
would use HELIOS_HOST_FILTER to come up with a list of
hosts matching the filter. But when it came time to deploy,
it would ignore this list, and use the list of all hosts
instead, effectively deploying to a random host.
