### PR TITLE
Respect JSON CLI switch on failed job creations

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/CreateJobResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/CreateJobResponse.java
@@ -24,6 +24,7 @@ package com.spotify.helios.common.protocol;
 import com.google.common.base.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.helios.common.Json;
 
 import java.util.List;
 
@@ -65,5 +66,9 @@ public class CreateJobResponse {
     return Objects.toStringHelper("JobDeployResponse")
         .add("status", status)
         .toString();
+  }
+
+  public String toJsonString() {
+    return Json.asStringUnchecked(this);
   }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -362,8 +362,10 @@ public class JobCreateCommand extends ControlCommand {
       }
       return 0;
     } else {
-      if (!quiet) {
+      if (!quiet && !json) {
         out.println("Failed: " + status);
+      } else if (json) {
+        out.println(status.toJsonString());
       }
       return 1;
     }


### PR DESCRIPTION
When we run `helios create --json ...`, we returned this:

  Failed: JobDeployResponse{status=JOB_ALREADY_EXISTS}

Let's return this:

  {"errors":[],"id":"foo-service:0.0.8:6a0","status":"JOB_ALREADY_EXISTS"}

So that users can parse the response.
