### PR TITLE
Set longer timeout when waiting for sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,13 +391,14 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.4</version>
+        <version>1.6.5</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <autoReleaseAfterClose>${autoReleaseAfterClose}</autoReleaseAfterClose>
           <skipRemoteStaging>true</skipRemoteStaging>
+          <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
We've gotten timeouts when waiting for sonatype to perform
the release operation. Let's change it to 10 minutes from
the default of 5 minutes. Also bump to the latest version.
