### PR TITLE
Add an end-to-end test for syslog redirection

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
@@ -21,6 +21,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -40,7 +41,7 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
 
   private final String syslogHostPort;
 
-  public SyslogRedirectingContainerDecorator(String syslogHostPort) {
+  public SyslogRedirectingContainerDecorator(final String syslogHostPort) {
     this.syslogHostPort = syslogHostPort;
   }
 
@@ -60,7 +61,10 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
     ContainerConfig imageConfig = imageInfo.config();
 
     // Inject syslog-redirector in the entrypoint to capture std out/err
-    final List<String> entrypoint = Lists.newArrayList("/helios/syslog-redirector",
+    final String syslogRedirectorPath = Optional.of(job.getEnv().get("SYSLOG_REDIRECTOR"))
+        .or("/helios/syslog-redirector");
+
+    final List<String> entrypoint = Lists.newArrayList(syslogRedirectorPath,
                                                        "-h", syslogHostPort,
                                                        "-n", job.getId().toString(),
                                                        "--");

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SyslogRedirectionTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SyslogRedirectionTest.java
@@ -22,16 +22,28 @@
 package com.spotify.helios.system;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Resources;
 
 import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.LogStream;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
 
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.spotify.docker.client.DockerClient.LogsParameter.STDERR;
 import static com.spotify.docker.client.DockerClient.LogsParameter.STDOUT;
@@ -39,41 +51,125 @@ import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.EXITED;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
-// TODO (dano): open source the syslog-redirector and enable this test
-@Ignore("This needs the syslog-redirector")
 public class SyslogRedirectionTest extends SystemTestBase {
+
+  private static final Pattern DEFAULT_GATEWAY_PATTERN =
+      Pattern.compile("^default via (?<gateway>[0-9\\.]+)");
+
+  private final String TEST_IMAGE = testTag + "_helios-syslog-test";
+
+  private String syslogHost;
+
+  @Before
+  public void setup() throws Exception {
+    try (final DockerClient docker = getNewDockerClient()) {
+      // Build an image with an ENTRYPOINT and CMD prespecified
+      final String dockerDirectory = Resources.getResource("syslog-test-image").getPath();
+      docker.build(Paths.get(dockerDirectory), TEST_IMAGE);
+
+      // Figure out the host IP from the container's point of view (needed for syslog)
+      final ContainerConfig config = ContainerConfig.builder()
+          .image(BUSYBOX)
+          .cmd(asList("ip", "route", "show"))
+          .build();
+      final ContainerCreation creation = docker.createContainer(config);
+      final String containerId = creation.id();
+      docker.startContainer(containerId);
+
+      final String log;
+      try (LogStream logs = docker.logs(containerId, STDOUT, STDERR)) {
+        log = logs.readFully();
+      }
+
+      final Matcher m = DEFAULT_GATEWAY_PATTERN.matcher(log);
+      if (m.find()) {
+        syslogHost = m.group("gateway");
+      } else {
+        fail("couldn't determine the host address");
+      }
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    try (final DockerClient docker = getNewDockerClient()) {
+      try {
+        docker.removeImage(TEST_IMAGE, true, false);
+      } catch (DockerException e) {
+        // oh well, we tried
+      }
+    }
+  }
 
   @Test
   public void test() throws Exception {
-    // While this test doesn't specifically test that the output actually goes to syslog, it tests
-    // just about every other part of it, and specifically, that the output doesn't get to
-    // docker, and that the redirector executable exists and doesn't do anything terribly stupid.
-    startDefaultMaster();
-    startDefaultAgent(testHost(), "--syslog-redirect", "10.0.3.1:6514");
-    awaitHostStatus(testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+    final String syslogOutput = "should-be-redirected";
 
-    try (final DockerClient dockerClient = getNewDockerClient()) {
-      final List<String> command = asList("sh", "-c", "echo should-be-redirected");
+    try (final DockerClient docker = getNewDockerClient()) {
+      // Start a container that will be our "syslog" endpoint (just run netcat and print whatever
+      // we receive).
+      final String port = "4711";
+      final String expose = port + "/udp";
 
-      // Create job
-      final JobId jobId = createJob(testJobName, testJobVersion, BUSYBOX, command,
-                                    ImmutableMap.of("FOO", "4711",
-                                                    "BAR", "deadbeef"));
+      docker.pull(ALPINE);
 
-      // deploy
+      final ContainerConfig config = ContainerConfig.builder()
+          .image(ALPINE) // includes busybox with netcat with udp support
+          .cmd(asList("nc", "-p", port, "-l", "-u"))
+          .exposedPorts(ImmutableSet.of(expose))
+          .build();
+      final HostConfig hostConfig = HostConfig.builder()
+          .publishAllPorts(true)
+          .build();
+      final ContainerCreation creation = docker.createContainer(config, testTag + "_syslog");
+      final String syslogContainerId = creation.id();
+      docker.startContainer(syslogContainerId, hostConfig);
+
+      final ContainerInfo containerInfo = docker.inspectContainer(syslogContainerId);
+      assertThat(containerInfo.state().running(), equalTo(true));
+
+      final String syslogEndpoint = syslogHost + ":" +
+          containerInfo.networkSettings().ports().get(expose).get(0).hostPort();
+
+      // Run a Helios job that logs to syslog.
+      startDefaultMaster();
+      startDefaultAgent(testHost(), "--syslog-redirect", syslogEndpoint);
+      awaitHostStatus(testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+      final List<String> command =  Collections.EMPTY_LIST;
+      final JobId jobId = createJob(testJobName, testJobVersion, TEST_IMAGE, command,
+                                    ImmutableMap.of("SYSLOG_REDIRECTOR", "/syslog-redirector"));
       deployJob(jobId, testHost());
 
       final TaskStatus taskStatus = awaitTaskState(jobId, testHost(), EXITED);
 
-      final String log;
-      try (LogStream logs = dockerClient.logs(taskStatus.getContainerId(), STDOUT, STDERR)) {
-        log = logs.readFully();
+      // Verify the log for the task container
+      {
+        final String log;
+        try (LogStream logs = docker.logs(taskStatus.getContainerId(), STDOUT, STDERR)) {
+          log = logs.readFully();
+        }
+
+        // should be nothing in the docker output log, either error text or our message
+        assertEquals("", log);
       }
 
-      // should be nothing in the docker output log, either error text or our message
-      assertEquals("", log);
+      // Verify the log for the syslog container
+      {
+        final String log;
+        try (LogStream logs = docker.logs(syslogContainerId, STDOUT, STDERR)) {
+          log = logs.readFully();
+        }
+
+        // the output message from the command should appear in the syslog container
+        assertThat(log, containsString(syslogOutput));
+      }
     }
   }
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -140,6 +140,7 @@ public abstract class SystemTestBase {
   public static final int INTERNAL_PORT = 4444;
 
   public static final String BUSYBOX = "busybox";
+  public static final String ALPINE = "uggedal/alpine-3.0";
   public static final List<String> IDLE_COMMAND = asList(
       "sh", "-c", "trap 'exit 0' SIGINT SIGTERM; while :; do sleep 1; done");
 
@@ -253,12 +254,20 @@ public abstract class SystemTestBase {
 
   private void assertDockerReachable(final int probePort) throws Exception {
     try (final DockerClient docker = getNewDockerClient()) {
+      // Pull our base images
       try {
         docker.inspectImage(BUSYBOX);
       } catch (ImageNotFoundException e) {
         docker.pull(BUSYBOX);
       }
 
+      try {
+        docker.inspectImage(ALPINE);
+      } catch (ImageNotFoundException e) {
+        docker.pull(ALPINE);
+      }
+
+      // Start a container with an exposed port
       final ContainerConfig config = ContainerConfig.builder()
           .image(BUSYBOX)
           .cmd("nc", "-p", "4711", "-lle", "cat")

--- a/helios-system-tests/src/main/resources/syslog-test-image/Dockerfile
+++ b/helios-system-tests/src/main/resources/syslog-test-image/Dockerfile
@@ -1,0 +1,8 @@
+FROM uggedal/alpine-3.0
+
+RUN apk update && apk add curl
+RUN curl -L -o /tmp/syslog-redirector.zip https://github.com/spotify/syslog-redirector/releases/download/0.0.5/syslog-redirector.zip
+RUN unzip /tmp/syslog-redirector.zip syslog-redirector -d / && rm /tmp/syslog-redirector.zip
+
+ENTRYPOINT ["/bin/sh"]
+CMD ["-c", "echo should-be-redirected"]


### PR DESCRIPTION
1. Make the path to syslog used by `SyslogRedirectingContainerDecorator`
   configurable via the `SYSLOG_REDIRECTOR` job environment variable.
2. With an image that has a prespecified `ENTRYPOINT` and `CMD`, test that
   redirection actually works is sending stdout to the specified endpoint,
   while respecting the command specified in the Dockerfile.
