### PR TITLE
Refactor Target.java and add tons of tests

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -49,7 +49,9 @@ public class CliConfig {
   private static final String MASTER_ENDPOINTS_KEY = "masterEndpoints";
   private static final String SITES_KEY = "sites";
   private static final String SRV_NAME_KEY = "srvName";
-  private static final String CONFIG_PATH = ".helios" + File.separator + "config";
+  private static final String CONFIG_DIR = ".helios";
+  private static final String CONFIG_FILE = "config";
+  private static final String CONFIG_PATH = CONFIG_DIR + File.separator + CONFIG_FILE;
   public static final List<String> EMPTY_STRING_LIST = Collections.emptyList();
   public static final TypeReference<Map<String, Object>> OBJECT_TYPE =
       new TypeReference<Map<String, Object>>() {};
@@ -86,6 +88,14 @@ public class CliConfig {
 
   public List<URI> getMasterEndpoints() {
     return masterEndpoints;
+  }
+
+  public static String getConfigDirName() {
+    return CONFIG_DIR;
+  }
+
+  public static String getConfigFileName() {
+    return CONFIG_FILE;
   }
 
   /**

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -138,9 +138,9 @@ public class CliParser {
 
     // Order of target precedence:
     // 1. endpoints from command line
-    // 2. sites from command line
+    // 2. domains from command line
     // 3. endpoints from config file
-    // 4. sites from config file
+    // 4. domains from config file
 
     // TODO (dano): complex, refactor and unit test it
     final List<String> domains = ImmutableList.copyOf(concat(domainsArguments, sitesArguments));
@@ -149,19 +149,25 @@ public class CliParser {
 
   private List<Target> computeTargets(final ArgumentParser parser,
                                       final List<String> explicitEndpoints,
-                                      final List<String> domainsArguments, final String srvName) {
+                                      final List<String> domainsArguments,
+                                      final String srvName) {
 
     if (explicitEndpoints != null && !explicitEndpoints.isEmpty()) {
-      final List<URI> explicitEndpointURIs = Lists.newArrayList();
+      final List<Target> targets = Lists.newArrayListWithExpectedSize(explicitEndpoints.size());
       for (final String endpoint : explicitEndpoints) {
-        explicitEndpointURIs.add(URI.create(endpoint));
+        targets.add(Target.from(URI.create(endpoint)));
       }
-      return asList(Target.from(explicitEndpointURIs));
+      return targets;
     } else if (domainsArguments != null && !domainsArguments.isEmpty()) {
       final Iterable<String> sites = parseDomains(domainsArguments);
       return Target.from(srvName, sites);
     } else if (!cliConfig.getMasterEndpoints().isEmpty()) {
-      return asList(Target.from(cliConfig.getMasterEndpoints()));
+      final List<URI> cliConfigMasterEndpoints = cliConfig.getMasterEndpoints();
+      List<Target> targets = Lists.newArrayListWithExpectedSize(cliConfigMasterEndpoints.size());
+      for (final URI endpoint : cliConfigMasterEndpoints) {
+        targets.add(Target.from(endpoint));
+      }
+      return targets;
     } else if (!cliConfig.getSitesString().isEmpty()) {
       final Iterable<String> sites = parseDomainsString(cliConfig.getSitesString());
       return Target.from(srvName, sites);

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Target.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Target.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.cli;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -53,9 +52,17 @@ public abstract class Target {
     private final String domain;
 
     private SrvTarget(final String srv, final String domain) {
-      super(srv);
+      super(domain);
       this.srv = srv;
       this.domain = domain;
+    }
+
+    public String getSrv() {
+      return srv;
+    }
+
+    public String getDomain() {
+      return domain;
     }
 
     @Override
@@ -67,32 +74,85 @@ public abstract class Target {
     public String toString() {
       return domain + " (srv: " + srv + ")";
     }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final SrvTarget srvTarget = (SrvTarget) o;
+
+      if (!srv.equals(srvTarget.getSrv())) {
+        return false;
+      }
+      if (!domain.equals(srvTarget.getDomain())) {
+        return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = srv != null ? srv.hashCode() : 0;
+      result = 31 * result + (domain != null ? domain.hashCode() : 0);
+      return result;
+    }
   }
 
   private static class ExplicitTarget extends Target {
-    private final List<URI> endpoints;
+    private final URI endpoint;
 
-    private ExplicitTarget(final Iterable<URI> endpoints) {
-      super(Joiner.on(',').join(endpoints));
-      this.endpoints = ImmutableList.copyOf(endpoints);
+    private ExplicitTarget(final URI endpoint) {
+      super(endpoint.toString());
+      this.endpoint = endpoint;
+    }
+
+    public URI getEndpoint() {
+      return endpoint;
     }
 
     @Override
     public Supplier<List<URI>> getEndpointSupplier() {
+      List<URI> endpoints = ImmutableList.of(endpoint);
       return Suppliers.ofInstance(endpoints);
     }
 
     @Override
     public String toString() {
-      return Joiner.on(',').join(endpoints);
+      return endpoint.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final ExplicitTarget explicitTarget = (ExplicitTarget) o;
+
+      return endpoint.equals(explicitTarget.getEndpoint());
+
+    }
+
+    @Override
+    public int hashCode() {
+      return endpoint != null ? endpoint.hashCode() : 0;
     }
   }
 
   /**
-   * Create a target from a list of explicit endpoints
+   * Create a target from an explicit endpoint
    */
-  public static Target from(final Iterable<URI> endpoints) {
-    return new ExplicitTarget(endpoints);
+  public static Target from(final URI endpoint) {
+    return new ExplicitTarget(endpoint);
   }
 
   /**

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
@@ -16,14 +16,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CliConfigTest {
-  private static final String SITE_NAME = "RaNd0m";
+
+  private static final String ENDPOINT1 = "http://master-a1.nyc.com:80";
+  private static final String ENDPOINT2 = "http://master-a2.nyc.com:80";
+  private static final String ENDPOINT3 = "http://master-a3.nyc.com:80";
+  private static final String SITE1 = "foo";
+  private static final String SITE2 = "bar";
+  private static final String SITE3 = "baz";
+
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   public void testSite() throws Exception {
-    CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", "site://" + SITE_NAME);
+    CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", "site://" + SITE1);
     final CliConfig config = CliConfig.fromUserConfig();
-    assertEquals(ImmutableList.of(SITE_NAME), config.getSites());
+    assertEquals(ImmutableList.of(SITE1), config.getSites());
     assertTrue(config.getMasterEndpoints().isEmpty());
   }
 
@@ -37,15 +44,33 @@ public class CliConfigTest {
   }
 
   @Test
+  public void testConfigFromFile() throws Exception {
+    final File file = temporaryFolder.newFile();
+    try (final FileOutputStream outFile = new FileOutputStream(file)) {
+      outFile.write(Charsets.UTF_8.encode(
+          "{\"masterEndpoints\":[\"" + ENDPOINT1 + "\", \"" + ENDPOINT2+ "\", \"" + ENDPOINT3 +
+          "\"], \"sites\":[\"" + SITE1 + "\", \"" + SITE2 + "\", \"" + SITE3 +
+          "\"], \"srvName\":\"foo\"}").array());
+      final CliConfig config = CliConfig.fromFile(file);
+
+      assertEquals(
+          ImmutableList.of(URI.create(ENDPOINT1), URI.create(ENDPOINT2), URI.create(ENDPOINT3)),
+          config.getMasterEndpoints());
+      assertEquals(ImmutableList.of(SITE1, SITE2, SITE3), config.getSites());
+      assertEquals("foo", config.getSrvName());
+    }
+  }
+
+  @Test
   public void testMixtureOfFileAndEnv() throws Exception {
     final File file = temporaryFolder.newFile();
     try (final FileOutputStream outFile = new FileOutputStream(file)) {
       outFile.write(Charsets.UTF_8.encode(
           "{\"masterEndpoints\":[\"http://localhost:5801\"], \"srvName\":\"foo\"}").array());
-      CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", "site://" + SITE_NAME);
+      CliConfig.environment = ImmutableMap.of("HELIOS_MASTER", "site://" + SITE1);
       final CliConfig config = CliConfig.fromFile(file);
 
-      assertEquals(ImmutableList.of(SITE_NAME), config.getSites());
+      assertEquals(ImmutableList.of(SITE1), config.getSites());
       assertTrue(config.getMasterEndpoints().isEmpty());
       assertEquals("foo", config.getSrvName());
     }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -1,0 +1,160 @@
+package com.spotify.helios.cli;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class CliParserTest {
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private static final String SUBCOMMAND = "jobs";
+  private static final String[] ENDPOINTS = {
+      "http://master-a1.nyc.com:80",
+      "http://master-a2.nyc.com:80",
+      "http://master-a3.nyc.com:80",
+  };
+  private static final String[] DOMAINS = {"foo", "bar", "baz"};
+  private static final String SERVICE = "foo-service";
+  private static final String SRV = "helios";
+
+  @Before
+  public void init() {
+    // TODO (dxia) For some reason CliConfig.java:59 never gets called here, but it's called when
+    // running CliConfigTest. If I don't clear the environment attribute, there's a stray key -> val
+    // of "HELIOS_MASTER" -> "site://foo" left behind from somewhere that screws up the tests.
+    CliConfig.environment = ImmutableMap.of();
+  }
+
+  @Test
+  public void testComputeTargetsSingleEndpoint() throws Exception {
+    final String[] args = {SUBCOMMAND, "--master", ENDPOINTS[0], SERVICE};
+    final CliParser cliParser = new CliParser(args);
+    final List<Target> targets = cliParser.getTargets();
+
+    // We expect the specified master endpoint target
+    final List<Target> expectedTargets =
+        ImmutableList.of(Target.from(URI.create(ENDPOINTS[0])));
+    assertEquals(expectedTargets, targets);
+  }
+
+  @Test
+  public void testComputeTargetsMultipleEndpoints() throws Exception {
+    final List<String> argsList = Lists.newArrayList(SUBCOMMAND, "-d", Joiner.on(",").join(DOMAINS));
+    for (String endpoint : ENDPOINTS) {
+      argsList.add("--master");
+      argsList.add(endpoint);
+    }
+    argsList.add(SERVICE);
+
+    final String[] args = new String[argsList.size()];
+    argsList.toArray(args);
+
+    final CliParser cliParser = new CliParser(args);
+    final List<Target> targets = cliParser.getTargets();
+
+    // We expect only the specified master endpoint targets since they take precedence over domains
+    final List<Target> expectedTargets = Lists.newArrayListWithExpectedSize(ENDPOINTS.length);
+    for (String endpoint : ENDPOINTS) {
+      expectedTargets.add(Target.from(URI.create(endpoint)));
+    }
+    assertEquals(expectedTargets, targets);
+  }
+
+  @Test
+  public void testComputeTargetsSingleDomain() throws Exception {
+    final String[] args = {SUBCOMMAND, "-d", DOMAINS[0], SERVICE};
+    final CliParser cliParser = new CliParser(args);
+    final List<Target> targets = cliParser.getTargets();
+
+    // We expect the specified domain
+    final List<Target> expectedTargets = Target.from(SRV, ImmutableList.of(DOMAINS[0]));
+    assertEquals(expectedTargets, targets);
+  }
+
+  @Test
+  public void testComputeTargetsMultiDomain() throws Exception {
+    final String[] args = {SUBCOMMAND, "-d", Joiner.on(",").join(DOMAINS), SERVICE};
+    final CliParser cliParser = new CliParser(args);
+    final List<Target> targets = cliParser.getTargets();
+
+    // We expect the specified domains
+    final List<Target> expectedTargets = Target.from(SRV, Lists.newArrayList(DOMAINS));
+    assertEquals(expectedTargets, targets);
+  }
+
+  @Test
+  public void testComputeTargetsMultipleEndpointsFromConfig() throws Exception {
+    final String[] args = {SUBCOMMAND, SERVICE};
+
+    // Create a "~/.helios/config" file, which is the path CliConfig reads by default
+    final File configDir = temporaryFolder.newFolder(CliConfig.getConfigDirName());
+    final File configFile = new File(configDir.getAbsolutePath() + File.separator +
+                                     CliConfig.getConfigFileName());
+
+    // Write configuration to that file
+    try (final FileOutputStream outFile = new FileOutputStream(configFile)) {
+      outFile.write(Charsets.UTF_8.encode(
+          "{\"masterEndpoints\":[\"" + ENDPOINTS[0] + "\", \"" +ENDPOINTS[1] + "\", \"" +
+          ENDPOINTS[2] + "\"], \"sites\":[\"" + DOMAINS[0] + "\"]}").array());
+
+      // Set user's home directory to this temporary folder
+      System.setProperty("user.home", temporaryFolder.getRoot().getAbsolutePath());
+
+      final CliParser cliParser = new CliParser(args);
+      final List<Target> targets = cliParser.getTargets();
+
+      // We expect only the specified master endpoint targets since they take precedence over
+      // domains
+      final List<Target> expectedTargets = ImmutableList.of(
+          Target.from(URI.create(ENDPOINTS[0])),
+          Target.from(URI.create(ENDPOINTS[1])),
+          Target.from(URI.create(ENDPOINTS[2]))
+      );
+      assertEquals(expectedTargets, targets);
+    }
+  }
+
+  @Test
+  public void testComputeTargetsMultipleDomainsFromConfig() throws Exception {
+    final String[] args = {SUBCOMMAND, SERVICE};
+
+    // Create a "~/.helios/config" file, which is the path CliConfig reads by default
+    final File configDir = temporaryFolder.newFolder(CliConfig.getConfigDirName());
+    final File configFile = new File(configDir.getAbsolutePath() + File.separator +
+                                     CliConfig.getConfigFileName());
+
+    // Write configuration to that file
+    try (final FileOutputStream outFile = new FileOutputStream(configFile)) {
+      outFile.write(Charsets.UTF_8.encode(
+          "{\"sites\":[\"" + DOMAINS[0] + "\", \"" + DOMAINS[1] + "\", \"" + DOMAINS[2] + "\"]}")
+                        .array());
+
+      // Set user's home directory to this temporary folder
+      System.setProperty("user.home", temporaryFolder.getRoot().getAbsolutePath());
+
+      final CliParser cliParser = new CliParser(args);
+      final List<Target> targets = cliParser.getTargets();
+
+      // We expect the specified sites
+      final List<Target> expectedTargets = Target.from(
+          SRV, ImmutableList.of(DOMAINS[0], DOMAINS[1], DOMAINS[2]));
+      assertEquals(expectedTargets, targets);
+    }
+  }
+}


### PR DESCRIPTION
Make ExplicitTarget have just one URI instead of a list of URIs.
This allows us to not collapse multiple master endpoints into one
target, which will enable better CLI output later on.

E.g. `helios jobs --master master1 --master master2 --json` outputs

```
{
  master1: {A},
  master2: {B}
}
```

instead of

```
{
  A+B
}
```
