### PR TITLE
Add ability to output a message when a job is deployed.

### DIFF
--- a/docs/testing_framework.md
+++ b/docs/testing_framework.md
@@ -197,6 +197,7 @@ accomplish this. Within a profile, the following keys having meaning:
 * `hostFilter`  - string -- same as the `TemporaryJobsbuilder.hostFilter()` method.
 * `domain`  - string -- same as the `TemporaryJobsbuilder.domain()` method.
 * `endpoints`  - list of string -- same as the `TemporaryJobsbuilder.endpoints()` method.
+* `jobDeployedMessageFormat` - string -- a string format for [Apache StrSubstitutor](https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/text/StrSubstitutor.html) to log a custom message when the job has started -- available substitutions are [`host`, `name`, `version`, `hash`, `containerId`, `job`] - useful to log a link where container logs might be found.
 
 There's also the `prefix` config variable, which is useless to set,
 but useful to reference from some of the above variables if you want

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -22,6 +22,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
@@ -22,6 +22,7 @@
 package com.spotify.helios.testing;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
@@ -82,6 +83,14 @@ public class TemporaryJob {
 
   public Job job() {
     return job;
+  }
+
+  public List<String> hosts() {
+    return hosts;
+  }
+
+  public Map<String, TaskStatus> statuses() {
+    return ImmutableMap.copyOf(statuses);
   }
 
   /**

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -21,11 +21,12 @@
 
 package com.spotify.helios.testing;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.Job;
@@ -33,7 +34,10 @@ import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.common.descriptors.ServiceEndpoint;
 import com.spotify.helios.common.descriptors.ServicePorts;
 
+import org.apache.commons.lang.text.StrSubstitutor;
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +62,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.fail;
 
 public class TemporaryJobBuilder {
-
+  private static final Logger log = LoggerFactory.getLogger(TemporaryJobBuilder.class);
   private static final Pattern JOB_NAME_FORBIDDEN_CHARS = Pattern.compile("[^0-9a-zA-Z-_.]+");
   private static final int DEFAULT_EXPIRES_MINUTES = 30;
 
@@ -67,13 +71,20 @@ public class TemporaryJobBuilder {
   private final Set<String> waitPorts = Sets.newHashSet();
   private final Deployer deployer;
   private final String jobNamePrefix;
-
+  private final String jobDeployedMessageFormat;
+  
   private String hostFilter;
   private Prober prober;
   private TemporaryJob job;
 
   public TemporaryJobBuilder(final Deployer deployer, final String jobNamePrefix,
                              final Prober defaultProber) {
+    this(deployer, jobNamePrefix, defaultProber, (String) null);
+  }
+  
+  
+  public TemporaryJobBuilder(final Deployer deployer, final String jobNamePrefix,
+      final Prober defaultProber, final String jobDeployedMessageFormat) {
     checkNotNull(deployer, "deployer");
     checkNotNull(jobNamePrefix, "jobNamePrefix");
     checkNotNull(defaultProber, "defaultProber");
@@ -81,6 +92,7 @@ public class TemporaryJobBuilder {
     this.jobNamePrefix = jobNamePrefix;
     this.prober = defaultProber;
     this.builder.setRegistrationDomain(jobNamePrefix);
+    this.jobDeployedMessageFormat = jobDeployedMessageFormat;
   }
 
   public TemporaryJobBuilder name(final String jobName) {
@@ -240,9 +252,28 @@ public class TemporaryJobBuilder {
       } else {
         job = deployer.deploy(builder.build(), this.hosts, waitPorts, prober);
       }
+      
+      if (!Strings.isNullOrEmpty(jobDeployedMessageFormat)) {
+        outputMessage(job);
+      }
     }
 
     return job;
+  }
+
+  private void outputMessage(final TemporaryJob job) {
+    for (String host : job.hosts()) {
+      final StrSubstitutor subst = new StrSubstitutor(new ImmutableMap.Builder<String, Object>()
+          .put("host", host)
+          .put("name", job.job().getId().getName())
+          .put("version", job.job().getId().getVersion())
+          .put("hash", job.job().getId().getHash())
+          .put("job", job.job().toString())
+          .put("containerId", job.statuses().get(host).getContainerId())
+          .build()
+          );
+      log.info("{}", subst.replace(jobDeployedMessageFormat));
+    }
   }
 
   public TemporaryJobBuilder imageFromBuild() {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -92,6 +92,7 @@ public class TemporaryJobs implements TestRule {
   private final Config config;
   private final List<TemporaryJob> jobs = Lists.newCopyOnWriteArrayList();
   private final Deployer deployer;
+  private final String jobDeployedMessageFormat;
 
   private final ExecutorService executor = MoreExecutors.getExitingExecutorService(
       (ThreadPoolExecutor) Executors.newFixedThreadPool(
@@ -121,6 +122,7 @@ public class TemporaryJobs implements TestRule {
         .withValue("prefix", ConfigValueFactory.fromAnyRef(prefix()));
 
     this.config = config.withFallback(configWithPrefix).resolve();
+    this.jobDeployedMessageFormat = Optional.fromNullable(builder.jobDeployedMessageFormat).or("");
   }
 
   /**
@@ -167,7 +169,7 @@ public class TemporaryJobs implements TestRule {
 
   public TemporaryJobBuilder job() {
     final TemporaryJobBuilder builder = new TemporaryJobBuilder(deployer, jobPrefixFile.prefix(),
-                                                                prober);
+                                                                prober, jobDeployedMessageFormat);
 
     if (config.hasPath("env")) {
       final Config env = config.getConfig("env");
@@ -477,7 +479,9 @@ public class TemporaryJobs implements TestRule {
       } else {
         this.config = ConfigFactory.empty();
       }
-
+      if (this.config.hasPath("jobDeployedMessageFormat")) {
+        jobDeployedMessageFormat(this.config.getString("jobDeployedMessageFormat"));
+      }
       if (this.config.hasPath("user")) {
         user(this.config.getString("user"));
       }
@@ -499,6 +503,7 @@ public class TemporaryJobs implements TestRule {
     private String hostFilter = DEFAULT_HOST_FILTER;
     private HeliosClient client;
     private String prefixDirectory;
+    private String jobDeployedMessageFormat = null;
 
     public Builder domain(final String domain) {
       return client(HeliosClient.newBuilder()
@@ -534,6 +539,11 @@ public class TemporaryJobs implements TestRule {
       return this;
     }
 
+    public Builder jobDeployedMessageFormat(final String jobLinkFormat) {
+      this.jobDeployedMessageFormat = jobLinkFormat;
+      return this;
+    }
+    
     public Builder prober(final Prober prober) {
       this.prober = prober;
       return this;

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTest.java
@@ -95,6 +95,7 @@ public class TemporaryJobsTest extends SystemTestBase {
     public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
         .client(client)
         .prober(new TestProber())
+        .jobDeployedMessageFormat("Logs Link: http://${host}:8150/${name}%3A${version}%3A${hash}?cid=${containerId}")
         .build();
 
     private TemporaryJob job1;


### PR DESCRIPTION
This is useful to possibly output a link to a place to
view logs for the job, if you had such a thing.
