### PR TITLE
Correct help for status command

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStatusCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStatusCommand.java
@@ -59,7 +59,7 @@ public class JobStatusCommand extends ControlCommand {
   public JobStatusCommand(final Subparser parser) {
     super(parser);
 
-    parser.help("show job status");
+    parser.help("show job or host status");
 
     jobArg = parser.addArgument("-j", "--job")
         .help("Job filter");


### PR DESCRIPTION
The help message had been "show job status", but this command
also show host status. Changed message to "show job or host status".
