### PR TITLE
cli: hosts: collapse DEPLOYED + RUNNING into JOBS

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -66,6 +66,8 @@ public class HostListCommand extends ControlCommand {
     super(parser);
 
     parser.help("list hosts");
+    parser.description("The \"JOBS\" column in the output shows \"X/Y\" where X is jobs running " +
+                       "on the host and Y is jobs deployed on the host.");
 
     patternArg = parser.addArgument("pattern")
         .nargs("?")


### PR DESCRIPTION
```
$ helios hosts
... DEPLOYED  RUNNING ...
... 1         1       ...
... 2         0       ...
```

becomes

```
$ helios hosts
... JOBS ...
... 1/1  ...
... 0/2  ...
```

Where the JOBS column contains RUNNING/DEPLOYED job counts.
