### PR TITLE
unban the tag latest

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -146,10 +146,6 @@ public class JobValidator {
     if (image == null) {
       errors.add(format("Image was not specified."));
     } else {
-      if (image.endsWith(":latest")) {
-        errors.add("Cannot use images that are tagged with :latest, use the hex id instead");
-      }
-
       // Validate image name
       validateImageReference(image, errors);
     }

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -129,14 +129,6 @@ public class JobValidatorTest {
   }
 
   @Test
-  public void testLatestTagIsBanned() {
-    final Job job = VALID_JOB.toBuilder().setImage("registry:80/myimage:latest").build();
-    assertEquals(ImmutableSet.of(
-        "Cannot use images that are tagged with :latest, use the hex id instead"),
-        validator.validate(job));
-  }
-
-  @Test
   public void testIdMismatchFails() throws Exception {
     final Job job = new Job(JobId.fromString("foo:bar:badf00d"),
                             "bar", EMPTY_COMMAND, EMPTY_ENV, EMPTY_RESOURCES, EMPTY_PORTS, EMPTY_REGISTRATION,


### PR DESCRIPTION
Used to be because we would keep the old image and not re-pull,
but since we always attempt a pull, it is not nearly as evil
as it once was.  Still though, use only in test environments.
