### PR TITLE
[agent] unconditionally pull when starting a container

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -27,7 +27,6 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.spotify.docker.client.ContainerNotFoundException;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
-import com.spotify.docker.client.ImageNotFoundException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerExit;
@@ -170,11 +169,6 @@ class TaskRunner extends InterruptingExecutionThreadService {
   }
 
   private void pullImage(final String image) throws DockerException, InterruptedException {
-    try {
-      docker.inspectImage(image);
-      return;
-    } catch (ImageNotFoundException ignore) {
-    }
     listener.pulling();
     docker.pull(image);
   }

--- a/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
@@ -69,6 +69,7 @@ import static com.spotify.helios.common.descriptors.Goal.START;
 import static com.spotify.helios.common.descriptors.Goal.STOP;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.CREATING;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.FAILED;
+import static com.spotify.helios.common.descriptors.TaskStatus.State.PULLING_IMAGE;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.RUNNING;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.STARTING;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.STOPPED;
@@ -291,6 +292,18 @@ public class SupervisorTest {
     // Change docker container state to stopped when it's killed
     when(docker.inspectContainer(eq(containerId))).thenReturn(STOPPED_RESPONSE);
     killFuture.set(null);
+
+    // Verify that the pulling state is signalled
+    verify(model, timeout(30000)).setTaskStatus(eq(JOB.getId()),
+                                                eq(TaskStatus.newBuilder()
+                                                       .setJob(JOB)
+                                                       .setGoal(START)
+                                                       .setState(PULLING_IMAGE)
+                                                       .setContainerId(null)
+                                                       .setEnv(ENV)
+                                                       .build())
+    );
+
 
     // Verify that the stopped state is signalled
     verify(model, timeout(30000)).setTaskStatus(eq(JOB.getId()),

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskRunnerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskRunnerTest.java
@@ -22,7 +22,6 @@
 package com.spotify.helios.agent;
 
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.messages.ImageInfo;
 import com.spotify.helios.common.HeliosRuntimeException;
 import com.spotify.helios.common.descriptors.Job;
 
@@ -37,7 +36,6 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TaskRunnerTest {
@@ -46,7 +44,7 @@ public class TaskRunnerTest {
   private static final Job JOB = Job.newBuilder()
       .setName("foobar")
       .setCommand(asList("foo", "bar"))
-      .setImage("spotify:17")
+      .setImage(IMAGE)
       .setVersion("4711")
       .build();
   private static final String HOST = "HOST";
@@ -69,10 +67,6 @@ public class TaskRunnerTest {
         .docker(mockDocker)
         .listener(new TaskRunner.NopListener())
         .build();
-
-    when(mockDocker.inspectImage(IMAGE))
-        .thenReturn(new ImageInfo())
-        .thenReturn(null);
 
     tr.run();
 

--- a/helios-services/src/test/java/com/spotify/helios/master/ExpiredJobReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/ExpiredJobReaperTest.java
@@ -1,13 +1,13 @@
 package com.spotify.helios.master;
 
 import com.google.common.collect.ImmutableMap;
+
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
-import com.spotify.helios.common.descriptors.PortMapping;
-import org.apache.http.impl.cookie.DateUtils;
+
 import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
So if the image should change, you'll get the changed container.
If nothing has changed, it's still pretty cheap since docker will
only fetch the tags file from the registry.
