### PR TITLE
Added metrics for image pull

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -31,6 +31,7 @@ import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.servicescommon.DefaultReactor;
 import com.spotify.helios.servicescommon.Reactor;
+import com.spotify.helios.servicescommon.statistics.MetricsContext;
 import com.spotify.helios.servicescommon.statistics.SupervisorMetrics;
 
 import org.slf4j.Logger;
@@ -427,6 +428,8 @@ public class Supervisor {
 
   private class TaskListener extends TaskRunner.NopListener {
 
+    private MetricsContext pullContext;
+
     @Override
     public void failed(final Throwable t) {
       metrics.containersThrewException();
@@ -434,7 +437,21 @@ public class Supervisor {
 
     @Override
     public void pulling() {
-      metrics.containerPull();
+      pullContext = metrics.containerPull();
+    }
+
+    @Override
+    public void pullFailed() {
+      if (pullContext != null) {
+        pullContext.failure();
+      }
+    }
+
+    @Override
+    public void pulled() {
+      if (pullContext != null) {
+        pullContext.success();
+      }
     }
 
     @Override

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskMonitor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskMonitor.java
@@ -125,6 +125,14 @@ public class TaskMonitor implements TaskRunner.Listener, Closeable {
   }
 
   @Override
+  public void pulled() {
+  }
+
+  @Override
+  public void pullFailed() {
+  }
+
+  @Override
   public void creating() {
     updateState(CREATING);
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -219,11 +219,14 @@ class TaskRunner extends InterruptingExecutionThreadService {
     // Attempt to pull.  Failure, while less than ideal, is ok.
     try {
       docker.pull(image);
+      listener.pulled();
     } catch (DockerTimeoutException e) {
       log.warn("Pulling image {} failed with timeout", image, e);
+      listener.pullFailed();
       wasTimeout = e;
     } catch (DockerException e) {
       log.warn("Pulling image {} failed", image, e);
+      listener.pullFailed();
     }
 
     try {
@@ -245,6 +248,10 @@ class TaskRunner extends InterruptingExecutionThreadService {
     void failed(Throwable t);
 
     void pulling();
+
+    void pulled();
+
+    void pullFailed();
 
     void creating();
 
@@ -320,6 +327,16 @@ class TaskRunner extends InterruptingExecutionThreadService {
 
     @Override
     public void pulling() {
+
+    }
+
+    @Override
+    public void pulled() {
+
+    }
+
+    @Override
+    public void pullFailed() {
 
     }
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
@@ -125,6 +125,20 @@ public class TaskRunnerFactory {
     }
 
     @Override
+    public void pulled() {
+      for (TaskRunner.Listener l : listeners) {
+        l.pulled();
+      }
+    }
+
+    @Override
+    public void pullFailed() {
+      for (TaskRunner.Listener l : listeners) {
+        l.pullFailed();
+      }
+    }
+
+    @Override
     public void creating() {
       for (TaskRunner.Listener l : listeners) {
         l.creating();


### PR DESCRIPTION
We now record metrics for number of successful pulls,
failed pulls and how long each pull takes.
