### PR TITLE
Don't paralellize VersionResponseFilterTest

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/VersionResponseFilterTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/VersionResponseFilterTest.java
@@ -47,7 +47,6 @@ import static com.spotify.helios.common.VersionCompatibility.HELIOS_VERSION_STAT
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(Parallelized.class)
 public class VersionResponseFilterTest extends SystemTestBase {
 
   private PomVersion current;


### PR DESCRIPTION
Tests that inherit from SystemTestBase should not be run parallelized,
since completion or an exception in a single test method will trigger a
teardwon of the Docker client and connection pool. All remaining tests
will then fail.
