### PR TITLE
agent: fix supervisor container teardown

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -23,6 +23,7 @@ package com.spotify.helios.agent;
 
 import com.google.common.base.Objects;
 
+import com.spotify.docker.client.ContainerNotFoundException;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.messages.ContainerInfo;
@@ -397,11 +398,13 @@ public class Supervisor {
       final ContainerInfo containerInfo;
       try {
         containerInfo = docker.inspectContainer(containerId);
+      } catch (ContainerNotFoundException e) {
+        return true;
       } catch (DockerException e) {
         log.error("failed to query container {}", containerId, e);
         return false;
       }
-      return containerInfo == null || !containerInfo.state().running();
+      return !containerInfo.state().running();
     }
   }
 


### PR DESCRIPTION
When checking for if a container is no longer running, appropriately
deal with ContainerNotFoundException and interpret it as the container
no longer running (obviously, as it no longer even exists).

Saw the helios agent hitting this and logging stack traces for the
ContainerNotFoundException when using helios-testing and TemporaryJobs.
