### PR TITLE
Use consistent jobPrefix for ProberTest

### DIFF
--- a/helios-testing/src/test/java/com/spotify/helios/testing/ProberTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ProberTest.java
@@ -1,5 +1,7 @@
 package com.spotify.helios.testing;
 
+import com.google.common.base.Optional;
+
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.system.SystemTestBase;
 
@@ -21,6 +23,9 @@ public class ProberTest extends SystemTestBase {
 
   public static class OverrideDefaultProberTest {
 
+    // Test tag to be injected by the runner, so that all containers we create are tagged
+    // for cleanup by SystemTestBase's teardown
+    private static String testTag;
     private MockProber defaultProber = new MockProber();
     private MockProber overrideProber = new MockProber();
 
@@ -28,6 +33,7 @@ public class ProberTest extends SystemTestBase {
     public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
         .client(client)
         .prober(defaultProber)
+        .jobPrefix(Optional.of(testTag).get())
         .build();
 
     @Before
@@ -60,6 +66,8 @@ public class ProberTest extends SystemTestBase {
     testHost = testHost();
     startDefaultAgent(testHost);
     awaitHostStatus(client, testHost, UP, LONG_WAIT_MINUTES, MINUTES);
+
+    OverrideDefaultProberTest.testTag = this.testTag;
     assertThat(testResult(OverrideDefaultProberTest.class), isSuccessful());
   }
 


### PR DESCRIPTION
Use the same tag for jobs so that SystemTestBase can cleanup leftover
containers.

Related to commit 0a5b0f8e4563818541f4884e5c531ed89dcc4d6b

Fixes #263
