### PR TITLE
[pom] add two profiles to control signing and test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,54 @@
     </profile>
 
     <profile>
+      <id>release-unsafe-fast</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.5</version>
+            <configuration>
+              <arguments>-DskipITs -Dgpg.skip=true -DskipTests -Prelease-unsafe-fast</arguments>
+              <pushChanges>false</pushChanges>
+              <tagNameFormat>@{project.version}</tagNameFormat>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-provider-gitexe</artifactId>
+                <version>1.9</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>release-no-sign</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>2.5</version>
+            <configuration>
+              <arguments>-DskipITs -Dgpg.skip=true -Prelease-no-sign</arguments>
+              <pushChanges>false</pushChanges>
+              <tagNameFormat>@{project.version}</tagNameFormat>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.scm</groupId>
+                <artifactId>maven-scm-provider-gitexe</artifactId>
+                <version>1.9</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>sign-artifacts</id>
       <build>
         <plugins>
@@ -269,6 +317,23 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <arguments>-DskipITs -Dgpg.skip=true</arguments>
+          <pushChanges>false</pushChanges>
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.9</version>
+          </dependency>
+        </dependencies>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
When testing the release process, or running the release bits (but not
deploying), it can be desirable to disable gpg signing and the running
of tests.

This change also reinstates part of the pom that was erroneously removed
in 5443b556d9ad6621815862861078875d2264402d, which turned off integration
testing when performing the release.
