### PR TITLE
Reduce log noise from docker health check

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/DockerHealthChecker.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/DockerHealthChecker.java
@@ -79,7 +79,9 @@ public class DockerHealthChecker extends HealthCheck implements Managed {
           metrics.getDockerTimeoutRates(), metrics.getSupervisorRunRates());
       final double exceptionRatio = fiveMinuteRatio(
           metrics.getContainersThrewExceptionRates(), metrics.getSupervisorRunRates());
-      log.info("timeout ratio is {}, exception ratio is {}", timeoutRatio, exceptionRatio);
+      if (timeoutRatio > 0 || exceptionRatio > 0) {
+        log.info("timeout ratio is {}, exception ratio is {}", timeoutRatio, exceptionRatio);
+      }
 
       final String origReason = reason;
 


### PR DESCRIPTION
The healthcheck is printing out a success message about 5 times per minute
which makes the logs tough to read. Let's print a message only if we detect
a problem.