### PR TITLE
docker client pool leak mitigation

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/DockerClientFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/DockerClientFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.google.common.base.Throwables;
+
+import com.spotify.docker.client.DockerCertificateException;
+import com.spotify.docker.client.DockerCertificates;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.helios.servicescommon.RiemannFacade;
+
+import java.nio.file.Path;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class DockerClientFactory {
+  private AgentConfig config;
+  private RiemannFacade riemannFacade;
+
+  public DockerClientFactory(final AgentConfig config, final RiemannFacade riemannFacade) {
+    this.config = config;
+    this.riemannFacade = riemannFacade;
+  }
+
+  public DockerClient getClient() {
+    PollingDockerClient client;
+    if (isNullOrEmpty(config.getDockerHost().dockerCertPath())) {
+      client = new PollingDockerClient(config.getDockerHost().uri());
+    } else {
+      final Path dockerCertPath = java.nio.file.Paths.get(config.getDockerHost().dockerCertPath());
+      final DockerCertificates dockerCertificates;
+      try {
+        dockerCertificates = new DockerCertificates(dockerCertPath);
+      } catch (DockerCertificateException e) {
+        throw Throwables.propagate(e);
+      }
+
+      client = new PollingDockerClient(config.getDockerHost().uri(), dockerCertificates);
+    }
+    return MonitoredDockerClient.wrap(riemannFacade, client);
+  }   
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/HostInfoReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/HostInfoReporter.java
@@ -55,14 +55,14 @@ public class HostInfoReporter extends InterruptingScheduledService {
   private final ZooKeeperNodeUpdater nodeUpdater;
   private final int interval;
   private final TimeUnit timeUnit;
-  private final DockerClient dockerClient;
+  private final DockerClientFactory dockerClientFactory;
 
   HostInfoReporter(final Builder builder) {
     this.operatingSystemMXBean = checkNotNull(builder.operatingSystemMXBean,
                                               "operatingSystemMXBean");
     this.nodeUpdater = builder.nodeUpdaterFactory.create(
         Paths.statusHostInfo(checkNotNull(builder.host, "host")));
-    this.dockerClient = checkNotNull(builder.dockerClient, "dockerClient");
+    this.dockerClientFactory = checkNotNull(builder.dockerClientFactory, "dockerClientFactory");
     this.interval = builder.interval;
     this.timeUnit = checkNotNull(builder.timeUnit, "timeUnit");
   }
@@ -91,8 +91,8 @@ public class HostInfoReporter extends InterruptingScheduledService {
   }
 
   private DockerVersion dockerVersion() throws InterruptedException {
-    try {
-      final com.spotify.docker.client.messages.Version version = dockerClient.version();
+    try (DockerClient client = dockerClientFactory.getClient()) {
+      final com.spotify.docker.client.messages.Version version = client.version();
       return version == null ? null : dockerVersion(version);
     } catch (DockerException e) {
       return null;
@@ -138,7 +138,7 @@ public class HostInfoReporter extends InterruptingScheduledService {
     private NodeUpdaterFactory nodeUpdaterFactory;
     private OperatingSystemMXBean operatingSystemMXBean;
     private String host;
-    private DockerClient dockerClient;
+    private DockerClientFactory dockerClientFactory;
     private int interval = DEFAULT_INTERVAL;
     private TimeUnit timeUnit = DEFAUL_TIMEUNIT;
 
@@ -158,8 +158,8 @@ public class HostInfoReporter extends InterruptingScheduledService {
       return this;
     }
 
-    public Builder setDockerClient(final DockerClient dockerClient) {
-      this.dockerClient = dockerClient;
+    public Builder setDockerClientFactory(final DockerClientFactory dockerClientFactory) {
+      this.dockerClientFactory = dockerClientFactory;
       return this;
     }
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/Reaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Reaper.java
@@ -42,10 +42,10 @@ public class Reaper {
 
   private final Logger log = LoggerFactory.getLogger(Reaper.class);
 
-  private final DockerClient docker;
+  private final DockerClientFactory docker;
   private final String prefix;
 
-  public Reaper(final DockerClient docker, final String namespace) {
+  public Reaper(final DockerClientFactory docker, final String namespace) {
     this.docker = docker;
     this.prefix = "/" + namespace;
   }
@@ -61,7 +61,10 @@ public class Reaper {
   private void reap0(final Supplier<Set<String>> activeSupplier)
       throws DockerException, InterruptedException {
     final List<String> candidates = Lists.newArrayList();
-    final List<Container> containers = docker.listContainers();
+    final List<Container> containers;
+    try (final DockerClient client = docker.getClient()) {
+      containers = client.listContainers();
+    }
     for (Container container : containers) {
       for (String name : container.names()) {
         if (name.startsWith(prefix)) {
@@ -83,6 +86,8 @@ public class Reaper {
 
   private void reap(final String containerId) throws InterruptedException, DockerException {
     log.info("reaping {}", containerId);
-    docker.killContainer(containerId);
+    try (final DockerClient client = docker.getClient()) {
+      client.killContainer(containerId);
+    }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/SupervisorFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SupervisorFactory.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.agent;
 
-import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
@@ -40,7 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SupervisorFactory {
 
   private final AgentModel model;
-  private final DockerClient dockerClient;
+  private final DockerClientFactory dockerClientFactory;
   private final String namespace;
   private final Map<String, String> envVars;
   private final ServiceRegistrar registrar;
@@ -50,7 +49,7 @@ public class SupervisorFactory {
   private final String defaultRegistrationDomain;
   private final List<String> dns;
 
-  public SupervisorFactory(final AgentModel model, final DockerClient dockerClient,
+  public SupervisorFactory(final AgentModel model, final DockerClientFactory dockerClientFactory,
                            final Map<String, String> envVars,
                            final ServiceRegistrar registrar,
                            final ContainerDecorator containerDecorator,
@@ -59,7 +58,7 @@ public class SupervisorFactory {
                            final String namespace,
                            final String defaultRegistrationDomain,
                            final List<String> dns) {
-    this.dockerClient = dockerClient;
+    this.dockerClientFactory = dockerClientFactory;
     this.namespace = namespace;
     this.model = checkNotNull(model, "model");
     this.envVars = checkNotNull(envVars, "envVars");
@@ -103,14 +102,14 @@ public class SupervisorFactory {
     final TaskRunnerFactory runnerFactory = TaskRunnerFactory.builder()
         .config(taskConfig)
         .registrar(registrar)
-        .dockerClient(dockerClient)
+        .dockerClientFactory(dockerClientFactory)
         .listener(taskMonitor)
         .build();
 
     return Supervisor.newBuilder()
         .setJob(job)
         .setExistingContainerId(existingContainerId)
-        .setDockerClient(dockerClient)
+        .setDockerClientFactory(dockerClientFactory)
         .setRestartPolicy(policy)
         .setMetrics(metrics)
         .setListener(listener)

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
@@ -23,7 +23,6 @@ package com.spotify.helios.agent;
 
 import com.google.common.collect.Lists;
 
-import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
 
 import java.util.List;
@@ -38,7 +37,7 @@ import static java.util.Arrays.asList;
 public class TaskRunnerFactory {
 
   private final TaskConfig taskConfig;
-  private final DockerClient docker;
+  private final DockerClientFactory docker;
   private final ServiceRegistrar registrar;
   private final List<TaskRunner.Listener> listeners;
 
@@ -73,7 +72,7 @@ public class TaskRunnerFactory {
     }
 
     private TaskConfig config;
-    private DockerClient docker;
+    private DockerClientFactory docker;
     private ServiceRegistrar registrar;
     private List<TaskRunner.Listener> listeners = Lists.newArrayList();
 
@@ -87,7 +86,7 @@ public class TaskRunnerFactory {
       return this;
     }
 
-    public Builder dockerClient(final DockerClient docker) {
+    public Builder dockerClientFactory(final DockerClientFactory docker) {
       this.docker = docker;
       return this;
     }

--- a/helios-services/src/test/java/com/spotify/helios/agent/GracePeriodTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/GracePeriodTest.java
@@ -48,6 +48,7 @@ import com.spotify.helios.serviceregistration.NopServiceRegistrationHandle;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
 import com.spotify.helios.servicescommon.statistics.NoopSupervisorMetrics;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -148,6 +149,7 @@ public class GracePeriodTest {
   };
 
   @Mock public AgentModel model;
+  @Mock public DockerClientFactory dockerFactory;
   @Mock public DockerClient docker;
   @Mock public RestartPolicy retryPolicy;
   @Mock public ServiceRegistrar registrar;
@@ -181,17 +183,19 @@ public class GracePeriodTest {
     final StatusUpdater statusUpdater = new DefaultStatusUpdater(model, taskStatus);
     final TaskMonitor monitor = new TaskMonitor(JOB.getId(), FlapController.create(), statusUpdater);
 
+    when(dockerFactory.getClient()).thenReturn(docker);
+
     final TaskRunnerFactory runnerFactory = TaskRunnerFactory.builder()
         .registrar(registrar)
         .config(config)
-        .dockerClient(docker)
+        .dockerClientFactory(dockerFactory)
         .listener(monitor)
         .build();
 
     sut = Supervisor.newBuilder()
         .setJob(JOB)
         .setStatusUpdater(statusUpdater)
-        .setDockerClient(docker)
+        .setDockerClientFactory(dockerFactory)
         .setRestartPolicy(retryPolicy)
         .setRunnerFactory(runnerFactory)
         .setMetrics(new NoopSupervisorMetrics())

--- a/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
@@ -134,6 +134,7 @@ public class SupervisorTest {
   };
 
   @Mock public AgentModel model;
+  @Mock public DockerClientFactory dockerFactory;
   @Mock public DockerClient docker;
   @Mock public RestartPolicy retryPolicy;
   @Mock public ServiceRegistrar registrar;
@@ -163,17 +164,18 @@ public class SupervisorTest {
     final StatusUpdater statusUpdater = new DefaultStatusUpdater(model, taskStatus);
     final TaskMonitor monitor = new TaskMonitor(JOB.getId(), FlapController.create(), statusUpdater);
 
+    when(dockerFactory.getClient()).thenReturn(docker);
     final TaskRunnerFactory runnerFactory = TaskRunnerFactory.builder()
         .registrar(registrar)
         .config(config)
-        .dockerClient(docker)
+        .dockerClientFactory(dockerFactory)
         .listener(monitor)
         .build();
 
     sut = Supervisor.newBuilder()
         .setJob(JOB)
         .setStatusUpdater(statusUpdater)
-        .setDockerClient(docker)
+        .setDockerClientFactory(dockerFactory)
         .setRestartPolicy(retryPolicy)
         .setRunnerFactory(runnerFactory)
         .setMetrics(new NoopSupervisorMetrics())

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskRunnerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskRunnerTest.java
@@ -28,9 +28,11 @@ import com.spotify.docker.client.ImagePullFailedException;
 import com.spotify.helios.common.HeliosRuntimeException;
 import com.spotify.helios.common.descriptors.Job;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.net.URI;
@@ -54,10 +56,16 @@ public class TaskRunnerTest {
       .build();
   private static final String HOST = "HOST";
 
+  @Mock private DockerClientFactory mockDockerFactory;
   @Mock private DockerClient mockDocker;
   @Mock private StatusUpdater statusUpdater;
   @Mock private Clock clock;
   @Mock private ContainerDecorator containerDecorator;
+
+  @Before
+  public void setUp() throws Exception {
+    Mockito.when(mockDockerFactory.getClient()).thenReturn(mockDocker);
+  }
 
   @Test
   public void test() throws Throwable {
@@ -69,7 +77,7 @@ public class TaskRunnerTest {
                     .job(JOB)
                     .containerDecorator(containerDecorator)
                     .build())
-        .docker(mockDocker)
+        .docker(mockDockerFactory)
         .listener(new TaskRunner.NopListener())
         .build();
 
@@ -100,7 +108,7 @@ public class TaskRunnerTest {
                     .job(JOB)
                     .containerDecorator(containerDecorator)
                     .build())
-        .docker(mockDocker)
+        .docker(mockDockerFactory)
         .listener(new TaskRunner.NopListener())
         .build();
 


### PR DESCRIPTION
Create and tear down the client at each usage.

Back Story: we've seen issues where excessive communication with the docker daemon has left the agent in a stuck state.  Upon investigation, it appears that threads are stuck attempting to get connections from the connection pool in the docker client.  We dug in some more and cannot figure out why, given the circumstances we see, how the pool would be exhausted.  So to avoid the whole thing, we just create clients when we need them, and dispose of them right away.
