### PR TITLE
[helios-tools] make it so deploy/undeploy can take non-fqdn names

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostResolver.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostResolver.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.cli.command;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import com.spotify.helios.client.HeliosClient;
+
+import org.xbill.DNS.Name;
+import org.xbill.DNS.ResolverConfig;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+class HostResolver {
+  private final Set<String> allHosts;
+  private final Name[] searchPath;
+
+  HostResolver(final Set<String> allHosts,
+               final Name[] searchPath) throws InterruptedException, ExecutionException {
+    this.allHosts = allHosts;
+    this.searchPath = searchPath;
+  }
+
+  static HostResolver create(HeliosClient client) throws InterruptedException, ExecutionException {
+    final ResolverConfig currentConfig = ResolverConfig.getCurrentConfig();
+    final Name[] path;
+    if (currentConfig != null) {
+      path = currentConfig.searchPath();
+    } else {
+      path = new Name[]{};
+    }
+    return new HostResolver(Sets.newHashSet(client.listHosts().get()), path);
+  }
+
+  private static class ScoredHost {
+    private final String host;
+    private final int score;
+
+    public ScoredHost(String host, int score) {
+      this.host = host;
+      this.score = score;
+    }
+  }
+
+  String resolveName(final String host) {
+    // passed FQDN, all set
+    if (allHosts.contains(host)) {
+      return host;
+    }
+
+    final List<String> matches = findPrefixMatches(host);
+    if (matches.isEmpty()) {
+      return host;  // no pfx matches, let it fail upstream
+    }
+
+    if (matches.size() == 1) {
+      return matches.iterator().next();
+    }
+
+    final List<ScoredHost> scored = scoreMatches(matches);
+    final List<ScoredHost> sorted = sortScoredHosts(scored);
+    final List<String> minScoreHosts = findMatchesWithLowestScore(sorted);
+
+    if (minScoreHosts.size() > 1) {
+      // ambiguous, just return it and let it fail upstream
+      return host;
+    }
+
+    return minScoreHosts.get(0);
+  }
+
+  private List<ScoredHost> sortScoredHosts(List<ScoredHost> scored) {
+    final List<ScoredHost> copy = Lists.newArrayList(scored);
+    Collections.sort(copy, new Comparator<ScoredHost>() {
+      @Override
+      public int compare(ScoredHost o1, ScoredHost o2) {
+        return o1.score - o2.score;
+      }
+    });
+    return copy;
+  }
+
+  private List<String> findPrefixMatches(final String pfx) {
+    final ImmutableList.Builder<String> builder = ImmutableList.builder();
+    for (final String name : allHosts) {
+      if (name.startsWith(pfx)) {
+        builder.add(name);
+      }
+    }
+    return builder.build();
+  }
+
+  // Assumes sorted input in scored
+  private List<String> findMatchesWithLowestScore(final List<ScoredHost> scored) {
+    final int minScore = scored.get(0).score;
+    final ImmutableList.Builder<String> minScoreHosts = ImmutableList.builder();
+    for (ScoredHost score : scored) {
+      if (score.score == minScore) {
+        minScoreHosts.add(score.host);
+      }
+    }
+    return minScoreHosts.build();
+  }
+
+  // Score matches based upon the position in the dns search domain that matches the result
+  private List<ScoredHost> scoreMatches(final List<String> results) {
+    final ImmutableList.Builder<ScoredHost> scored = ImmutableList.builder();
+    for (final String name : results) {
+      int score = Integer.MAX_VALUE;
+      for (int i = 0; i < searchPath.length; i++) {
+        if (name.endsWith(searchPath[i].toString())) {
+          if (i < score) {
+            score = i;
+          }
+        }
+      }
+      scored.add(new ScoredHost(name, score));
+    }
+    return scored.build();
+  }
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobDeployCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobDeployCommand.java
@@ -74,7 +74,6 @@ public class JobDeployCommand extends WildcardJobCommand {
                              final PrintStream out, final boolean json, final JobId jobId)
       throws ExecutionException, InterruptedException {
     final List<String> hosts = options.getList(hostsArg.getDest());
-
     final Deployment job = Deployment.of(jobId,
                                          options.getBoolean(noStartArg.getDest()) ? STOP : START);
 
@@ -82,7 +81,10 @@ public class JobDeployCommand extends WildcardJobCommand {
 
     int code = 0;
 
-    for (final String host : hosts) {
+    final HostResolver resolver = HostResolver.create(client);
+
+    for (final String candidateHost : hosts) {
+      final String host = resolver.resolveName(candidateHost);
       out.printf("%s: ", host);
       final JobDeployResponse result = client.deploy(job, host).get();
       if (result.getStatus() == JobDeployResponse.Status.OK) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobUndeployCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobUndeployCommand.java
@@ -103,8 +103,11 @@ public class JobUndeployCommand extends WildcardJobCommand {
     out.printf("Undeploying %s from %s%n", jobId, hosts);
 
     int code = 0;
+    final HostResolver resolver = HostResolver.create(client);
 
-    for (final String host : hosts) {
+    for (final String candidateHost : hosts) {
+      final String host = resolver.resolveName(candidateHost);
+
       out.printf("%s: ", host);
       final JobUndeployResponse response = client.undeploy(jobId, host).get();
       if (response.getStatus() == JobUndeployResponse.Status.OK) {

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/HostResolverTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/HostResolverTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.cli.command;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Test;
+import org.xbill.DNS.Name;
+
+import static org.junit.Assert.assertEquals;
+
+public class HostResolverTest {
+
+  private static final Name[] SEARCH_PATH = new Name[]{Name.fromConstantString("bar.com"),
+                                                       Name.fromConstantString("foo.com")};
+  private static final ImmutableSet<String> ALL_HOSTS = ImmutableSet.of(
+      "host1.bar.com", "host1.foo.com");
+
+  @Test
+  public void test() throws Exception {
+    final HostResolver resolver = new HostResolver(ALL_HOSTS, new Name[]{});
+    // fully spec'd that's in allHosts
+    assertEquals("host1.bar.com", resolver.resolveName("host1.bar.com"));
+
+    // fully spec'd not in allHosts
+    assertEquals("whee.bar.com", resolver.resolveName("whee.bar.com"));
+
+    // can disambiguate on unique prefix
+    assertEquals("host1.bar.com", resolver.resolveName("host1.bar"));
+
+    // can disambiguate on unique prefix
+    assertEquals("host1.bar.com", resolver.resolveName("host1.b"));
+
+    // falls through when can't disambiguate (here, w/o search paths)
+    assertEquals("host1", resolver.resolveName("host1"));
+  }
+
+  @Test
+  public void testWithSearchPathDisambiguation() throws Exception {
+    final HostResolver resolver = new HostResolver(ALL_HOSTS, SEARCH_PATH);
+
+    assertEquals("host1.bar.com", resolver.resolveName("host1"));
+    assertEquals("host1.bar.com", resolver.resolveName("ho"));
+  }
+
+  @Test
+  public void testAmbiguousWithSearchPathDisambiguation() throws Exception {
+    final HostResolver resolver = new HostResolver(
+        ImmutableSet.of("host1.foo.com", "host2.foo.com"),
+        SEARCH_PATH);
+
+    // Even with path disambiguation, we can't disambiguate
+    assertEquals("ho", resolver.resolveName("ho"));
+  }
+}


### PR DESCRIPTION
Specifically, if you specify a unique prefix, it will [un]deploy to
the matching host.  If you specify a non-unique prefix, it will
look at the matches and the one whose domain appears first in the
dns search path will be returned.  This works much more intuitively
than I'm explaining.
