### PR TITLE
Java 8 build fix ( javadoc errors with the new angry javadoc tool)

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/DockerHost.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/DockerHost.java
@@ -94,7 +94,7 @@ public class DockerHost {
   }
 
   /**
-   * Get the path to certicate & key for connecting to Docker via HTTPS.
+   * Get the path to certicate &amp; key for connecting to Docker via HTTPS.
    */
   public String dockerCertPath() {
     return dockerCertPath;

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -242,6 +242,9 @@ public class TemporaryJobs implements TestRule {
    * </ol>
    *
    * @return an instance of TemporaryJobs
+   * @see <a href=
+   * "https://github.com/spotify/helios/blob/master/docs/testing_framework.md#configuration-by-file"
+   * >Helios Testing Framework - Configuration By File</a>
    */
   public static TemporaryJobs create() {
     return builder().build();

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -242,8 +242,6 @@ public class TemporaryJobs implements TestRule {
    * </ol>
    *
    * @return an instance of TemporaryJobs
-   * @see <a href="https://github.com/spotify/helios/blob/master/docs/testing_framework.md#
-   * configuration-by-file">Helios Testing Framework - Configuration By File</a>
    */
   public static TemporaryJobs create() {
     return builder().build();


### PR DESCRIPTION
The long URL in the TemporaryJobs.java can no longer be split into two lines, and we enforce line lengths, so I'm removing it. If anyone wants to figure out the proper way to do that instead, be my guest :)