### PR TITLE
Use in-process ZooKeeper instance for testing

### DIFF
--- a/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
@@ -24,14 +24,14 @@ package com.spotify.helios;
 import com.google.common.collect.ImmutableList;
 
 import com.spotify.helios.common.HeliosException;
-import com.spotify.helios.master.HostNotFoundException;
-import com.spotify.helios.master.JobDoesNotExistException;
-import com.spotify.helios.master.JobNotDeployedException;
-import com.spotify.helios.master.JobStillDeployedException;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.master.HostNotFoundException;
+import com.spotify.helios.master.JobDoesNotExistException;
+import com.spotify.helios.master.JobNotDeployedException;
+import com.spotify.helios.master.JobStillDeployedException;
 import com.spotify.helios.master.ZooKeeperMasterModel;
 import com.spotify.helios.servicescommon.coordination.DefaultZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.Paths;
@@ -79,7 +79,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   private ZooKeeperClient client;
   private ZooKeeperMasterModel model;
 
-  private ZooKeeperStandaloneServerManager zk = new ZooKeeperStandaloneServerManager();
+  private ZooKeeperTestManager zk = new ZooKeeperTestingServerManager();
 
   @Before
   public void setup() throws Exception {

--- a/helios-services/src/test/java/com/spotify/helios/agent/QueueingHistoryWriterTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/QueueingHistoryWriterTest.java
@@ -25,7 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 import com.spotify.helios.Polling;
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
+import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -80,7 +81,7 @@ public class QueueingHistoryWriterTest {
       .setContainerId("containerId")
       .build();
 
-  private ZooKeeperStandaloneServerManager zk;
+  private ZooKeeperTestManager zk;
   private DefaultZooKeeperClient client;
   private QueueingHistoryWriter writer;
   private ZooKeeperMasterModel masterModel;
@@ -88,7 +89,7 @@ public class QueueingHistoryWriterTest {
 
   @Before
   public void setUp() throws Exception {
-    zk = new ZooKeeperStandaloneServerManager();
+    zk = new ZooKeeperTestingServerManager();
     agentStateDirs = Files.createTempDirectory("helios-agents");
 
     client = new DefaultZooKeeperClient(zk.curator());

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCacheTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCacheTest.java
@@ -29,7 +29,8 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import com.spotify.helios.Parallelized;
 import com.spotify.helios.Polling;
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
+import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.common.Json;
 
 import org.apache.commons.io.FileUtils;
@@ -122,7 +123,7 @@ public class PersistentPathChildrenCacheTest {
 
   private static final String PATH = "/foos";
 
-  private ZooKeeperStandaloneServerManager zk;
+  private ZooKeeperTestManager zk;
 
   private PersistentPathChildrenCache<DataPojo> cache;
   private Path directory;
@@ -133,7 +134,7 @@ public class PersistentPathChildrenCacheTest {
 
   @Before
   public void setup() throws Exception {
-    zk = new ZooKeeperStandaloneServerManager();
+    zk = new ZooKeeperTestingServerManager();
     zk.ensure("/foos");
     directory = Files.createTempDirectory("helios-test");
     stateFile = directory.resolve("persistent-path-children-cache-test-nodes.json");

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthCheckerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthCheckerTest.java
@@ -23,7 +23,8 @@ package com.spotify.helios.servicescommon.coordination;
 
 import com.aphyr.riemann.Proto.Event;
 import com.spotify.helios.Polling;
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
+import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.servicescommon.CapturingRiemannClient;
 
 import org.junit.After;
@@ -39,12 +40,12 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class ZooKeeperHealthCheckerTest {
   private CapturingRiemannClient riemannClient;
-  private ZooKeeperStandaloneServerManager zk;
+  private ZooKeeperTestManager zk;
 
   @Before
   public void setUp() throws Exception {
     riemannClient = new CapturingRiemannClient();
-    zk = new ZooKeeperStandaloneServerManager();
+    zk = new ZooKeeperTestingServerManager();
   }
 
   @After

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectoryTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectoryTest.java
@@ -22,7 +22,7 @@
 package com.spotify.helios.servicescommon.coordination;
 
 import com.spotify.helios.Parallelized;
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.utils.ZKPaths;
@@ -60,7 +60,7 @@ public class ZooKeeperUpdatingPersistentDirectoryTest {
   private static final String FOO_PATH = ZKPaths.makePath(PARENT_PATH, FOO_NODE);
   private static final String BAZ_PATH = ZKPaths.makePath(PARENT_PATH, BAZ_NODE);
 
-  private ZooKeeperStandaloneServerManager zk = new ZooKeeperStandaloneServerManager();
+  private ZooKeeperTestingServerManager zk = new ZooKeeperTestingServerManager();
 
   private ZooKeeperUpdatingPersistentDirectory sut;
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/AgentStateDirConflictTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/AgentStateDirConflictTest.java
@@ -23,7 +23,8 @@ package com.spotify.helios.system;
 
 import com.google.common.util.concurrent.Service;
 
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
+import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.agent.AgentMain;
 
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
@@ -46,11 +47,11 @@ public class AgentStateDirConflictTest {
   private Path stateDir;
   private AgentMain first;
   private AgentMain second;
-  private ZooKeeperStandaloneServerManager zk;
+  private ZooKeeperTestManager zk;
 
   @Before
   public void setup() throws Exception {
-    zk = new ZooKeeperStandaloneServerManager();
+    zk = new ZooKeeperTestingServerManager();
     dueh = Thread.getDefaultUncaughtExceptionHandler();
 
     Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -52,8 +52,8 @@ import com.spotify.docker.client.messages.PortBinding;
 import com.spotify.helios.Polling;
 import com.spotify.helios.TemporaryPorts;
 import com.spotify.helios.TemporaryPorts.AllocatedPort;
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
 import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.agent.AgentMain;
 import com.spotify.helios.cli.CliMain;
 import com.spotify.helios.client.HeliosClient;
@@ -306,7 +306,7 @@ public abstract class SystemTestBase {
   }
 
   protected ZooKeeperTestManager zooKeeperTestManager() {
-    return new ZooKeeperStandaloneServerManager(zooKeeperNamespace);
+    return new ZooKeeperTestingServerManager(zooKeeperNamespace);
   }
 
   @After

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperRestoreTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperRestoreTest.java
@@ -21,8 +21,8 @@
 
 package com.spotify.helios.system;
 
-import com.spotify.helios.ZooKeeperStandaloneServerManager;
 import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.agent.AgentMain;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
@@ -54,7 +54,7 @@ public class ZooKeeperRestoreTest extends SystemTestBase {
       .setCommand(IDLE_COMMAND)
       .build();
 
-  private final ZooKeeperStandaloneServerManager zkc = new ZooKeeperStandaloneServerManager();
+  private final ZooKeeperTestingServerManager zkc = new ZooKeeperTestingServerManager();
 
   private HeliosClient client;
   private Path backupDir;

--- a/helios-testing-common/pom.xml
+++ b/helios-testing-common/pom.xml
@@ -56,6 +56,25 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>2.5.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
       <version>3.0.1</version>


### PR DESCRIPTION
Use curator's TestingServer to run an in-process ZooKeeper instance for
tests, which will hopefully perform better and be more reliable than using
a child process.
