### PR TITLE
Made failure to find tempjobs cleanup file ok

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -398,6 +399,8 @@ public class TemporaryJobs implements TestRule {
         if (!jobRemovalFailed) {
           prefixFile.delete();
         }
+      } catch (NoSuchFileException e) {
+        log.debug("File {} already processed by somebody else.", file.getPath());
       } catch (Exception e) {
         // log exception and continue on to next file
         log.warn("Exception processing file {}", file.getPath(), e);


### PR DESCRIPTION
Can show up in test logs if users run more than
one TJ test concurrently, and since this isn't
a real error, it's just suppressed for now.
