### PR TITLE
Use dashes not underscores in tempJob prefix

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/JobPrefixFile.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/JobPrefixFile.java
@@ -124,7 +124,7 @@ class JobPrefixFile implements AutoCloseable {
   private JobPrefixFile(final String prefix, final Path directory) throws IOException {
     Preconditions.checkNotNull(directory);
     this.prefix = prefix == null
-                     ? "tmp_" + new SimpleDateFormat("yyyyMMdd").format(new Date()) + "_"
+                     ? "tmp-" + new SimpleDateFormat("yyyyMMdd").format(new Date()) + "-"
                        + toHexString(ThreadLocalRandom.current().nextInt())
                      : prefix;
 


### PR DESCRIPTION
TemporaryJobs uses the tempJob prefix as the registration domain.
Depending on the registration plugin you are using, containers may
find each other by looking up SRV records in this domain. Previously
the domain contained underscores, but this caused problems for some
users because they tried to use the domain in a URI object. The URI
object does not correctly parse a string which contains underscores
because they are not allowed according to RFC 2396. The problem goes
away if we use dashes instead.
