### PR TITLE
Remove Teamcity's required release branch

### DIFF
--- a/push-release.sh
+++ b/push-release.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e
 git push origin master
-git push origin release
-TAGREF=refs/tags/$(git describe --abbrev=0 release)
+TAGREF=refs/tags/$(git describe --abbrev=0 master)
 git push origin ${TAGREF}:${TAGREF}

--- a/release.sh
+++ b/release.sh
@@ -9,10 +9,5 @@ fi
 # Use the maven release plugin to update the pom versions and tag the release commit
 mvn -B release:prepare release:clean
 
-# Fast-forward release branch to the tagged release commit
-git checkout release
-git merge --ff-only `git describe --abbrev=0 master`
-git checkout master
-
 echo "Created release tag" `git describe --abbrev=0 master`
 echo "Remember to: ./push-release.sh"


### PR DESCRIPTION
Our internal release process required a release branch for teamcity. We no longer need this and will help with the new release process where this could cause a problem
