### PR TITLE
Log full error when task runner throws exception

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -316,7 +316,7 @@ public class Supervisor {
           reactor.signal();
           return;
         } else if (t instanceof DockerException) {
-          log.warn("docker error: {}", t.getMessage());
+          log.error("docker error", t);
         } else {
           log.error("task runner threw exception", t);
         }


### PR DESCRIPTION
This seems to be happening pretty often on our Jenkins build machines, so
it would be nice to have the full stacktrace and details to debug.
