### PR TITLE
tests: Only pull busybox if it not found locally

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -39,6 +39,7 @@ import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.DockerRequestException;
+import com.spotify.docker.client.ImageNotFoundException;
 import com.spotify.docker.client.LogMessage;
 import com.spotify.docker.client.LogReader;
 import com.spotify.docker.client.messages.Container;
@@ -236,7 +237,13 @@ public abstract class SystemTestBase {
 
   private void assertDockerReachable(final int probePort) throws Exception {
     final DockerClient docker = new DefaultDockerClient(DOCKER_HOST.uri());
-    docker.pull(BUSYBOX);
+
+    try {
+      docker.inspectImage(BUSYBOX);
+    } catch (ImageNotFoundException e) {
+      docker.pull(BUSYBOX);
+    }
+
     final ContainerConfig config = ContainerConfig.builder()
         .image(BUSYBOX)
         .cmd("nc", "-p", "4711", "-lle", "cat")


### PR DESCRIPTION
We docker pull busybox before each test, but this can be slow in a shared
build environment. As a workaround, only pull if the image doesn't exist
locally.
