### PR TITLE
Fix SyslogRedirectionTest

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SyslogRedirectionTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SyslogRedirectionTest.java
@@ -82,6 +82,11 @@ public class SyslogRedirectionTest extends SystemTestBase {
       final String containerId = creation.id();
       docker.startContainer(containerId);
 
+      // Wait for the container to exit.
+      // If we don't wait, docker.logs() might return an epmty string because the container
+      // cmd hasn't run yet.
+      docker.waitContainer(containerId);
+
       final String log;
       try (LogStream logs = docker.logs(containerId, STDOUT, STDERR)) {
         log = logs.readFully();
@@ -91,7 +96,7 @@ public class SyslogRedirectionTest extends SystemTestBase {
       if (m.find()) {
         syslogHost = m.group("gateway");
       } else {
-        fail("couldn't determine the host address");
+        fail("couldn't determine the host address from '" + log + "'");
       }
     }
   }


### PR DESCRIPTION
Wait for container to exit to ensure cmd was run
and logs aren't empty which causes the test to fail.
