### PR TITLE
Provide for bulk host status fetching

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -391,6 +391,14 @@ public class HeliosClient implements AutoCloseable {
     return get(uri(path("/hosts/%s/status", host)), HostStatus.class);
   }
 
+  public ListenableFuture<Map<String, HostStatus>> hostStatuses(final List<String> hosts) {
+    final ConvertResponseToPojo<Map<String, HostStatus>> converter = ConvertResponseToPojo.create(
+        TypeFactory.defaultInstance().constructMapType(Map.class, String.class, HostStatus.class),
+        ImmutableSet.of(HTTP_OK));
+
+    return transform(request(uri("/hosts/statuses"), "POST", hosts), converter);
+  }
+
   public ListenableFuture<Integer> registerHost(final String host, final String id) {
     return put(uri(path("/hosts/%s", host), ImmutableMap.of("id", id)));
   }
@@ -489,11 +497,11 @@ public class HeliosClient implements AutoCloseable {
     private final JavaType javaType;
     private final Set<Integer> decodeableStatusCodes;
 
-    private ConvertResponseToPojo(JavaType javaType) {
+    private ConvertResponseToPojo(final JavaType javaType) {
       this(javaType, ImmutableSet.of(HTTP_OK));
     }
 
-    public ConvertResponseToPojo(JavaType type, Set<Integer> decodeableStatusCodes) {
+    public ConvertResponseToPojo(final JavaType type, final Set<Integer> decodeableStatusCodes) {
       this.javaType = type;
       this.decodeableStatusCodes = decodeableStatusCodes;
     }
@@ -503,8 +511,8 @@ public class HeliosClient implements AutoCloseable {
       return new ConvertResponseToPojo<>(type, decodeableStatusCodes);
     }
 
-    public static <T> ConvertResponseToPojo<T> create(Class<T> clazz,
-                                                      Set<Integer> decodeableStatusCodes) {
+    public static <T> ConvertResponseToPojo<T> create(final Class<T> clazz,
+                                                      final Set<Integer> decodeableStatusCodes) {
       return new ConvertResponseToPojo<>(Json.type(clazz), decodeableStatusCodes);
     }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -22,6 +22,7 @@
 package com.spotify.helios.master.resources;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
@@ -45,10 +46,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -134,6 +137,25 @@ public class HostsResource {
   @ExceptionMetered
   public Optional<HostStatus> hostStatus(@PathParam("id") final String host) {
     return Optional.fromNullable(model.getHostStatus(host));
+  }
+
+  /**
+   * Returns various status information about the hosts.
+   */
+  @POST
+  @Path("/statuses")
+  @Produces(APPLICATION_JSON)
+  @Timed
+  @ExceptionMetered
+  public Map<String, HostStatus> hostStatuses(final List<String> hosts) {
+    final Map<String, HostStatus> statuses = Maps.newHashMap();
+    for (final String current : hosts) {
+      final HostStatus status = model.getHostStatus(current);
+      if (status != null) {
+        statuses.put(current, status);
+      }
+    }
+    return statuses;
   }
 
   /**

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/MultipleHostsTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/MultipleHostsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.system;
+
+import com.google.common.collect.ImmutableList;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.HostStatus;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+
+public class MultipleHostsTest extends SystemTestBase {
+  @Test
+  public void testHostStatuses() throws Exception {
+    final String aHost = testHost() + "a";
+    final String bHost = testHost() + "b";
+
+    startDefaultMaster();
+    startDefaultAgent(aHost);
+    startDefaultAgent(bHost);
+    awaitHostStatus(aHost, UP, LONG_WAIT_SECONDS, SECONDS);
+    awaitHostStatus(bHost, UP, LONG_WAIT_SECONDS, SECONDS);
+
+    final Map<String, HostStatus> cliStatuses = new ObjectMapper().readValue(cli("hosts", "--json"),
+        new TypeReference<Map<String, HostStatus>>(){});
+    assertTrue("status must contain key for " + aHost, cliStatuses.containsKey(aHost));
+    assertTrue("status must contain key for " + bHost, cliStatuses.containsKey(bHost));
+
+    final HeliosClient client = defaultClient();
+    final Map<String, HostStatus> clientStatuses = client.hostStatuses(
+        ImmutableList.of(aHost, bHost)).get();
+
+    assertTrue("status must contain key for " + aHost, clientStatuses.containsKey(aHost));
+    assertTrue("status must contain key for " + bHost, clientStatuses.containsKey(bHost));
+  }
+}


### PR DESCRIPTION
This turns an operation making N+1 requests to one
that makes only 2, which should speed things up significantly as
the number of hosts increases.
