### PR TITLE
TemporaryJobs now honors the HELIOS_HOST_ADDRESS env var

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostStatus.java
@@ -29,9 +29,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class HostStatus extends Descriptor {
@@ -61,7 +63,7 @@ public class HostStatus extends Descriptor {
     // Host, runtime info and environment might not be available
     this.hostInfo = hostInfo;
     this.agentInfo = agentInfo;
-    this.environment = environment;
+    this.environment = fromNullable(environment).or(Collections.<String, String>emptyMap());
   }
 
   public Map<String, String> getEnvironment() {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -145,7 +145,8 @@ public class TemporaryJobs extends ExternalResource {
 
   public TemporaryJobBuilder job() {
     return new TemporaryJobBuilder(deployer, jobPrefixFile.prefix())
-        .hostFilter(defaultHostFilter);
+        .hostFilter(defaultHostFilter)
+        .env("SPOTIFY_POD", prefix() + ".local");
   }
 
   /**


### PR DESCRIPTION
HELIOS_HOST_ADDRESS is the IP address we should use to reach the host, instead of
the hostname. This is used when running a helios cluster inside a VM, and the containers
can be reached by IP address only, since DNS won't be able to resolve the host name of
the helios agent running in the VM.
