### PR TITLE
Have TempJobs use randomOneHost by default

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -583,7 +583,7 @@ public class TemporaryJobs implements TestRule {
     private String prefixDirectory;
     private String jobPrefix;
     private String jobDeployedMessageFormat = null;
-    private HostPickingStrategy hostPickingStrategy = HostPickingStrategies.random();
+    private HostPickingStrategy hostPickingStrategy = HostPickingStrategies.randomOneHost();
 
     public Builder domain(final String domain) {
       return client(HeliosClient.newBuilder()


### PR DESCRIPTION
Using randomOneHost by default instead of random has the nice
benefits of making debugging simpler because all logs are on one
machine, and may speed up the tests because the images will be
pulled once per test class.
