### PR TITLE
Add env vars containing exposed port info

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -16,7 +16,7 @@ Note that this guide assumes that you are familiar with [Docker](http://docker.i
 * [Deploying Your Job](#deploying-your-job)
   * [Checking deployment status and history](#checking-deployment-status-and-history)
   * [Undeploying](#undeploying)
-
+* [Once Inside The Container](#once-inside-the-container)
 
 Basic Concepts in Helios
 ---
@@ -178,3 +178,16 @@ If we view the history again, it should show something like this:
     192.168.33.10    2014-08-11 14:42:14.403    STOPPED     NO           60671498ae98
 
 We can see that the job stopped. Additionally, checking job status will show again, that the job is stopped.
+
+Once Inside The Container
+---
+
+Now once you are inside your container, if you have exposed ports,
+you'll find a few environment variables set that you may need.  If you
+have a port named `foo`, there will be an environment variable named
+`HELIOS_PORT_foo` set to the host and port of the port named `foo` as
+it is seen *from outside the container*.  So if you had `-p foo=2121`
+in your job creation commmand, once deployed on a host named
+`foo.example.com`, from inside the container you would see
+`HELIOS_PORT_foo` set to something like `foo.example.com:23238`
+depending on what port was allocated when it was deployed.

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -47,6 +47,7 @@ import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -130,6 +131,11 @@ public class TaskConfig {
    */
   public Map<String, String> containerEnv() {
     final Map<String, String> env = Maps.newHashMap(envVars);
+
+    // Put in variables that tell the container where it's exposed
+    for (Entry<String, Integer> entry : ports.entrySet()) {
+      env.put("HELIOS_PORT_" + entry.getKey(), host + ":" + entry.getValue());
+    }
     // Job environment variables take precedence.
     env.putAll(job.getEnv());
     return env;


### PR DESCRIPTION
This way, if a container needs to tell another service where it is
without using service discovery, it can.
