### PR TITLE
Add a STOPPING state for tasks that are in the grace period.

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
@@ -73,6 +73,7 @@ public class TaskStatus extends Descriptor {
     STARTING,
     RUNNING,
     EXITED,
+    STOPPING,
     STOPPED,
     FAILED,
     UNKNOWN

--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.STOPPED;
+import static com.spotify.helios.common.descriptors.TaskStatus.State.STOPPING;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -351,6 +352,8 @@ public class Supervisor {
       if (gracePeriod != null && gracePeriod > 0) {
         log.info("Unregistering from service discovery for {} seconds before stopping",
                  gracePeriod);
+        statusUpdater.setState(STOPPING);
+        statusUpdater.update();
 
         if (runner.unregister()) {
           log.info("Unregistered. Now sleeping for {} seconds.", gracePeriod);


### PR DESCRIPTION
Before this patch, a task in the grace period would appear to be RUNNING, causing our continuous deployment scripts to undeploy certain jobs twice.