### PR TITLE
Fix config file reading

### DIFF
--- a/docs/testing_framework.md
+++ b/docs/testing_framework.md
@@ -208,7 +208,7 @@ files) you could put in your projects
 `src/test/resources/application.conf` file might be:
 
 ```
-helios.testing.defaultProfile : foo
+helios.testing.profile : foo
 helios.testing.profiles {
   foo : {
     env : {
@@ -236,10 +236,11 @@ Also, any settings on the builders in code will override what's in the
 file.
 
 If the profile specified either to the builder directly, or by the
-`defaultProfile` setting does not exist, you'll get a failure.  Since
-we're using the Typesafe Library, you can then make the default
-profile settable by java property or environment variable, which can
-then be configured via Maven (if you're using it) profiles.
+`profile` setting does not exist, you'll get a failure.  If there is
+no profile set, this is still ok.  Since we're using the Typesafe
+Library, you can then make the default profile settable by java
+property or environment variable, which can then be configured via
+Maven (if you're using it) profiles.
 
 # Job Cleanup
 

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -277,12 +277,14 @@ public class HeliosClient {
       if (endpoints.isEmpty()) {
         throw new RuntimeException("failed to resolve master");
       }
+      log.debug("endpoint uris are {}", endpoints);
       for (int i = 0; i < endpoints.size() && currentTimeMillis() < deadline; i++) {
         final URI endpoint = endpoints.get(positive(offset + i) % endpoints.size());
         final String fullpath = endpoint.getPath() + uri.getPath();
         final URI realUri = new URI("http", endpoint.getHost() + ":" + endpoint.getPort(),
                                     fullpath, uri.getQuery(), null);
         try {
+          log.debug("connecting to {}", realUri);
           return connect0(realUri, method, entity, headers);
         } catch (ConnectException e) {
           // Connecting failed, sleep a bit to avoid hammering and then try another endpoint

--- a/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
@@ -116,7 +116,7 @@ public class ConfigTest {
     final TestParameters.JobValidator validator = new TestParameters.JobValidator() {
       @Override
       public void validate(Job job, String prefix) {
-        final String domain = prefix + ".services.heliosci.cloud.spotify.net";
+        final String domain = prefix + ".services.helios-ci.cloud.spotify.net";
         final Map<String, String> map = ImmutableMap.of(
             "SPOTIFY_DOMAIN", domain,
             "SPOTIFY_POD", domain,
@@ -129,7 +129,7 @@ public class ConfigTest {
 
     // Specify the helios-ci profile explicitly
     parameters = new TestParameters(TemporaryJobs.builder("helios-ci"),
-                                ".+\\.heliosci\\.cloud",
+                                ".+\\.helios-ci\\.cloud",
                                 validator);
     assertThat(testResult(ProfileTest.class), isSuccessful());
   }

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TempJobsProfileOverrideTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TempJobsProfileOverrideTest.java
@@ -1,0 +1,24 @@
+package com.spotify.helios.testing;
+
+import com.typesafe.config.Config;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static com.spotify.helios.testing.TemporaryJobs.HELIOS_TESTING_PROFILE;
+import static org.junit.Assert.assertEquals;
+
+public class TempJobsProfileOverrideTest {
+  @Test public void foo() throws Exception {
+    final Properties oldProperties = System.getProperties();
+    final Config c;
+    try {
+      System.setProperty(HELIOS_TESTING_PROFILE, "this");
+      c = TemporaryJobs.loadConfig();
+    } finally {
+      System.setProperties(oldProperties);
+    }
+    assertEquals("this", TemporaryJobs.getProfileFromConfig(c));
+  }
+}

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTest.java
@@ -92,7 +92,6 @@ public class TemporaryJobsTest extends SystemTestBase {
 
     @Rule
     public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
-//        .hostFilter(".*")
         .client(client)
         .prober(new TestProber())
         .build();
@@ -102,7 +101,6 @@ public class TemporaryJobsTest extends SystemTestBase {
     @Before
     public void setup() {
       job1 = temporaryJobs.job()
-//          .image(BUSYBOX)
           .command("nc", "-p", "4711", "-lle", "cat")
           .port("echo", 4711)
           .deploy(testHost1);
@@ -112,7 +110,6 @@ public class TemporaryJobsTest extends SystemTestBase {
     public void testDeployment() throws Exception {
       // Verify that it is possible to deploy additional jobs during test
       temporaryJobs.job()
-          .image(BUSYBOX)
           .command(IDLE_COMMAND)
           .host(testHost1)
           .deploy();
@@ -133,9 +130,7 @@ public class TemporaryJobsTest extends SystemTestBase {
     @Test
     public void testRandomHost() throws Exception {
       temporaryJobs.job()
-          .image(BUSYBOX)
           .command("sh", "-c", "while :; do sleep 5; done")
-          .hostFilter(".+")
           .deploy();
 
       final Map<JobId, Job> jobs = client.jobs().get(15, SECONDS);
@@ -150,7 +145,6 @@ public class TemporaryJobsTest extends SystemTestBase {
     @Test
     public void testSpecificHost() throws Exception {
       final TemporaryJob job = temporaryJobs.job()
-          .image(BUSYBOX)
           .command(IDLE_COMMAND)
           .hostFilter(testHost2)
           .deploy();
@@ -162,7 +156,6 @@ public class TemporaryJobsTest extends SystemTestBase {
 
     public void testDefaultLocalHostFilter() throws Exception {
       temporaryJobs.job()
-          .image(BUSYBOX)
           .command("sh", "-c", "while :; do sleep 5; done")
           .deploy();
     }
@@ -171,7 +164,6 @@ public class TemporaryJobsTest extends SystemTestBase {
     public void testExceptionWithBadHostFilter() throws Exception {
       // Shouldn't be able to deploy if filter doesn't match any hosts
       temporaryJobs.job()
-          .image(BUSYBOX)
           .command("sh", "-c", "while :; do sleep 5; done")
           .hostFilter("THIS_FILTER_SHOULDNT_MATCH_ANY_HOST")
           .deploy();
@@ -201,7 +193,6 @@ public class TemporaryJobsTest extends SystemTestBase {
 
     @Rule
     public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
-        .hostFilter(".*")
         .client(client)
         .prober(new TestProber())
         .build();
@@ -221,7 +212,6 @@ public class TemporaryJobsTest extends SystemTestBase {
 
     @Rule
     public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
-        .hostFilter(".*")
         .client(client)
         .prober(new TestProber())
         .prefixDirectory(prefixDirectory.toString())
@@ -235,12 +225,10 @@ public class TemporaryJobsTest extends SystemTestBase {
     @Before
     public void setup() {
       job1 = temporaryJobs.job()
-          .image(BUSYBOX)
           .command(IDLE_COMMAND)
           .deploy(testHost1);
 
       job2 = temporaryJobs.job()
-          .image(BUSYBOX)
           .command(IDLE_COMMAND)
           .expires(expires)
           .deploy(testHost1);

--- a/helios-testing/src/test/resources/helios-base.conf
+++ b/helios-testing/src/test/resources/helios-base.conf
@@ -1,4 +1,5 @@
-helios.testing.defaultProfile = local
+#Overridden by the helios.conf, so this tests overriding works properly
+helios.testing.profile : "some totally bogus profile"
 helios.testing.profiles : {
 
   local : {
@@ -15,10 +16,10 @@ helios.testing.profiles : {
   helios-ci: {
     image: busybox
     domain: "shared.cloud.spotify.net"
-    hostFilter: ".+\\.heliosci\\.cloud"
+    hostFilter: ".+\\.helios-ci\\.cloud"
     env: {
-      SPOTIFY_DOMAIN: ${prefix}".services.heliosci.cloud.spotify.net"
-      SPOTIFY_POD: ${prefix}".services.heliosci.cloud.spotify.net"
+      SPOTIFY_DOMAIN: ${prefix}".services.helios-ci.cloud.spotify.net"
+      SPOTIFY_POD: ${prefix}".services.helios-ci.cloud.spotify.net"
       SPOTIFY_SYSLOG_HOST: 10.99.0.1
     }
   }

--- a/helios-testing/src/test/resources/helios.conf
+++ b/helios-testing/src/test/resources/helios.conf
@@ -1,0 +1,3 @@
+helios.testing.profile = local
+helios.testing.profile = ${?HELIOS_TESTING_PROFILE}
+


### PR DESCRIPTION
Now use helios-base.conf and helios.conf as config files.
Won't conflict with any other Typesafe config things the
project might be using.  Also fixes the client creation
code in TemporaryJobs to not stomp on an existing client
if the domain/endpoints, etc. was set in the config file.
