### PR TITLE
Replace ${revision} with 0-SNAPSHOT in pom files

### DIFF
--- a/helios-api-documentation/pom.xml
+++ b/helios-api-documentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios API Documentation</name>

--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Client</name>

--- a/helios-integration-tests/pom.xml
+++ b/helios-integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Integration Tests</name>

--- a/helios-service-registration/pom.xml
+++ b/helios-service-registration/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Service Registration</name>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Services</name>

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios System Tests</name>

--- a/helios-testing-common/pom.xml
+++ b/helios-testing-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Testing Common Library</name>

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Testing Library</name>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify</groupId>
     <artifactId>helios-parent</artifactId>
-    <version>0.8.${revision}</version>
+    <version>0.8.0-SNAPSHOT</version>
   </parent>
 
   <name>Helios Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <url>https://github.com/spotify/helios</url>
   <groupId>com.spotify</groupId>
   <artifactId>helios-parent</artifactId>
-  <version>0.8.${revision}</version>
+  <version>0.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -122,9 +122,6 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <properties>
-        <revision>0-SNAPSHOT</revision>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
The point of using ${revsion} was so that the build system could replace
it at runtime with the build number by passing -Drevision=BUILD_NUMBER.
This works while maven is building your code, but causes issues when doing
a maven install. This is because it doesn't actually substitute the value
on disk, and maven install copies the actual files. So you end up with jars
which are dependent on com.spotify:helios-parent:pom:0.8.${revision}, which
causes a failure when the jar is used.

To get around this, our build machine already replaces ${revision} with the
actual build number before invoking maven. So let's just replace ${revision}
with 0-SNAPSHOT so local installs work too. The build machine can just search
and replace this new string instead.
