### PR TITLE
HeliosClient should not return null, when deleting nonexistent job

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -394,13 +394,15 @@ public class HeliosClient {
   public ListenableFuture<JobDeleteResponse> deleteJob(final JobId id) {
     return transform(request(uri(path("/jobs/%s", id)), "DELETE"),
                      ConvertResponseToPojo.create(JobDeleteResponse.class,
-                                                  ImmutableSet.of(HTTP_OK, HTTP_BAD_REQUEST)));
+                                                  ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND,
+                                                                  HTTP_BAD_REQUEST)));
   }
 
   public ListenableFuture<JobUndeployResponse> undeploy(final JobId jobId, final String host) {
     return transform(request(uri(path("/hosts/%s/jobs/%s", host, jobId)), "DELETE"),
                      ConvertResponseToPojo.create(JobUndeployResponse.class,
-                                                  ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND)));
+                                                  ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND,
+                                                                  HTTP_BAD_REQUEST)));
   }
 
   public ListenableFuture<HostDeregisterResponse> deregisterHost(final String host) {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/JobDeleteResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/JobDeleteResponse.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
 public class JobDeleteResponse {
-  public enum Status { OK, STILL_IN_USE }
+  public enum Status { OK, STILL_IN_USE, JOB_NOT_FOUND }
 
   private final Status status;
 

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
@@ -154,7 +154,7 @@ public class JobsResource {
       model.removeJob(id);
       return new JobDeleteResponse(JobDeleteResponse.Status.OK);
     } catch (JobDoesNotExistException e) {
-      throw notFound();
+      throw notFound(new JobDeleteResponse(JobDeleteResponse.Status.JOB_NOT_FOUND));
     } catch (JobStillDeployedException e) {
       throw badRequest(new JobDeleteResponse(JobDeleteResponse.Status.STILL_IN_USE));
     }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentTest.java
@@ -149,5 +149,8 @@ public class DeploymentTest extends SystemTestBase {
 
     // Verify that the job can be deleted
     assertEquals(JobDeleteResponse.Status.OK, client.deleteJob(jobId).get().getStatus());
+
+    // Verify that a nonexistent job returns JOB_NOT_FOUND
+    assertEquals(JobDeleteResponse.Status.JOB_NOT_FOUND, client.deleteJob(jobId).get().getStatus());
   }
 }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Jobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Jobs.java
@@ -79,7 +79,8 @@ class Jobs {
 
     try {
       final JobDeleteResponse response = get(client.deleteJob(jobId));
-      if (response.getStatus() != JobDeleteResponse.Status.OK) {
+      if (response.getStatus() != JobDeleteResponse.Status.OK &&
+          response.getStatus() != JobDeleteResponse.Status.JOB_NOT_FOUND) {
         errors.add(new AssertionError(format("Failed to delete job %s - %s",
                                              jobId.toString(), response.toString())));
       }


### PR DESCRIPTION
Currently if you try to delete a nonexistent job, HeliosClient returns null,
so the caller doesn't know what happened. This caused a NPE in TemporaryJobs,
because it tried to delete a nonexistent job, and didn't expect the client to
return null. It now returns JobDeleteResponse with the status set to
JOB_NOT_FOUND so the caller can decide if this should be handled as an error
or not.
