### PR TITLE
Various cleanups and warning fixes.

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -160,14 +160,16 @@ public class JobValidator {
   private Set<String> validateJobId(final Job job) {
     final Set<String> errors = Sets.newHashSet();
     final JobId jobId = job.getId();
-    final String jobIdVersion = jobId.getVersion();
-    final String jobIdHash = jobId.getHash();
-    final JobId recomputedId = job.toBuilder().build().getId();
 
     if (jobId == null) {
       errors.add(format("Job id was not specified."));
       return errors;
     }
+
+    final String jobIdVersion = jobId.getVersion();
+    final String jobIdHash = jobId.getHash();
+    final JobId recomputedId = job.toBuilder().build().getId();
+
 
     errors.addAll(validateJobName(jobId, recomputedId));
     errors.addAll(validateJobVersion(jobIdVersion, recomputedId));

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentMain.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentMain.java
@@ -74,7 +74,7 @@ public class AgentMain extends ServiceMain {
     final AgentMain main;
     final AtomicBoolean exitSignalTriggered = new AtomicBoolean(false);
 
-    final AtomicReference<SignalHandler> existingIntHandler =
+    final AtomicReference<SignalHandler> existingExitHandler =
         new AtomicReference<SignalHandler>(null);
 
     final SignalHandler handler = new SignalHandler() {
@@ -87,11 +87,11 @@ public class AgentMain extends ServiceMain {
         } else {
           System.err.println("Attempting gentle exit on " + signal);
           exitSignalTriggered.set(true);
-          existingIntHandler.get().handle(signal);
+          existingExitHandler.get().handle(signal);
         }
       }
     };
-    existingIntHandler.set(Signal.handle(new Signal("INT"), handler));
+    existingExitHandler.set(Signal.handle(new Signal("INT"), handler));
     Signal.handle(new Signal("TERM"), handler);
 
     try {

--- a/helios-services/src/main/java/com/spotify/helios/master/ExpiredJobReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ExpiredJobReaper.java
@@ -63,12 +63,13 @@ public class ExpiredJobReaper extends InterruptingScheduledService {
   @Override
   protected void runOneIteration() {
     for (Entry<JobId, Job> entry : masterModel.getJobs().entrySet()) {
-      JobId jobId = entry.getKey();
-      Job job = entry.getValue();
+      final JobId jobId = entry.getKey();
+      final Job job = entry.getValue();
 
       if (job.getExpires() == null) {
         continue;
-      } else if (job.getExpires().getTime() <= System.currentTimeMillis()) {
+      }
+      if (job.getExpires().getTime() <= System.currentTimeMillis()) {
         final JobStatus status = masterModel.getJobStatus(jobId);
         final List<String> hosts = ImmutableList.copyOf(status.getDeployments().keySet());
 

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectory.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectory.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
@@ -339,7 +340,8 @@ public class ZooKeeperUpdatingPersistentDirectory extends AbstractIdleService {
       }
 
       // Remove undesired nodes
-      for (final String node : remote.keySet()) {
+      final ImmutableSet<String> keySet = ImmutableSet.copyOf(remote.keySet());
+      for (final String node : keySet) {
         if (!snapshot.containsKey(node)) {
           final String nodePath = ZKPaths.makePath(path, node);
           log.debug("sync: deleting node {}", nodePath);

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliMasterListTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliMasterListTest.java
@@ -54,7 +54,7 @@ public class CliMasterListTest extends SystemTestBase {
   @Test
   public void testMasterListJson() throws Exception {
     final String jsonOutput = cli("masters", "-f", "--json");
-    final List masterList = Json.read(jsonOutput, List.class);
+    final List<?> masterList = Json.read(jsonOutput, List.class);
     final List<String> expectedList = Lists.newArrayList(TEST_MASTER);
     assertEquals(expectedList, masterList);
   }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentTest.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap;
 
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
-import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;


### PR DESCRIPTION
Particularly interesting is the change to ZooKeeperUpdatingPersistentDirectory.
I have no idea if that ever worked, as if it ever removed a node, it would get
a ConcurrentModificationException.

In JobValidator, the `if (jobId == null)` could never be reached as an NPE would
be thrown before it got there.

As usual, kudos to the writers of Eclipse for catching most of these.  The ZKUPD
issue I happened to notice when doing the release build/test.
