### PR TITLE
Fix build issue w/fetching key to install Docker

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -2,7 +2,7 @@
 
 case "$1" in
   before_install)
-    sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
+    sudo sh -c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
     sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
     sudo apt-get update
 


### PR DESCRIPTION
The old method to retrieve the Docker repository key has stopped working.
Use `apt-key adv` instead.
