### PR TITLE
Added Thread Context bits

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/context/CallPathToExecutorException.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/CallPathToExecutorException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import java.util.Arrays;
+
+/**
+ * Not indicative of an exception in and of itself, but it extends the stack trace
+ * of Exceptions of *ables wrapped using Context.makeContext(Runnable|Callable).
+ *
+ * See Context.java for more details.
+ */
+public class CallPathToExecutorException extends Exception {
+  private static final String CONTEXT_RUNNABLE = ContextRunnable.class.getCanonicalName();
+  private static final String CONTEXT_CALLABLE = ContextCallable.class.getCanonicalName();
+
+  CallPathToExecutorException(StackTraceElement[] trace) {
+    super();
+    int c = 0;
+    for (StackTraceElement element : trace) {
+      c++;
+      // Trim the head exception so that it should start at makeContext*able
+      final String className = element.getClassName();
+      if (className.equals(CONTEXT_RUNNABLE)
+          || className.equals(CONTEXT_CALLABLE)) {
+        break;
+      }
+    }
+    // Should never happen, but if it does, don't chop off everything.
+    if (c == trace.length) {
+      c = 0;
+    }
+    this.setStackTrace(Arrays.copyOfRange(trace, c, trace.length));
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/Context.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/Context.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Include call origin information in stacktraces of Callables and Runnables.  For brevity,
+ * *able will stand in for both Callable and Runnable below.
+ *
+ * Normally, if you call .get() on a Future of a *able that fails, you get
+ * an ExecutionException wrapping the actual Exception thrown from within the *able.
+ * Unfortunately, you do not get the call path that got you to the submission of the *able
+ * into the Executor. This class is designed to fix that.  All you do is call
+ * makeContextCallable or makeContextRunnable on your *able and submit the result instead of
+ * the original *able.
+ *
+ * So, if you look at ContextTest, if the exception wasn't caught, you'd see (edited for brevity):
+ *
+ * java.util.concurrent.ExecutionException: java.lang.RuntimeException: No boolean for you
+ *     at java.util.concurrent.FutureTask.report(FutureTask.java:122)
+ *     at java.util.concurrent.FutureTask.get(FutureTask.java:188)
+ *     at com.spotify.helios.common.ContextTest.testContextCallable(ContextTest.java:57)
+ * ....
+ *     at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
+ *     at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
+ * Caused by: java.lang.RuntimeException: No boolean for you
+ *     at com.spotify.helios.common.ContextTest$1.call(ContextTest.java:55)
+ *     at com.spotify.helios.common.ContextTest$1.call(ContextTest.java:1)
+ *     at com.spotify.helios.common.Context$1.call(Context.java:44)
+ *     at java.util.concurrent.FutureTask.run(FutureTask.java:262)
+ *     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
+ *     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
+ *     at java.lang.Thread.run(Thread.java:744)
+ * Caused by: com.spotify.helios.common.CallPathToExecutorException
+ *     at com.spotify.helios.common.Context.makeContextCallable(Context.java:38)
+ *     at com.spotify.helios.common.ContextTest.testContextCallable(ContextTest.java:52)
+ *     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+ * ....
+ *     at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
+ *     at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
+ *
+ * Normally, you'd not see anything from the CallPathToExcecutorException line on down.  Here,
+ * you can see that it originated in the method testContextCallable, and the normal information
+ * lists the call site of the get (third line down from the top).
+ */
+public final class Context {
+  private static final Field causeField;
+
+  static {
+    Field fieldValue = null;
+    try {
+      fieldValue = Throwable.class.getDeclaredField("cause");
+      fieldValue.setAccessible(true);
+    } catch (NoSuchFieldException | SecurityException e) { // Should never happen
+    }
+    causeField = fieldValue;
+  }
+
+  /**
+   * Returns a Callable that will retain the stack trace information about where it
+   * originated from.
+   *
+   * @param in The original Callable.
+   */
+  public static <T> Callable<T> makeContextCallable(final Callable<T> in) {
+    return new ContextCallable<T>(in);
+  }
+
+  /**
+   * Returns a Runnable that will retain the stack trace information about where it
+   * originated from.
+   *
+   * @param in The original Runnable
+   */
+  public static Runnable makeContextRunnable(final Runnable in) {
+    return new ContextRunnable(in);
+  }
+
+  /**
+   * Returns an Executor that wraps Runnables before submission to the passed in Executor.
+   */
+  public static Executor decorate(final Executor executor) {
+    return new Executor() {
+      @Override
+      public void execute(Runnable command) {
+        executor.execute(makeContextRunnable(command));
+      }
+    };
+  }
+
+  /**
+   * Returns an ExecutorService that wraps *ables before submission to the passed in
+   * ExecutorService.
+   */
+  public static ExecutorService decorate(final ExecutorService executorService) {
+    return new ContextExecutorService(executorService);
+  }
+
+  /**
+   * Returns a ScheduledExecutorService that wraps *ables before submission to the passed in
+   * ScheduledExecutorService.
+   */
+  public static ScheduledExecutorService decorate(final ScheduledExecutorService service) {
+    return new ContextScheduledExecutorService(service);
+  }
+
+  /**
+   * Returns a ListeningExecutorService that wraps *ables before submission to the passed in
+   * ListeningExecutorService.
+   */
+  public static ListeningExecutorService decorate(final ListeningExecutorService service) {
+    return new ContextListeningExecutorService(service);
+  }
+
+  /**
+   * Returns a ListeningScheduledExecutorService that wraps *ables before submission to the passed
+   * in ListeningScheduledExecutorService.
+   */
+  public static ListeningScheduledExecutorService decorate(
+      final ListeningScheduledExecutorService service) {
+    return new ContextListeningScheduledExecutorService(service);
+  }
+
+  /**
+   * Set the cause of the root-cause Exception to a new CallPathToExcecutorException
+   * that has the trace info in it.
+   */
+  static void handleException(final StackTraceElement[] trace, final Throwable th) {
+    if (causeField != null) { // should *always* be non-null
+      try {
+        causeField.set(findRootCause(th), new CallPathToExecutorException(trace));
+      } catch (IllegalArgumentException | IllegalAccessException e) {
+      }
+    }
+  }
+
+  static StackTraceElement[] getStackContext() {
+    // Per http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6375302, this is 10x faster
+    // than Thread.getCurrentThread().getStackTrace()
+    return new Throwable().getStackTrace();
+  }
+
+  private static Throwable findRootCause(Throwable th) {
+    // find end of the causality chain
+    while (th.getCause() != null) {
+      th = th.getCause();
+    }
+    return th;
+  }
+
+  /** Utility function used by the Context*Executor classes */
+  static <T> List<Callable<T>> makeContextWrappedCollection(
+      Collection<? extends Callable<T>> tasks) {
+    final List<Callable<T>> contexted = Lists.newArrayList();
+    for (Callable<T> task : tasks) {
+      contexted.add(makeContextCallable(task));
+    }
+    return contexted;
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/ContextCallable.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/ContextCallable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A Callable that will include additional stack trace information if run() throws an
+ * Exception.
+ */
+final class ContextCallable<T> implements Callable<T> {
+  private final Callable<T> task;
+  private final StackTraceElement[] trace;
+
+  ContextCallable(final Callable<T> task) {
+    this.task = task;
+    this.trace = Context.getStackContext();
+  }
+
+  @Override
+  public T call() throws Exception {
+    try {
+      return task.call();
+    } catch (final Throwable th) {
+      Context.handleException(trace, th);
+      throw th;
+    }
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/ContextExecutorService.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/ContextExecutorService.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+class ContextExecutorService implements ExecutorService {
+  private final ExecutorService service;
+
+  ContextExecutorService(ExecutorService executorService) {
+    this.service = executorService;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    service.execute(Context.makeContextRunnable(command));
+  }
+
+  @Override
+  public void shutdown() {
+    service.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return service.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return service.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return service.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return service.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return service.submit(Context.makeContextCallable(task));
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return service.submit(Context.makeContextRunnable(task), result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return service.submit(Context.makeContextRunnable(task));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return service.invokeAll(Context.makeContextWrappedCollection(tasks));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+      TimeUnit unit) throws InterruptedException {
+    return service.invokeAll(Context.makeContextWrappedCollection(tasks), timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException,
+      ExecutionException {
+    return service.invokeAny(Context.makeContextWrappedCollection(tasks));
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return service.invokeAny(Context.makeContextWrappedCollection(tasks), timeout, unit);
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/ContextListeningExecutorService.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/ContextListeningExecutorService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.spotify.helios.common.context.Context.makeContextCallable;
+import static com.spotify.helios.common.context.Context.makeContextRunnable;
+import static com.spotify.helios.common.context.Context.makeContextWrappedCollection;
+
+class ContextListeningExecutorService implements ListeningExecutorService {
+  private final ListeningExecutorService service;
+
+  ContextListeningExecutorService(ListeningExecutorService service) {
+    this.service = service;
+  }
+
+  @Override
+  public void shutdown() {
+    service.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return service.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return service.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return service.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return service.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException,
+      ExecutionException {
+    return service.invokeAny(makeContextWrappedCollection(tasks));
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return service.invokeAny(makeContextWrappedCollection(tasks), timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    service.execute(makeContextRunnable(command));
+
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return service.invokeAll(makeContextWrappedCollection(tasks));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+      TimeUnit unit) throws InterruptedException {
+    return service.invokeAll(makeContextWrappedCollection(tasks), timeout, unit);
+  }
+
+  @Override
+  public <T> ListenableFuture<T> submit(Callable<T> task) {
+    return service.submit(makeContextCallable(task));
+  }
+
+  @Override
+  public ListenableFuture<?> submit(Runnable command) {
+    return service.submit(makeContextRunnable(command));
+  }
+
+  @Override
+  public <T> ListenableFuture<T> submit(Runnable command, T result) {
+    return service.submit(makeContextRunnable(command), result);
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/ContextListeningScheduledExecutorService.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/ContextListeningScheduledExecutorService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static com.spotify.helios.common.context.Context.makeContextCallable;
+import static com.spotify.helios.common.context.Context.makeContextRunnable;
+
+class ContextListeningScheduledExecutorService extends ContextListeningExecutorService
+    implements ListeningScheduledExecutorService {
+
+  private final ListeningScheduledExecutorService service;
+
+  ContextListeningScheduledExecutorService(ListeningScheduledExecutorService service) {
+    super(service);
+    this.service = service;
+  }
+
+  @Override
+  public ListenableScheduledFuture<?> schedule(Runnable command, long timeout, TimeUnit unit) {
+    return service.schedule(makeContextRunnable(command), timeout, unit);
+  }
+
+  @Override
+  public <V> ListenableScheduledFuture<V> schedule(Callable<V> task, long timeout, TimeUnit unit) {
+    return service.schedule(makeContextCallable(task), timeout, unit);
+  }
+
+  @Override
+  public ListenableScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
+      long period, TimeUnit unit) {
+    return service.scheduleAtFixedRate(makeContextRunnable(command), initialDelay, period, unit);
+  }
+
+  @Override
+  public ListenableScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
+      long delay, TimeUnit unit) {
+    return service.scheduleWithFixedDelay(makeContextRunnable(command), initialDelay, delay, unit);
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/ContextRunnable.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/ContextRunnable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+/**
+ * A Runnable that will include additional stack trace information if run() throws an
+ * Exception.
+ */
+final class ContextRunnable implements Runnable {
+  private final Runnable command;
+  private final StackTraceElement[] trace;
+
+  ContextRunnable(final Runnable command) {
+    this.command = command;
+    this.trace = Context.getStackContext();
+  }
+
+  @Override
+  public void run() {
+    try {
+      command.run();
+    } catch (final Throwable th) {
+      Context.handleException(trace, th);
+      throw th;
+    }
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/context/ContextScheduledExecutorService.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/context/ContextScheduledExecutorService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.spotify.helios.common.context.Context.makeContextCallable;
+import static com.spotify.helios.common.context.Context.makeContextRunnable;
+
+class ContextScheduledExecutorService extends ContextExecutorService
+    implements ScheduledExecutorService {
+
+  private final ScheduledExecutorService service;
+
+  public ContextScheduledExecutorService(ScheduledExecutorService service) {
+    super(service);
+    this.service = service;
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    return service.schedule(makeContextRunnable(command), delay, unit);
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    return service.schedule(makeContextCallable(callable), delay, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
+      TimeUnit unit) {
+    return service.scheduleAtFixedRate(makeContextRunnable(command), initialDelay, period, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+      TimeUnit unit) {
+    return service.scheduleWithFixedDelay(makeContextRunnable(command), initialDelay, delay, unit);
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/common/context/ContextTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/context/ContextTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.context;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContextTest {
+  private ExecutorService executorService;
+  private final Callable<Boolean> KABOOM_CALLABLE = new Callable<Boolean>() {
+    @Override
+    public Boolean call() throws Exception {
+      throw new RuntimeException("No boolean for you");
+    }
+  };
+
+  @Before
+  public void setUp() throws Exception {
+    executorService = Executors.newCachedThreadPool();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    executorService.shutdownNow();
+  }
+
+  @Test
+  public void testContextExecutorService() throws Exception {
+    final ExecutorService svc = Context.decorate(executorService);
+    try {
+      svc.submit(KABOOM_CALLABLE).get();
+    } catch (ExecutionException e) {
+      final Throwable rte = e.getCause();
+      final Throwable cptee = rte.getCause();
+      assertEquals(CallPathToExecutorException.class, cptee.getClass());
+      assertEquals("testContextExecutorService", cptee.getStackTrace()[2].getMethodName());
+    }
+  }
+
+  @Test
+  public void testContextCallable() throws Exception {
+    try {
+      executorService.submit(Context.makeContextCallable(KABOOM_CALLABLE)).get();
+    } catch (ExecutionException e) {
+      final Throwable rte = e.getCause();
+      final Throwable cptee = rte.getCause();
+      assertEquals(CallPathToExecutorException.class, cptee.getClass());
+      assertEquals("testContextCallable", cptee.getStackTrace()[1].getMethodName());
+    }
+  }
+
+  @Test
+  public void testContextRunnable() throws Exception {
+    try {
+      executorService.submit(Context.makeContextRunnable(new Runnable() {
+        @Override
+        public void run() {
+          throw new RuntimeException("Oy vey!");
+        }
+      })).get();
+    } catch (ExecutionException e) {
+      final Throwable rte = e.getCause(); //the RuntimeException above
+      final Throwable cptee = rte.getCause(); // should be CallPathToExecutorException
+      assertEquals(CallPathToExecutorException.class, cptee.getClass());
+      assertEquals("testContextRunnable", cptee.getStackTrace()[1].getMethodName());
+    }
+  }
+}


### PR DESCRIPTION
Sometimes you get exceptions in Callables and Runnables and it would be really nice
 if you could see the trace path that got them on the executor.  The Context class should
help with this.
