### PR TITLE
Use nexus-staging-maven-plugin

### DIFF
--- a/.travis.addServer.py
+++ b/.travis.addServer.py
@@ -87,8 +87,7 @@ def make_active_profile_node(activeProfilesNodes):
   activeProfileNode.appendChild(profileName)
   activeProfilesNodes.appendChild(activeProfileNode)
 
-make_server_node("sonatype-nexus-snapshots", serversNode)
-make_server_node("sonatype-nexus-staging", serversNode)
+make_server_node("ossrh", serversNode)
 make_profile_node(profilesNode)
 make_active_profile_node(activeProfilesNode)
 m2Str = m2.toprettyxml()

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,6 @@
   <version>0.8.4-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -30,6 +24,13 @@
     <url>https://github.com/spotify/helios</url>
     <tag>HEAD</tag>
   </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <developers>
     <developer>
@@ -341,6 +342,17 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The nexus-staging-maven-plugin allows you to deploy to
sonatype, and automatically close and release a repository
without having to log into the sonatype UI. This will allow
us to use sonatype in a CD pipeline.
