### PR TITLE
Support connecting to Docker via HTTPS

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -56,6 +56,7 @@ public class AgentParser extends ServiceParser {
   private Argument adminArg;
   private Argument stateDirArg;
   private Argument dockerArg;
+  private Argument dockerCertPathArg;
   private Argument envArg;
   private Argument syslogRedirectToArg;
   private Argument portRangeArg;
@@ -66,7 +67,9 @@ public class AgentParser extends ServiceParser {
     super("helios-agent", "Spotify Helios Agent", args);
 
     final Namespace options = getNamespace();
-    final DockerHost dockerHost = DockerHost.from(options.getString(dockerArg.getDest()));
+    final DockerHost dockerHost = DockerHost.from(
+        options.getString(dockerArg.getDest()),
+        options.getString(dockerCertPathArg.getDest()));
 
     final List<List<String>> env = options.getList(envArg.getDest());
     final Map<String, String> envVars = Maps.newHashMap();
@@ -170,6 +173,10 @@ public class AgentParser extends ServiceParser {
     dockerArg = parser.addArgument("--docker")
         .setDefault(DockerHost.fromEnv().host())
         .help("docker endpoint");
+
+    dockerCertPathArg = parser.addArgument("--docker-cert-path")
+        .setDefault(DockerHost.fromEnv().dockerCertPath())
+        .help("directory containing client.pem and client.key for connecting to Docker over HTTPS");
 
     envArg = parser.addArgument("--env")
         .action(append())

--- a/helios-services/src/main/java/com/spotify/helios/agent/PollingDockerClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/PollingDockerClient.java
@@ -22,6 +22,7 @@
 package com.spotify.helios.agent;
 
 import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerCertificates;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.messages.ContainerExit;
@@ -44,6 +45,10 @@ public class PollingDockerClient extends DefaultDockerClient {
 
   public PollingDockerClient(final URI uri) {
     super(uri);
+  }
+
+  public PollingDockerClient(final URI uri, DockerCertificates dockerCertificates) {
+    super(uri, dockerCertificates);
   }
 
   @Override


### PR DESCRIPTION
We will attempt an HTTPS connection if a path to a client.key/client.pem
pair is specified via the `--docker-cert-path` argument in the agent or via
the `DOCKER_CERT_PATH` environment variable.
