### PR TITLE
Allow other options for the host picking strategy for TempJobs

### DIFF
--- a/docs/testing_framework.md
+++ b/docs/testing_framework.md
@@ -198,6 +198,18 @@ accomplish this. Within a profile, the following keys having meaning:
 * `domain`  - string -- same as the `TemporaryJobsbuilder.domain()` method.
 * `endpoints`  - list of string -- same as the `TemporaryJobsbuilder.endpoints()` method.
 * `jobDeployedMessageFormat` - string -- a string format for [Apache StrSubstitutor](https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/text/StrSubstitutor.html) to log a custom message when the job has started -- available substitutions are [`host`, `name`, `version`, `hash`, `containerId`, `job`] - useful to log a link where container logs might be found.
+* `hostPickingStrategy` - string -- one of
+    * `random` (the default) - randomly pick a host for each temporary job.
+    * `onerandom` - randomly pick a host and deploy all temporary jobs there
+    * `deterministic` - seed the random number generator so it
+       "randomly" picks the same hosts across test runs that it
+       did in previous runs.  You must specify `hostPickingStrategyKey`.
+    * `onedetermistic` - seed the random number generator so it
+       "randomly" picks the same host on which it deploys all
+       jobs across test runs. You must specify `hostPickingStrategyKey`.
+* `hostPickingStrategyKey` - string - a string used to seed the random number
+  generator.  It can be basically anything, but it's best for it to not
+  be empty.
 
 There's also the `prefix` config variable, which is useless to set,
 but useful to reference from some of the above variables if you want

