### PR TITLE
CircleCI: Collect JUnit test reports

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -58,4 +58,9 @@ case "$1" in
 
     ;;
 
+  collect_test_reports)
+    cp */target/surefire-reports/*.xml $CI_REPORTS
+
+    ;;
+
 esac

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ test:
         parallel: true
   post:
     - ./circle.sh post_test
+    - ./circle.sh collect_test_reports:
+        parallel: true
 
 machine:
   pre:


### PR DESCRIPTION
This makes it easier to quickly identify which tests failed in a build.
