### PR TITLE
Bulk Job Status fetching

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
@@ -191,5 +192,26 @@ public class JobsResource {
       throw badRequest("Invalid id");
     }
     return Optional.fromNullable(model.getJobStatus(id));
+  }
+  
+  @Path("/statuses")
+  @POST
+  @Produces(APPLICATION_JSON)
+  @Timed
+  @ExceptionMetered
+  public Map<JobId, JobStatus> jobStatuses(@Valid final Set<JobId> ids) {
+    for (final JobId id : ids) {
+      if (!id.isFullyQualified()) {
+        throw badRequest("Invalid id " + id);
+      }
+    }
+    final Map<JobId, JobStatus> results = Maps.newHashMap();
+    for (final JobId id : ids) {
+      final JobStatus status = model.getJobStatus(id);
+      if (status != null) {
+        results.put(id, status);
+      }
+    }
+    return results;
   }
 }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/MultipleJobsTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/MultipleJobsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.system;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.JobStatus;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.spotify.helios.common.descriptors.Goal.START;
+import static com.spotify.helios.common.descriptors.TaskStatus.State.RUNNING;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+
+public class MultipleJobsTest extends SystemTestBase {
+  @Test
+  public void jobStatusBulk() throws Exception {
+    startDefaultMaster();
+    final HeliosClient client = defaultClient();
+    startDefaultAgent(testHost());
+    
+    final Job job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(IDLE_COMMAND)
+        .setCreatingUser(TEST_USER)
+        .build();
+    final JobId jobId = job.getId();
+    client.createJob(job).get();
+   
+    final Job job2 = Job.newBuilder()
+        .setName(testJobName + "2")
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(IDLE_COMMAND)
+        .setCreatingUser(TEST_USER)
+        .build();
+    final JobId job2Id = job2.getId();
+    client.createJob(job2).get();
+    
+    final Deployment deployment = Deployment.of(jobId, START, TEST_USER);
+    final Deployment deployment2 = Deployment.of(job2Id, START, TEST_USER);
+
+    client.deploy(deployment, testHost()).get();
+    awaitJobState(client, testHost(), jobId, RUNNING,
+        LONG_WAIT_SECONDS, SECONDS);
+    
+    client.deploy(deployment2, testHost()).get();
+    awaitJobState(client, testHost(), job2Id, RUNNING,
+        LONG_WAIT_SECONDS, SECONDS);
+
+    final Map<JobId, JobStatus> statuses = client.jobStatuses(ImmutableSet.of(jobId, job2Id)).get();
+    assertTrue("should contain job 1 id", statuses.containsKey(jobId));
+    assertTrue("should contain job 2 id", statuses.containsKey(job2Id));
+  }
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobListCommand.java
@@ -24,7 +24,6 @@ package com.spotify.helios.cli.command;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -116,12 +115,10 @@ public class JobListCommand extends ControlCommand {
         final Table table = table(out);
         table.row("JOB ID", "NAME", "VERSION", "HOSTS", "COMMAND", "ENVIRONMENT");
 
-        final Map<JobId, ListenableFuture<JobStatus>> statuses = Maps.newTreeMap();
-        for (final JobId jobId : sortedJobIds) {
-          statuses.put(jobId, client.jobStatus(jobId));
-        }
-
-        for (final Map.Entry<JobId, ListenableFuture<JobStatus>> e : statuses.entrySet()) {
+        final Map<JobId, ListenableFuture<JobStatus>> futures = 
+            JobStatusFetcher.getJobsStatuses(client, sortedJobIds);
+        
+        for (final Map.Entry<JobId, ListenableFuture<JobStatus>> e : futures.entrySet()) {
           final JobId jobId = e.getKey();
           final Job job = jobs.get(jobId);
           final String command = on(' ').join(escape(job.getCommand()));

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStatusCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStatusCommand.java
@@ -101,11 +101,8 @@ public class JobStatusCommand extends ControlCommand {
     }
 
     // TODO (dano): it would sure be nice to be able to report container/task uptime
-
-    final Map<JobId, ListenableFuture<JobStatus>> futures = Maps.newTreeMap();
-    for (final JobId jobId : jobIds) {
-      futures.put(jobId, client.jobStatus(jobId));
-    }
+    final Map<JobId, ListenableFuture<JobStatus>> futures = 
+        JobStatusFetcher.getJobsStatuses(client, jobIds);
     final Map<JobId, JobStatus> statuses = Maps.newTreeMap();
     statuses.putAll(allAsMap(futures));
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStatusFetcher.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStatusFetcher.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.cli.command;
+
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.JobStatus;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+
+public class JobStatusFetcher {
+
+  public static Map<JobId, ListenableFuture<JobStatus>> getJobsStatuses(HeliosClient client,
+      Set<JobId> jobIds) throws InterruptedException {
+    final Map<JobId, ListenableFuture<JobStatus>> futures = Maps.newTreeMap();
+    try {
+      final Map<JobId, JobStatus> statuses = client.jobStatuses(jobIds).get();
+      for (final Entry<JobId, JobStatus> entry : statuses.entrySet()) {
+        futures.put(entry.getKey(), Futures.immediateFuture(entry.getValue()));
+      }
+    } catch (final ExecutionException e) {
+      System.err.println("Warning: masters failed batch status fetching.  Falling back to"
+          + " slower job status method");
+      for (final JobId jobId : jobIds) {
+        futures.put(jobId, client.jobStatus(jobId));
+      }
+    }
+    return futures;
+  }
+
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobWatchCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobWatchCommand.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static com.spotify.helios.cli.Utils.allAsMap;
+import static com.spotify.helios.cli.command.JobStatusFetcher.getJobsStatuses;
 import static java.lang.String.format;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
@@ -205,11 +206,8 @@ public class JobWatchCommand extends MultiTargetControlCommand {
   private static Map<JobId, JobStatus> getStatuses(final HeliosClient client,
                                                    final Set<JobId> jobIds)
       throws ExecutionException, InterruptedException {
-    final Map<JobId, ListenableFuture<JobStatus>> futures = Maps.newTreeMap();
+    final Map<JobId, ListenableFuture<JobStatus>> futures = getJobsStatuses(client, jobIds);
 
-    for (final JobId jobId : jobIds) {
-      futures.put(jobId, client.jobStatus(jobId));
-    }
     final Map<JobId, JobStatus> statuses = Maps.newTreeMap();
     statuses.putAll(allAsMap(futures));
     return statuses;


### PR DESCRIPTION
This turns an operation making N+1 requests to one
that makes only 2, which should speed things up significantly as
the number of hosts increases.
