### PR TITLE
Travis CI: Only build tagged versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - /^\d+\.\d+\.\d+$/
+
 language: java
 
 jdk:


### PR DESCRIPTION
We only want to use Travis CI for releases. Everything else will get built
by CircleCI.
