### PR TITLE
helios-testing: add SPOTIFY_DOMAIN env var

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -210,7 +210,9 @@ public class TemporaryJobs implements TestRule {
   public TemporaryJobBuilder job() {
     return new TemporaryJobBuilder(deployer, jobPrefixFile.prefix())
         .hostFilter(defaultHostFilter)
-        .env("SPOTIFY_POD", prefix() + ".local");
+        // TODO (dano): these spotify specific environment variables should go somewhere else
+        .env("SPOTIFY_POD", prefix() + ".local")
+        .env("SPOTIFY_DOMAIN", prefix() + ".local");
   }
 
   /**


### PR DESCRIPTION
Internal users need this as their containers use SPOTIFY_DOMAIN for
service discovery.
