### PR TITLE
Add support for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+dependencies:
+  override:
+    - mvn install -DskipTests=true -B -V
+
+test:
+  override:
+    - mvn test -B
+
+machine:
+  pre:
+    - sudo sh -c 'echo DOCKER_OPTS=\"\$DOCKER_OPTS -H tcp://127.0.0.1:2375\" >> /etc/default/docker'
+  services:
+    - docker
+  environment:
+    DOCKER_HOST: tcp://127.0.0.1:2375
+    MAVEN_OPTS: -Xmx128m

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,40 @@
     </profile>
 
     <profile>
+      <id>circleci</id>
+      <activation>
+        <property>
+          <name>env.CIRCLECI</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.16</version>
+            <configuration>
+              <enableAssertions>false</enableAssertions>
+              <forkCount>16</forkCount>
+              <reuseForks>false</reuseForks>
+              <argLine>-Xmx128m -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
+              <environmentVariables>
+                <HELIOS_CLUSTER_DEPLOYMENT_TEST_HOSTS>2</HELIOS_CLUSTER_DEPLOYMENT_TEST_HOSTS>
+              </environmentVariables>
+              <systemPropertyVariables>
+                <junit.parallel.threads>1</junit.parallel.threads>
+                <logToFile>false</logToFile>
+                <heliosLoggingLevel>WARN</heliosLoggingLevel>
+                <externalLoggingLevel>OFF</externalLoggingLevel>
+                <rootLoggingLevel>WARN</rootLoggingLevel>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>debug</id>
       <activation>
         <property>


### PR DESCRIPTION
CircleCI gives us faster, more reliable builds than Travis, since it has a
higher memory limit (4G vs 2G) and also has Docker running natively, rather
than us having to hack it into a usermode Linux instance.
- Add circle.yml configuration. It sets environment variables, ensures that
  Docker is exposed via TCP, and runs our Maven commands.
- Add a circle build profile.