--- a/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -47,12 +46,15 @@ public class DefaultDeployer implements Deployer {
 
   private final HeliosClient client;
   private final List<TemporaryJob> jobs;
+  private final HostPickingStrategy hostPicker;
 
   private boolean readyToDeploy;
 
-  public DefaultDeployer(HeliosClient client, List<TemporaryJob> jobs) {
+  public DefaultDeployer(final HeliosClient client, final List<TemporaryJob> jobs,
+                         final HostPickingStrategy hostPicker) {
     this.client = client;
     this.jobs = jobs;
+    this.hostPicker = hostPicker;
   }
 
   @Override
@@ -80,7 +82,7 @@ public class DefaultDeployer implements Deployer {
       fail(format("no hosts matched the filter pattern - %s", hostFilter));
     }
 
-    final String chosenHost = filteredHosts.get(new Random().nextInt(filteredHosts.size()));
+    final String chosenHost = hostPicker.pickHost(filteredHosts);
     return deploy(job, asList(chosenHost), waitPorts, prober);
   }
 
@@ -104,6 +106,7 @@ public class DefaultDeployer implements Deployer {
     return temporaryJob;
   }
 
+  @Override
   public void readyToDeploy() {
     readyToDeploy = true;
   }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HostPickingStrategies.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HostPickingStrategies.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import java.util.List;
+import java.util.Random;
+
+import static java.lang.Math.floor;
+
+public class HostPickingStrategies {
+  private static class RandomHostPickingStrategy implements HostPickingStrategy {
+    private final Random random;
+
+    public RandomHostPickingStrategy(final Random random) {
+      this.random = random;
+    }
+
+    @Override
+    public String pickHost(final List<String> hosts) {
+      return hosts.get(random.nextInt(hosts.size()));
+    }
+  }
+
+  private static class RandomOneHostPickingStrategy implements HostPickingStrategy {
+    private final double random;
+
+    RandomOneHostPickingStrategy(final Random randomGenerator) {
+      this.random = randomGenerator.nextDouble();
+    }
+
+    @Override
+    public String pickHost(final List<String> hosts) {
+      final Double index = floor(random * hosts.size());
+      return hosts.get(index.intValue());
+    }
+  }
+
+  private static Random getSeededRandom(final String key) {
+    final Random randomGenerator = new Random();
+    randomGenerator.setSeed(key.hashCode());
+    return randomGenerator;
+  }
+
+  /** For any given invocation returns a random host */
+  public static HostPickingStrategy random() {
+    return new RandomHostPickingStrategy(new Random());
+  }
+
+  /**
+   * Pick a single host and use that for all jobs to be deployed in the tests used by this
+   * strategy.  If you want multiple test classes to use the same host, share the strategy
+   * between tests as a constant.
+   */
+  public static HostPickingStrategy randomOneHost() {
+    return new RandomOneHostPickingStrategy(new Random());
+  }
+
+  /**
+   * For any given invocation returns a random host, but running the same test with the same
+   * key should put jobs on the same hosts as they were the last time.
+   */
+  public static HostPickingStrategy deterministic(final String key) {
+    return new RandomHostPickingStrategy(getSeededRandom(key));
+  }
+
+  /**
+   * Deterministically, choose a single host for all jobs in the test.  That is, it will
+   * choose the same host given equal values of key.  If you want multiple test classes to
+   * use the same host, share the strategy between tests as a constant.
+   */
+  public static HostPickingStrategy deterministicOneHost(final String key) {
+    return new RandomOneHostPickingStrategy(getSeededRandom(key));
+  }
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HostPickingStrategy.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HostPickingStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import java.util.List;
+
+public interface HostPickingStrategy {
+  String pickHost(final List<String> hosts);
+}

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HostPickingStrategiesTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HostPickingStrategiesTest.java
@@ -1,0 +1,86 @@
+package com.spotify.helios.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class HostPickingStrategiesTest {
+  private static final int NUM_ITERATIONS = 1000;
+  private static final ImmutableList<String> HOSTS =
+      ImmutableList.of("hosta", "hostb", "hostc", "hostd");
+
+  @Test
+  public void testDeterministicOneHost() {
+    final Set<String> chosenHosts = Sets.newHashSet();
+    final HostPickingStrategy strategy1 = HostPickingStrategies.deterministicOneHost("");
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      chosenHosts.add(strategy1.pickHost(HOSTS));
+    }
+
+    final HostPickingStrategy strategy2 = HostPickingStrategies.deterministicOneHost("");
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      chosenHosts.add(strategy2.pickHost(HOSTS));
+    }
+    assertEquals(1, chosenHosts.size());
+  }
+
+  @Test
+  public void testDeterministic() {
+    final List<String> order = Lists.newArrayList();
+    final Set<String> chosenHosts = Sets.newHashSet();
+    final HostPickingStrategy strategy1 = HostPickingStrategies.deterministic("");
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      final String picked = strategy1.pickHost(HOSTS);
+      order.add(picked);
+      chosenHosts.add(picked);
+    }
+    // should've hit them all
+    assertEquals(HOSTS.size(), chosenHosts.size());
+
+    final HostPickingStrategy strategy2 = HostPickingStrategies.deterministic("");
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      assertEquals("at index " + i, order.get(i), strategy2.pickHost(HOSTS));
+    }
+  }
+
+  @Test
+  public void testRandomOneHost() {
+    final Set<String> chosenHosts = Sets.newHashSet();
+    final HostPickingStrategy strategy1 = HostPickingStrategies.randomOneHost();
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      chosenHosts.add(strategy1.pickHost(HOSTS));
+    }
+    assertEquals(1, chosenHosts.size());
+  }
+
+  @Test
+  public void testRandom() {
+    final List<String> order = Lists.newArrayList();
+    final Set<String> chosenHosts = Sets.newHashSet();
+    final HostPickingStrategy strategy1 = HostPickingStrategies.random();
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      final String picked = strategy1.pickHost(HOSTS);
+      order.add(picked);
+      chosenHosts.add(picked);
+    }
+    // should've hit them all
+    assertEquals(HOSTS.size(), chosenHosts.size());
+
+    final HostPickingStrategy strategy2 = HostPickingStrategies.random();
+    boolean different = false;
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      if (!order.get(i).equals(strategy2.pickHost(HOSTS))) {
+        different = true;
+        break;
+      }
+    }
+    assertTrue(different);
+  }
+}


### PR DESCRIPTION
can choose:
- random (the default)
- onerandom - randomly pick a host and deploy all jobs there
- deterministic - seed the random number generator so it
  "randomly" picks the same hosts across test runs that it
  did in previous runs
- onedetermistic - seed the random number generator so it
  "randomly" picks the same host on which it deploys all
  jobs across test runs.
