### PR TITLE
CircleCI: artifacts and parallel builds

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -ex
+
+case "$1" in
+  pre_machine)
+    # have docker bind to localhost
+    docker_opts='DOCKER_OPTS="$DOCKER_OPTS -H tcp://127.0.0.1:2375"'
+    sudo sh -c "echo '$docker_opts' >> /etc/default/docker"
+
+    cat /etc/default/docker
+
+    ;;
+
+  dependencies)
+    mvn clean install -T 2 -Dmaven.javadoc.skip=true -DskipTests=true -B -V
+
+    ;;
+
+  pre_test)
+    # clean the artifacts dir from the previous build
+    rm -rf artifacts && mkdir artifacts
+
+    ;;
+
+  test)
+    # expected parallelism: 2x. needs to be set in the project settings via CircleCI's UI.
+    case $CIRCLE_NODE_INDEX in
+      0)
+        # run all tests *except* helios-system-tests
+        sed -i'' 's/<module>helios-system-tests<\/module>//' pom.xml
+        mvn test -B
+
+        ;;
+
+      1)
+        # run helios-system-tests
+        mvn test -B -pl helios-system-tests
+
+        ;;
+
+    esac
+
+    ;;
+
+  post_test)
+    # collect artifacts into the artifacts dir
+    find . -regex ".*/target/.*-[0-9]\.jar" | xargs -I {} mv {} artifacts
+    find . -regex ".*/target/.*-SNAPSHOT\.jar" | xargs -I {} mv {} artifacts
+    find . -regex ".*/target/.*\.deb" | xargs -I {} mv {} artifacts
+
+    ;;
+
+esac

--- a/circle.yml
+++ b/circle.yml
@@ -1,19 +1,19 @@
 dependencies:
   override:
-    - mvn install -DskipTests=true -B -V
+    - ./circle.sh dependencies
 
 test:
+  pre:
+    - ./circle.sh pre_test
   override:
-    - mvn test -B
+    - ./circle.sh test:
+        parallel: true
   post:
-    - rm -rf artifacts && mkdir artifacts
-    - find . -regex ".*/target/.*-[0-9]\.jar" | xargs -I {} mv {} artifacts
-    - find . -regex ".*/target/.*-SNAPSHOT\.jar" | xargs -I {} mv {} artifacts
-    - find . -regex ".*/target/.*\.deb" | xargs -I {} mv {} artifacts
+    - ./circle.sh post_test
 
 machine:
   pre:
-    - sudo sh -c 'echo DOCKER_OPTS=\"\$DOCKER_OPTS -H tcp://127.0.0.1:2375\" >> /etc/default/docker'
+    - helios/circle.sh pre_machine
   services:
     - docker
   environment:


### PR DESCRIPTION
- Collect generated Debian packages, and any JAR's that end in a version or snapshot number (that is, not sources, javadoc, or shaded).
- Add parallelism for builds and tests, bringing build time down to ~7 minutes.
