### PR TITLE
upstart: Run Helios without forking

### DIFF
--- a/src/deb/helios-agent/upstart
+++ b/src/deb/helios-agent/upstart
@@ -28,7 +28,7 @@ end script
 script
   [ -f $DEFAULTFILE ] && . $DEFAULTFILE
   export HELIOS_AGENT_JVM_OPTS
-  /usr/bin/helios-agent $HELIOS_AGENT_OPTS
+  exec /usr/bin/helios-agent $HELIOS_AGENT_OPTS
 end script
 
 # prevent respawning more than once every 5 seconds

--- a/src/deb/helios-master/upstart
+++ b/src/deb/helios-master/upstart
@@ -14,6 +14,7 @@ respawn limit unlimited
 env DEFAULTFILE=/etc/default/helios-master
 
 setuid helios
+
 pre-start script
   [ -f $DEFAULTFILE ] && . $DEFAULTFILE
 
@@ -26,7 +27,7 @@ end script
 script
   [ -f $DEFAULTFILE ] && . $DEFAULTFILE
   export HELIOS_MASTER_JVM_OPTS
-  /usr/bin/helios-master $HELIOS_MASTER_OPTS
+  exec /usr/bin/helios-master $HELIOS_MASTER_OPTS
 end script
 
 # prevent respawning more than once every 5 seconds


### PR DESCRIPTION
Otherwise we have an extra process hanging out, Upstart tracks the wrong PID,
and if the shell process gets killed the actual Helios process is orphaned.
