### PR TITLE
Add more info to testing framework logs

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
@@ -212,7 +212,7 @@ public class TemporaryJob {
             verifyHealthy(host, taskStatus);
 
             final TaskStatus.State state = taskStatus.getState();
-            log.info("Job state: {}", state);
+            log.info("Job state of {}: {}", job.getImage(), state);
 
             if (state == TaskStatus.State.RUNNING) {
               return taskStatus;
@@ -253,7 +253,8 @@ public class TemporaryJob {
         stateString += format("(%s)", status.getThrottled());
       }
       throw new AssertionError(format(
-          "Unexpected job state %s. Check helios agent logs for details.", stateString));
+          "Unexpected job state %s for job %s with image %s on host %s. Check helios agent "
+          + "logs for details.", stateString, job.getId().toShortString(), job.getImage(), host));
     }
   }
 


### PR DESCRIPTION
Before, if a container failed to start we would throw an exception
with an error message, but we would not say which job threw the
exception. This was confusing to debug when you've deployed multiple
containers. We now throw an exception with this message:

Unexpected job state EXITED for job tmp_5ebc2788_spotify_cassandra:c008a672:bc1ebbf
with image spotify/cassandra on host heliosciagent Check helios agent logs for details.

Also when pulling an image takes a long time your screen would
fill up with the message "Job state: PULLING_IMAGE". When pulling
and image takes a long time, it would be easy to lose context and
know which image is being pulled. The message is now this:
Job state of spotify/cassandra: PULLING_IMAGE
