### PR TITLE
Fix tests that were failing against HTTPS Docker

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/AgentReportingTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/AgentReportingTest.java
@@ -21,7 +21,7 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.Polling;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.DockerVersion;
@@ -56,7 +56,7 @@ public class AgentReportingTest extends SystemTestBase {
           }
         });
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final String expectedDockerVersion = dockerClient.version().version();
       assertThat(dockerVersion.getVersion(), is(expectedDockerVersion));
     }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/AgentRestartTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/AgentRestartTest.java
@@ -23,7 +23,6 @@ package com.spotify.helios.system;
 
 import com.spotify.helios.Polling;
 import com.spotify.helios.agent.AgentMain;
-import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
@@ -58,7 +57,7 @@ public class AgentRestartTest extends SystemTestBase {
   public void test() throws Exception {
     startDefaultMaster();
 
-    final DockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri());
+    final DockerClient dockerClient = getNewDockerClient();
 
     final HeliosClient client = defaultClient();
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/AgentZooKeeperDownTolerationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/AgentZooKeeperDownTolerationTest.java
@@ -23,7 +23,6 @@ package com.spotify.helios.system;
 
 import com.spotify.helios.Polling;
 import com.spotify.helios.agent.AgentMain;
-import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.helios.client.HeliosClient;
@@ -56,7 +55,7 @@ public class AgentZooKeeperDownTolerationTest extends SystemTestBase {
   public void test() throws Exception {
     startDefaultMaster();
 
-    final DockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri());
+    final DockerClient dockerClient = getNewDockerClient();
 
     final HeliosClient client = defaultClient();
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ContainerHostNameTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ContainerHostNameTest.java
@@ -23,7 +23,7 @@ package com.spotify.helios.system;
 
 import com.google.common.base.Splitter;
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -51,7 +51,7 @@ public class ContainerHostNameTest extends SystemTestBase {
     startDefaultAgent(testHost());
     awaitHostStatus(testHost(), UP, LONG_WAIT_MINUTES, MINUTES);
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
 
       final List<String> command = asList("hostname", "-f");
 
@@ -78,7 +78,7 @@ public class ContainerHostNameTest extends SystemTestBase {
     startDefaultAgent(testHost());
     awaitHostStatus(testHost(), UP, LONG_WAIT_MINUTES, MINUTES);
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final List<String> command = asList("hostname", "-f");
 
       // make something absurdly long

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DnsServerTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DnsServerTest.java
@@ -22,7 +22,7 @@
 package com.spotify.helios.system;
 
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -54,7 +54,7 @@ public class DnsServerTest extends SystemTestBase {
     deployJob(jobId, testHost());
 
     final TaskStatus taskStatus = awaitTaskState(jobId, testHost(), EXITED);
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final LogStream logs = dockerClient.logs(taskStatus.getContainerId(), STDOUT, STDERR);
       final String log = logs.readFully();
 
@@ -75,7 +75,7 @@ public class DnsServerTest extends SystemTestBase {
     deployJob(jobId, testHost());
 
     final TaskStatus taskStatus = awaitTaskState(jobId, testHost(), EXITED);
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final LogStream logs = dockerClient.logs(taskStatus.getContainerId(), STDOUT, STDERR);
       final String log = logs.readFully();
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/EnvironmentVariableTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/EnvironmentVariableTest.java
@@ -24,7 +24,7 @@ package com.spotify.helios.system;
 import com.google.common.collect.ImmutableMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.helios.Polling;
 import com.spotify.helios.common.Json;
@@ -71,7 +71,7 @@ public class EnvironmentVariableTest extends SystemTestBase {
       }
     });
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final List<String> command = asList("sh", "-c",
                                           "echo pod: $SPOTIFY_POD; " +
                                           "echo role: $SPOTIFY_ROLE; " +

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/JobExpirationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/JobExpirationTest.java
@@ -21,13 +21,13 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.helios.Polling;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
+
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,7 +47,11 @@ import static org.junit.Assert.assertThat;
 @RunWith(MockitoJUnitRunner.class)
 public class JobExpirationTest extends SystemTestBase {
 
-  private final DockerClient docker = new DefaultDockerClient(DOCKER_HOST.uri());
+  private final DockerClient docker;
+
+  public JobExpirationTest() throws Exception {
+    this.docker = getNewDockerClient();
+  }
 
   @Rule public ExpectedException expectedException = ExpectedException.none();
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/MultiplePortJobTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/MultiplePortJobTest.java
@@ -24,7 +24,7 @@ package com.spotify.helios.system;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.helios.Polling;
 import com.spotify.helios.agent.AgentMain;
@@ -65,7 +65,7 @@ public class MultiplePortJobTest extends SystemTestBase {
                                                           portRange.lowerEndpoint() + ":" +
                                                           portRange.upperEndpoint());
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final HeliosClient client = defaultClient();
 
       awaitHostStatus(client, testHost(), UP, LONG_WAIT_MINUTES, MINUTES);
@@ -150,7 +150,7 @@ public class MultiplePortJobTest extends SystemTestBase {
     final Map<String, PortMapping> ports =
         ImmutableMap.of("bar", PortMapping.of(4712, externalPort1));
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final JobId jobId = createJob(testJobName + 1, testJobVersion, BUSYBOX,
         asList("sh", "-c", "echo $HELIOS_PORT_bar"), EMPTY_ENV, ports);
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/NamespaceTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/NamespaceTest.java
@@ -21,7 +21,7 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
@@ -76,7 +76,7 @@ public class NamespaceTest extends SystemTestBase {
 
     awaitJobState(client, testHost(), jobId, RUNNING, LONG_WAIT_MINUTES, MINUTES);
 
-    try (final DefaultDockerClient docker = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient docker = getNewDockerClient()) {
       final List<Container> containers = docker.listContainers();
       Container jobContainer = null;
       for (Container container : containers) {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ReapingTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ReapingTest.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.messages.ContainerConfig;
@@ -42,7 +41,11 @@ import static org.junit.Assert.assertThat;
 
 public class ReapingTest extends SystemTestBase {
 
-  private final DockerClient docker = new DefaultDockerClient(DOCKER_HOST.uri());
+  private final DockerClient docker;
+
+  public ReapingTest() throws Exception {
+    this.docker = getNewDockerClient();
+  }
 
   @Test
   public void test() throws Exception {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SyslogRedirectionTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SyslogRedirectionTest.java
@@ -23,7 +23,7 @@ package com.spotify.helios.system;
 
 import com.google.common.collect.ImmutableMap;
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -54,7 +54,7 @@ public class SyslogRedirectionTest extends SystemTestBase {
     startDefaultAgent(testHost(), "--syslog-redirect", "10.0.3.1:6514");
     awaitHostStatus(testHost(), UP, LONG_WAIT_MINUTES, MINUTES);
 
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final List<String> command = asList("sh", "-c", "echo should-be-redirected");
 
       // Create job

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -127,9 +127,9 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
 
 public abstract class SystemTestBase {
 
@@ -241,7 +241,7 @@ public abstract class SystemTestBase {
     }
   }
 
-  private DockerClient getDockerClient() throws Exception {
+  protected DockerClient getNewDockerClient() throws Exception {
     if (isNullOrEmpty(DOCKER_HOST.dockerCertPath())) {
       return new DefaultDockerClient(DOCKER_HOST.uri());
     } else {
@@ -251,7 +251,7 @@ public abstract class SystemTestBase {
   }
 
   private void assertDockerReachable(final int probePort) throws Exception {
-    try (final DockerClient docker = getDockerClient()) {
+    try (final DockerClient docker = getNewDockerClient()) {
       try {
         docker.inspectImage(BUSYBOX);
       } catch (ImageNotFoundException e) {
@@ -333,7 +333,7 @@ public abstract class SystemTestBase {
     services.clear();
 
     // Clean up docker
-    try (final DockerClient dockerClient = getDockerClient()) {
+    try (final DockerClient dockerClient = getNewDockerClient()) {
       final List<Container> containers = dockerClient.listContainers();
       for (final Container container : containers) {
         for (final String name : container.names()) {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/TerminationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/TerminationTest.java
@@ -21,9 +21,7 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.LogStream;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
@@ -48,11 +46,11 @@ import static org.junit.Assume.assumeThat;
 public class TerminationTest extends SystemTestBase {
 
   @Before
-  public void setup() throws DockerException, InterruptedException {
+  public void setup() throws Exception {
     // LXC has a bug where the TERM signal isn't sent to containers, so we can only run this test
     // if docker runs with the native driver.
     // See: https://github.com/docker/docker/issues/2436
-    final DockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri());
+    final DockerClient dockerClient = getNewDockerClient();
     assumeThat(dockerClient.info().executionDriver(), startsWith("native"));
   }
 
@@ -85,7 +83,7 @@ public class TerminationTest extends SystemTestBase {
     final TaskStatus taskStatus = awaitTaskState(jobId, host, STOPPED);
 
     final String log;
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri());
+    try (final DockerClient dockerClient = getNewDockerClient();
          LogStream logs = dockerClient.logs(taskStatus.getContainerId(), STDOUT)) {
       log = logs.readFully();
     }
@@ -123,7 +121,7 @@ public class TerminationTest extends SystemTestBase {
     final TaskStatus taskStatus = awaitTaskState(jobId, host, STOPPED);
 
     final String log;
-    try (final DefaultDockerClient dockerClient = new DefaultDockerClient(DOCKER_HOST.uri());
+    try (final DockerClient dockerClient = getNewDockerClient();
          LogStream logs = dockerClient.logs(taskStatus.getContainerId(), STDOUT)) {
       log = logs.readFully();
     }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperClusterIdTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperClusterIdTest.java
@@ -21,7 +21,7 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.Container;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.JobId;
@@ -127,7 +127,7 @@ public class ZooKeeperClusterIdTest extends SystemTestBase {
     Thread.sleep(1000);
 
     // Make sure the agent didn't stop the job
-    try (final DefaultDockerClient docker = new DefaultDockerClient(DOCKER_HOST.uri())) {
+    try (final DockerClient docker = getNewDockerClient()) {
       final List<Container> containers = docker.listContainers();
       final CustomTypeSafeMatcher<Container> containerIdMatcher =
           new CustomTypeSafeMatcher<Container>("Container with id " + containerId) {


### PR DESCRIPTION
These tests were failing against HTTPS Docker instances because they create
their own DockerClient without checking for HTTPS or certs.

Instead, have them delegate creation of the DockerClient to SystemTestBase,
which is aware of certs.
