### PR TITLE
Use docker-client 2.6.4

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.6.3</version>
+      <version>2.6.4</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>


### PR DESCRIPTION
Contains a fix for connection pooling:

> By default, the Apache HTTP client will only use two connections per
> server. Instead, we want to use all the available connections in the
> connection pool (20). This is to prevent issues where requests get blocked
> while waiting on Docker to pull an image, stop a container, etc.
