### PR TITLE
Workaround incorrect exit code when using LXC

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.2</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/JobExpirationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/JobExpirationTest.java
@@ -86,8 +86,14 @@ public class JobExpirationTest extends SystemTestBase {
       }
     });
 
+    int expectedExitCode = -1;
+    if (docker.info().executionDriver().startsWith("lxc-")) {
+      // with LXC, killing a container results in exit code 0
+      expectedExitCode = 0;
+    }
+
     // Wait for the agent to kill the container
     final ContainerExit exit = docker.waitContainer(taskStatus.getContainerId());
-    assertThat(exit.statusCode(), is(-1));
+    assertThat(exit.statusCode(), is(expectedExitCode));
   }
 }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ReapingTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ReapingTest.java
@@ -62,16 +62,22 @@ public class ReapingTest extends SystemTestBase {
     awaitHostRegistered(client, testHost(), LONG_WAIT_MINUTES, MINUTES);
     awaitHostStatus(client, testHost(), UP, LONG_WAIT_MINUTES, MINUTES);
 
+    int expectedExitCode = -1;
+    if (docker.info().executionDriver().startsWith("lxc-")) {
+      // with LXC, killing a container results in exit code 0
+      expectedExitCode = 0;
+    }
+
     // Wait for the agent to kill the container
     final ContainerExit exit1 = docker.waitContainer(intruder1);
-    assertThat(exit1.statusCode(), is(-1));
+    assertThat(exit1.statusCode(), is(expectedExitCode));
 
     // Start another container in the agent namespace
     startContainer(intruder2);
 
     // Wait for the agent to kill the second container as well
     final ContainerExit exit2 = docker.waitContainer(intruder2);
-    assertThat(exit2.statusCode(), is(-1));
+    assertThat(exit2.statusCode(), is(expectedExitCode));
   }
 
   private String intruder(final String namespace) {


### PR DESCRIPTION
When an LXC container is killed via docker kill, the exit code is 0 instead
of -1.
