### PR TITLE
TemporaryJobs now sets randomized registration domain

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   pkg_cmd << "apt-get update && apt-get -y install lxc-docker; "
 
   # Set up docker to listen on 0.0.0.0:2375
-  pkg_cmd << "echo 'DOCKER_OPTS=\"--restart=false -D=true -H=tcp://0.0.0.0:2375 -H=unix:///var/run/docker.sock\"' > /etc/default/docker; "
+  pkg_cmd << "echo 'DOCKER_OPTS=\"--restart=false -D=true -H=tcp://0.0.0.0:2375 -H=unix:///var/run/docker.sock --dns=192.168.33.10\"' > /etc/default/docker; "
   # make docker usable by vagrant user w/o sudo
   pkg_cmd << "groupadd docker; gpasswd -a vagrant docker; service docker restart;"
 

--- a/helios-integration-tests/pom.xml
+++ b/helios-integration-tests/pom.xml
@@ -32,6 +32,12 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>helios-testing</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
   <build>

--- a/helios-integration-tests/src/test/java/com/spotify/helios/TemporaryJobsSkyDnsITCase.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/TemporaryJobsSkyDnsITCase.java
@@ -1,0 +1,66 @@
+package com.spotify.helios;
+
+import com.google.common.base.Charsets;
+import com.google.common.net.HostAndPort;
+
+import com.spotify.helios.testing.TemporaryJob;
+import com.spotify.helios.testing.TemporaryJobs;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.Socket;
+
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This test verifies that TemporaryJobs works correctly with SkyDNS. SkyDNS must be running
+ * for the test to pass. It's easiest to use the vagrant image in the helios root directory
+ * which will install and run SkyDNS.
+ */
+public class TemporaryJobsSkyDnsITCase {
+
+  @Rule
+  public final TemporaryJobs temporaryJobs = TemporaryJobs.create();
+
+  private TemporaryJob job;
+
+  @Before
+  public void setup() {
+    // When this job gets deployed, helios will register it with SkyDNS, using the randomized
+    // prefix string as part of the SRV record. The container will then use dig to lookup that
+    // SRV record, and expose the response on port 4711 via netcat.
+    job = temporaryJobs.job()
+        .image("rculbertson/dnsutils_netcat-traditional")
+        .command("bash", "-c", "while true;" +
+                               "do nc -p 4711 -lc 'dig -t srv +short lookup.tcp." +
+                               temporaryJobs.prefix() + ".skydns.local'; " +
+                               "done")
+        .port("lookup", 4711, false)
+        .registration("lookup", "tcp", "lookup")
+        .deploy();
+  }
+
+  @Test
+  public void test() throws Exception {
+    final HostAndPort hostAndPort = job.address("lookup");
+    final String host = hostAndPort.getHostText();
+    final int port = hostAndPort.getPort();
+
+    // Connect to the container to get the dig response. If we get back the correct value, we know
+    // that helios properly registered the service in SkyDNS, and other services will be able to
+    // find that service by doing a DNS lookup.
+    try (final Socket s = new Socket(host, port)) {
+      final byte[] bytes = new byte[32];
+      final int bytesRead = s.getInputStream().read(bytes);
+      assertThat(bytesRead, greaterThan(0));
+      final String result = new String(bytes, Charsets.UTF_8).trim();
+      assertThat(result, equalTo(format("10 100 %d %s.", port, host)));
+    }
+  }
+
+}

--- a/helios-integration-tests/src/test/resources/Dockerfile
+++ b/helios-integration-tests/src/test/resources/Dockerfile
@@ -1,0 +1,5 @@
+# This generates an image which is used by TemporaryJobsITCase. The test needs dig and
+# netcat-traditional, so this will install the dnsutils and netcat-traditional packages.
+
+FROM ubuntu:14.04
+RUN apt-get update && apt-get install -y dnsutils netcat-traditional && update-alternatives --set nc /bin/nc.traditional

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -74,6 +74,7 @@ public class TemporaryJobBuilder {
   public TemporaryJobBuilder(final TemporaryJob.Deployer deployer, final String jobNamePrefix) {
     this.deployer = deployer;
     this.jobNamePrefix = jobNamePrefix;
+    this.builder.setRegistrationDomain(jobNamePrefix);
   }
 
   public TemporaryJobBuilder name(final String jobName) {
@@ -102,6 +103,11 @@ public class TemporaryJobBuilder {
 
   public TemporaryJobBuilder env(final String key, final Object value) {
     this.builder.addEnv(key, value.toString());
+    return this;
+  }
+
+  public TemporaryJobBuilder disablePrivateRegistrationDomain() {
+    this.builder.setRegistrationDomain(Job.EMPTY_REGISTRATION_DOMAIN);
     return this;
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -291,6 +291,10 @@ public class TemporaryJobs extends ExternalResource {
     return jobPrefixFile;
   }
 
+  public String prefix() {
+    return jobPrefixFile.prefix();
+  }
+
   public static Builder builder() {
     return new Builder();
   }


### PR DESCRIPTION
When helios registers a service in DNS, it will insert this random string into
SRV record. This is so multiple tests can run concurrently, without having
them clobber each other's DNS records.
