### PR TITLE
Do not set container hostname

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -104,8 +104,6 @@ public class TaskConfig {
     builder.cmd(job.getCommand());
     builder.env(containerEnvStrings());
     builder.exposedPorts(containerExposedPorts());
-    builder.hostname(containerHostname(job.getId().getName() + "_" +
-                                       job.getId().getVersion()));
     builder.domainname(host);
     builder.volumes(volumes());
     containerDecorator.decorateContainerConfig(job, imageInfo, builder);

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ContainerHostNameTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ContainerHostNameTest.java
@@ -68,8 +68,7 @@ public class ContainerHostNameTest extends SystemTestBase {
         log = logs.readFully();
       }
 
-      final String needle = testJobName + "_" + testJobVersion + "." + testHost();
-      assertThat(log, containsString(needle));
+      assertThat(log, containsString(testHost()));
     }
   }
 


### PR DESCRIPTION
Docker 1.3 seems to not like hostnames that
exceed 17 characters. We also don't seem to need it
