### PR TITLE
CircleCI: Collect Docker logs as an artifact

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -13,6 +13,12 @@ case "$1" in
 
     ;;
 
+  post_machine)
+    # fix permissions on docker.log so it can be collected as an artifact
+    sudo chown ubuntu:ubuntu /var/log/upstart/docker.log
+
+    ;;
+
   dependencies)
     mvn clean install -T 2 -Dmaven.javadoc.skip=true -DskipTests=true -B -V
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,8 @@ test:
 machine:
   pre:
     - helios/circle.sh pre_machine
+  post:
+    - helios/circle.sh post_machine
   services:
     - docker
   environment:
@@ -23,3 +25,4 @@ machine:
 general:
   artifacts:
     - artifacts
+    - /var/log/upstart/docker.log


### PR DESCRIPTION
This can be useful for debugging after failed tests.
