### PR TITLE
Reset joda-time to use system clock after test.

### DIFF
--- a/helios-services/src/test/java/com/spotify/helios/agent/GracePeriodTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/GracePeriodTest.java
@@ -236,6 +236,7 @@ public class GracePeriodTest {
       sut.close();
       sut.join();
     }
+    DateTimeUtils.setCurrentMillisSystem();
   }
 
   @Test


### PR DESCRIPTION
This would actually have a chance to affect other tests later on,
e.g. the ExpiredJobReaperTest which also depends on now()
