### PR TITLE
Fix visibility of Prober to public

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/Prober.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Prober.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.testing;
 
-interface Prober {
-
+public interface Prober {
   boolean probe(String host, int port);
 }


### PR DESCRIPTION
It's hard to make your own if we don't allow access.  Oops.
