### PR TITLE
Removing unused dependencies

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -38,11 +38,6 @@
       <version>1.7.6</version>
     </dependency>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>2.2.0</version>
-    </dependency>
-    <dependency>
       <groupId>dnsjava</groupId>
       <artifactId>dnsjava</artifactId>
       <version>2.1.6</version>

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -50,11 +50,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>2.0.3</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -39,11 +39,6 @@
       <version>1.1.2</version>
     </dependency>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>2.2.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.6</version>


### PR DESCRIPTION
Found a couple dependenices which aren't being used. The jsr305 dependency
in helios-testing was causing a problem for one of our users because it
conflicts with a lower version they are using. Since we're not using it,
might as well remove it and not force them to exclude it in their pom.
