### PR TITLE
[agent] Catch all DockerExceptions on pull

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -27,7 +27,6 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.spotify.docker.client.ContainerNotFoundException;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
-import com.spotify.docker.client.ImageNotFoundException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerExit;
@@ -175,7 +174,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
     // Attempt to pull.  Failure, while less than ideal, is ok.
     try {
       docker.pull(image);
-    } catch (ImageNotFoundException e) {
+    } catch (DockerException e) {
       log.warn("Pulling image {} failed", image, e);
     }
 


### PR DESCRIPTION
Right now if you try to pull a non-existent image, the TaskRunner will
catch the ImageNotFound exception, but if the image exists locally, it
proceeds without a warning.

If the image repo exists, but a specific tag does not exist, then it throws
an ImagePullFailed exception, which doesn't get caught and the operation
fails even if it is present locally.
