### PR TITLE
TemporaryJobs: Enable manually undeploying jobs

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
@@ -192,6 +192,21 @@ public class TemporaryJob {
     Jobs.undeploy(client, job, hosts, errors);
   }
 
+  /**
+   * Undeploys and removes this TemporaryJob from the Helios cluster. This is normally done
+   * automatically by TemporaryJObs at the end of the test run. Use this method if you need to
+   * manually undeploy a job prior to the end of the test run.
+   */
+  public void undeploy() {
+    final List<AssertionError> errors = Lists.newArrayList();
+    undeploy(errors);
+
+    if (errors.size() > 0) {
+      fail(format("Failed to undeploy job %s - %s",
+                  getJobDescription(job), errors.get(0)));
+    }
+  }
+
   private void awaitUp(final String host) throws TimeoutException {
 
     final TaskStatus status = Polling.awaitUnchecked(

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTest.java
@@ -57,6 +57,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -152,6 +153,18 @@ public class TemporaryJobsTest extends SystemTestBase {
       final JobStatus status = client.jobStatus(job.job().getId()).get(15, SECONDS);
       final Map<String, Deployment> deployments = status.getDeployments();
       assertThat(deployments.keySet(), contains(testHost2));
+    }
+
+    @Test
+    public void testManualUndeploy() throws Exception {
+      final TemporaryJob job = temporaryJobs.job()
+          .command(IDLE_COMMAND)
+          .deploy();
+
+      job.undeploy();
+
+      final JobStatus status = client.jobStatus(job.job().getId()).get(15, SECONDS);
+      assertNull("job still exists", status);
     }
 
     public void testDefaultLocalHostFilter() throws Exception {


### PR DESCRIPTION
Undeploying jobs is normally done automatically by TemporaryJobs, but the
new public overload of TemporaryJob.undeploy can be used to manually
undeploy a job prior to the end of the test run.
