### PR TITLE
Log "Using profile" as info instead of debug

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -492,7 +492,7 @@ public class TemporaryJobs implements TestRule {
     }
 
     private Builder(final String profile, final Config preConfig) {
-      log.debug("Using profile: " + profile);
+      log.info("Using profile: " + profile);
       if (profile != null) {
         final String key = HELIOS_TESTING_PROFILES + profile;
         if (preConfig.hasPath(key)) {


### PR DESCRIPTION
I usually log at info level because debug is noisy, but I'd
still like to see which profile I'm using.
