### PR TITLE
Add support for binding volumes to all containers

### DIFF
--- a/docs/how_to_deploy.md
+++ b/docs/how_to_deploy.md
@@ -90,7 +90,7 @@ Takes options:
 
   `--admin ADMIN` admin http port (default: 5802) the master will listen on.
 
-Example `/etc/default/helios-master`
+Example `/etc/default/helios-master`:
 
     ENABLED=true
 
@@ -179,7 +179,10 @@ Takes options:
                          Port   allocation   range,   start:end   (end   exclusive).
                          (default: 20000:32768)
 
-Example `/etc/default/helios-agent
+  `--bind VOLUME` Bind the given volume into all containers. You may specify multiply --bind
+                  arguments. Each bind must conform to the [`docker run -v` syntax](https://docs.docker.com/reference/run/#volume-shared-filesystems).
+
+Example `/etc/default/helios-agent`:
 
     ENABLED=true
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -59,6 +59,7 @@ public class AgentConfig extends Configuration {
   private int adminPort;
   private InetSocketAddress httpEndpoint;
   private boolean noHttp;
+  private List<String> binds;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -269,5 +270,14 @@ public class AgentConfig extends Configuration {
 
   public boolean getNoHttp() {
     return noHttp;
+  }
+
+  public List<String> getBinds() {
+    return binds;
+  }
+
+  public AgentConfig setBinds(List<String> binds) {
+    this.binds = binds;
+    return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -41,6 +41,7 @@ import java.util.Map;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static com.google.common.net.InetAddresses.isInetAddress;
+import static com.spotify.helios.agent.BindVolumeContainerDecorator.isValidBind;
 import static net.sourceforge.argparse4j.impl.Arguments.append;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
@@ -62,6 +63,7 @@ public class AgentParser extends ServiceParser {
   private Argument portRangeArg;
   private Argument agentIdArg;
   private Argument dnsArg;
+  private Argument bindArg;
 
   public AgentParser(final String... args) throws ArgumentParserException {
     super("helios-agent", "Spotify Helios Agent", args);
@@ -138,13 +140,23 @@ public class AgentParser extends ServiceParser {
 
     final List<String> dns = options.getList(dnsArg.getDest());
     if (!dns.isEmpty()) {
-      for (String d : dns) {
+      for (final String d : dns) {
         if (!isInetAddress(d)) {
           throw new IllegalArgumentException("Invalid IP address " + d);
         }
       }
     }
     agentConfig.setDns(dns);
+
+    final List<String> binds = options.getList(bindArg.getDest());
+    if (!binds.isEmpty()) {
+      for (final String b : binds) {
+        if (!isValidBind(b)) {
+          throw new IllegalArgumentException("Invalid bind " + b);
+        }
+      }
+    }
+    agentConfig.setBinds(binds);
   }
 
   @Override
@@ -196,6 +208,10 @@ public class AgentParser extends ServiceParser {
         .setDefault(new ArrayList<String>())
         .help("Dns servers to use.");
 
+    bindArg = parser.addArgument("--bind")
+        .action(append())
+        .setDefault(new ArrayList<String>())
+        .help("volumes to bind to all containers");
   }
 
   public AgentConfig getAgentConfig() {

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -242,6 +242,10 @@ public class AgentService extends AbstractIdleService implements Managed {
       decorators.add(new SyslogRedirectingContainerDecorator(config.getRedirectToSyslog()));
     }
 
+    if (!config.getBinds().isEmpty()) {
+      decorators.add(new BindVolumeContainerDecorator(config.getBinds()));
+    }
+
     final SupervisorFactory supervisorFactory = new SupervisorFactory(
         model, monitoredDockerClient,
         config.getEnvVars(), serviceRegistrar,

--- a/helios-services/src/main/java/com/spotify/helios/agent/BindVolumeContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/BindVolumeContainerDecorator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.ImageInfo;
+import com.spotify.helios.common.descriptors.Job;
+
+import java.util.List;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Bind mounts user-specified volumes into all containers.
+ */
+public class BindVolumeContainerDecorator implements ContainerDecorator {
+
+  private final List<String> binds;
+
+  public BindVolumeContainerDecorator(final List<String> binds) {
+    this.binds = ImmutableList.copyOf(binds);
+  }
+
+  public static boolean isValidBind(final String bind) {
+    if (isNullOrEmpty(bind)) {
+      return false;
+    }
+
+    final String[] parts = bind.split(":");
+
+    if (isNullOrEmpty(parts[0])) {
+      return false;
+    }
+    if ((parts.length > 1) && isNullOrEmpty(parts[1])) {
+      return false;
+    }
+    if ((parts.length > 2) && !parts[2].equals("ro") && !parts[2].equals("rw")) {
+      return false;
+    }
+    if (parts.length > 3) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public void decorateHostConfig(HostConfig.Builder hostConfig) {
+    final List<String> b = Lists.newArrayList();
+
+    if (hostConfig.binds() != null) {
+      b.addAll(hostConfig.binds());
+    }
+
+    b.addAll(this.binds);
+
+    hostConfig.binds(b);
+  }
+
+  @Override
+  public void decorateContainerConfig(Job job, ImageInfo imageInfo,
+                                      ContainerConfig.Builder containerConfig) {
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/SupervisorFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SupervisorFactory.java
@@ -44,7 +44,7 @@ public class SupervisorFactory {
   private final String namespace;
   private final Map<String, String> envVars;
   private final ServiceRegistrar registrar;
-  private final ContainerDecorator containerDecorator;
+  private final List<ContainerDecorator> containerDecorators;
   private final String host;
   private final SupervisorMetrics metrics;
   private final String defaultRegistrationDomain;
@@ -53,7 +53,7 @@ public class SupervisorFactory {
   public SupervisorFactory(final AgentModel model, final DockerClient dockerClient,
                            final Map<String, String> envVars,
                            final ServiceRegistrar registrar,
-                           final ContainerDecorator containerDecorator,
+                           final List<ContainerDecorator> containerDecorators,
                            final String host,
                            final SupervisorMetrics supervisorMetrics,
                            final String namespace,
@@ -64,7 +64,7 @@ public class SupervisorFactory {
     this.model = checkNotNull(model, "model");
     this.envVars = checkNotNull(envVars, "envVars");
     this.registrar = registrar;
-    this.containerDecorator = containerDecorator;
+    this.containerDecorators = containerDecorators;
     this.host = host;
     this.metrics = supervisorMetrics;
     this.defaultRegistrationDomain = checkNotNull(defaultRegistrationDomain,
@@ -86,7 +86,7 @@ public class SupervisorFactory {
         .job(job)
         .ports(ports)
         .envVars(envVars)
-        .containerDecorator(containerDecorator)
+        .containerDecorators(containerDecorators)
         .namespace(namespace)
         .defaultRegistrationDomain(defaultRegistrationDomain)
         .dns(dns)

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskRunnerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskRunnerTest.java
@@ -21,6 +21,8 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.collect.ImmutableList;
+
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerTimeoutException;
 import com.spotify.docker.client.ImageNotFoundException;
@@ -67,7 +69,7 @@ public class TaskRunnerTest {
                     .namespace("test")
                     .host(HOST)
                     .job(JOB)
-                    .containerDecorator(containerDecorator)
+                    .containerDecorators(ImmutableList.of(containerDecorator))
                     .build())
         .docker(mockDocker)
         .listener(new TaskRunner.NopListener())
@@ -98,7 +100,7 @@ public class TaskRunnerTest {
                     .namespace("test")
                     .host(HOST)
                     .job(JOB)
-                    .containerDecorator(containerDecorator)
+                    .containerDecorators(ImmutableList.of(containerDecorator))
                     .build())
         .docker(mockDocker)
         .listener(new TaskRunner.NopListener())

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/BindVolumeTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/BindVolumeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.system;
+
+import com.google.common.collect.ImmutableList;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.LogStream;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.TaskStatus;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.spotify.docker.client.DockerClient.LogsParameter.STDERR;
+import static com.spotify.docker.client.DockerClient.LogsParameter.STDOUT;
+import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
+import static com.spotify.helios.common.descriptors.TaskStatus.State.EXITED;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class BindVolumeTest extends SystemTestBase {
+
+  @Test
+  public void test() throws Exception {
+    try (final DockerClient docker = getNewDockerClient()) {
+      // Start Helios agent, configured to bind host /proc into container /mnt/host-proc
+      startDefaultMaster();
+      startDefaultAgent(testHost(), "--bind", "/proc:/mnt/host-proc:ro");
+      awaitHostStatus(testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+      // Figure out the host kernel version
+      final String hostKernelVersion = docker.info().kernelVersion();
+
+      // Run a job that cat's /mnt/host-proc/version, which should be the host's version info
+      final List<String> command = ImmutableList.of("cat", "/mnt/host-proc/version");
+      final JobId jobId = createJob(testJobName, testJobVersion, BUSYBOX, command);
+      deployJob(jobId, testHost());
+
+      final TaskStatus taskStatus = awaitTaskState(jobId, testHost(), EXITED);
+
+      {
+        final String log;
+        try (LogStream logs = docker.logs(taskStatus.getContainerId(), STDOUT, STDERR)) {
+          log = logs.readFully();
+        }
+
+        // the kernel version from the host should be in the log
+        assertThat(log, containsString(hostKernelVersion));
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Add an agent-level argument for binding a volume into all containers. This
is handy if you have a directory on all agents that you want accessible in
every container.

Our use case at Spotify is to mount the host's /etc/ssl/certs into all
containers.