### PR TITLE
Do not print no match warnings in -q quiet mode.

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/MonitoredDockerClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/MonitoredDockerClient.java
@@ -34,7 +34,7 @@ import java.lang.reflect.Proxy;
 /**
  * A docker client proxy used to monitor docker operations.  It's abstract and doesn't implement
  * {@link DockerClient}, but don't let it fool you.  You call {@link #wrap} with the
- * {@link RiemmanFacade} and the real {@link DockerClient} and you then use that.
+ * {@link RiemannFacade} and the real {@link DockerClient} and you then use that.
  */
 public abstract class MonitoredDockerClient {
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.Task;
@@ -110,7 +111,7 @@ public class ZooKeeperAgentModel extends AbstractIdleService implements AgentMod
   }
 
   /**
-   * Returns the tasks (basically, a pair of {@link Job} and {@Goal}) for the current agent.
+   * Returns the tasks (basically, a pair of {@link JobId} and {@link Goal}) for the current agent.
    */
   @Override
   public Map<JobId, Task> getTasks() {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterMain.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterMain.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Instantiates and runs the helios master. We do our own bootstrapping instead of using
- * {@link com.yammer.dropwizard.config.Bootstrap} because we want more control over logging etc.
+ * {@link io.dropwizard.setup.Bootstrap} because we want more control over logging etc.
  */
 public class MasterMain extends ServiceMain {
 

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
@@ -45,7 +45,7 @@ import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
- * A class that is similar to {@link AtomicReference<T>} but is backed by a file, so can be
+ * A class that is similar to {@link AtomicReference} but is backed by a file, so can be
  * persisted across a server restart.  Assumes the underlying type can be serialized by Jackson.
  *
  * Strangely, this is not actually atomic in the {@link AtomicReference} way; i.e. not threadsafe,

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/ResolverConfReader.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/ResolverConfReader.java
@@ -41,7 +41,7 @@ public class ResolverConfReader {
   /**
    * Looks in file to find the domain setting.
    *
-   * @param string path to resolver config file
+   * @param file path to resolver config file
    * @return the domain specified there, or empty string if any failure
    */
   public static String getDomainFromResolverConf(final String file) {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliDeploymentTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliDeploymentTest.java
@@ -46,6 +46,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class CliDeploymentTest extends SystemTestBase {
 
@@ -106,7 +107,8 @@ public class CliDeploymentTest extends SystemTestBase {
     assertThat(cli("jobs", testJobName, "-q"), containsString(jobId.toString()));
     assertThat(cli("jobs", testJobName + ":" + testJobVersion, "-q"),
                containsString(jobId.toString()));
-    assertEquals("job pattern foozbarz matched no jobs", cli("jobs", "foozbarz", "-q").trim());
+    assertEquals("job pattern foozbarz matched no jobs", cli("jobs", "foozbarz").trim());
+    assertTrue(cli("jobs", "foozbarz", "-q").isEmpty());
 
     // Create a new job using the first job as a template
     final Job expectedCloned = expected.toBuilder()

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/QueryFailureTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/QueryFailureTest.java
@@ -31,13 +31,14 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests that commands which do search matching tell you that you didn't match anything if you
  * provided something to match against.  Specifically, if you do something like
  *     helios -s foo hosts list
  * and no host starts with 'list', it'll at least tell you that no hosts matched that, rather than
- * just returning an empty display
+ * just returning an empty display, unless option -q (quiet) is used.
  *
  * @author (Drew Csillag) drewc@spotify.com
  */
@@ -51,11 +52,27 @@ public class QueryFailureTest extends SystemTestBase {
   }
 
   @Test
+  public void testQuietHostList() throws Exception {
+    startDefaultMaster();
+
+    final String result = cli("hosts", "framazama", "-q");
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
   public void testJobList() throws Exception {
     startDefaultMaster();
 
     final String result = cli("jobs", "framazama");
     assertThat(result, containsString("matched no jobs"));
+  }
+
+  @Test
+  public void testQuietJobList() throws Exception {
+    startDefaultMaster();
+
+    final String result = cli("jobs", "framazama", "-q");
+    assertTrue(result.isEmpty());
   }
 
   @Test

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -103,7 +103,7 @@ public class CliConfig {
    * Returns a CliConfig instance with values from a config file from under the users home
    * directory:
    *
-   * <user.home>/.helios/config
+   * &lt;user.home&gt;/.helios/config
    *
    * If the file is not found, a CliConfig with pre-defined values will be returned.
    *

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -94,15 +94,16 @@ public class HostListCommand extends ControlCommand {
         .filter(containsPattern(pattern))
         .toList();
     final boolean full = options.getBoolean(fullArg.getDest());
+    final boolean quiet = options.getBoolean(quietArg.getDest());
 
     if (!Strings.isNullOrEmpty(pattern) && hosts.isEmpty()) {
-      out.printf("host pattern %s matched no hosts%n", pattern);
+      if (!quiet) {
+        out.printf("host pattern %s matched no hosts%n", pattern);
+      }
       return 1;
     }
 
     final List<String> sortedHosts = natural().sortedCopy(hosts);
-
-    final boolean quiet = options.getBoolean(quietArg.getDest());
 
     if (quiet) {
       if (json) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobListCommand.java
@@ -91,7 +91,9 @@ public class JobListCommand extends ControlCommand {
     }
 
     if (!Strings.isNullOrEmpty(pattern) && jobs.isEmpty()) {
-      out.printf("job pattern %s matched no jobs%n", pattern);
+      if (!quiet) {
+        out.printf("job pattern %s matched no jobs%n", pattern);
+      }
       return 1;
     }
 


### PR DESCRIPTION
Since the quiet option (-q) of commands is mostly targeted for scripting, it is bad that it prints warnings about no matches. That warning will otherwise have to filtered out before using the output in scripts.

Also, made a few trivial adjustments to broken javadoc to make the project build with JDK 8, which has a more strict javadoc tool.
