### PR TITLE
Get rid of mentions of & references to Hermes

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServiceEndpoint.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServiceEndpoint.java
@@ -44,7 +44,6 @@ public class ServiceEndpoint extends Descriptor implements Comparable<ServiceEnd
 
   public static final String UDP = "udp";
   public static final String TCP = "tcp";
-  public static final String HERMES = "hm";
   public static final String HTTP = "http";
 
   private final String name;

--- a/helios-services/src/test/java/com/spotify/helios/agent/GracePeriodTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/GracePeriodTest.java
@@ -107,7 +107,7 @@ public class GracePeriodTest {
       "bar", PortMapping.of(5000, EXTERNAL_PORT)
   );
   static final Map<ServiceEndpoint, ServicePorts> REGISTRATION = ImmutableMap.of(
-      ServiceEndpoint.of("foo-service", "hm"), ServicePorts.of("foo"),
+      ServiceEndpoint.of("foo-service", "tcp"), ServicePorts.of("foo"),
       ServiceEndpoint.of("bar-service", "http"), ServicePorts.of("bar"));
   static final String VERSION = "4711";
   static final Integer GRACE_PERIOD = 60;

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliDeploymentTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliDeploymentTest.java
@@ -79,7 +79,7 @@ public class CliDeploymentTest extends SystemTestBase {
         "foo", PortMapping.of(4711),
         "bar", PortMapping.of(5000, externalPort));
     final Map<ServiceEndpoint, ServicePorts> registration = ImmutableMap.of(
-        ServiceEndpoint.of("foo-service", "hm"), ServicePorts.of("foo"),
+        ServiceEndpoint.of("foo-service", "tcp"), ServicePorts.of("foo"),
         ServiceEndpoint.of("bar-service", "http"), ServicePorts.of("bar"));
     final Map<String, String> env = ImmutableMap.of("BAD", "f00d");
 
@@ -128,7 +128,7 @@ public class CliDeploymentTest extends SystemTestBase {
     final Map<JobId, JobStatus> statuses = Json.read(statusString, STATUSES_TYPE);
     final Job job = statuses.get(jobId).getJob();
     assertEquals(ServicePorts.of("foo"),
-                 job.getRegistration().get(ServiceEndpoint.of("foo-service", "hm")));
+                 job.getRegistration().get(ServiceEndpoint.of("foo-service", "tcp")));
     assertEquals(ServicePorts.of("bar"),
                  job.getRegistration().get(ServiceEndpoint.of("bar-service", "http")));
     assertEquals(4711, job.getPorts().get("foo").getInternalPort());

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliJobCreationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliJobCreationTest.java
@@ -71,7 +71,7 @@ public class CliJobCreationTest extends SystemTestBase {
         "foo", PortMapping.of(4711),
         "bar", PortMapping.of(5000, externalPort));
     final Map<ServiceEndpoint, ServicePorts> registration = ImmutableMap.of(
-        ServiceEndpoint.of("foo-service", "hm"), ServicePorts.of("foo"),
+        ServiceEndpoint.of("foo-service", "tcp"), ServicePorts.of("foo"),
         ServiceEndpoint.of("bar-service", "http"), ServicePorts.of("bar"));
     final Map<String, String> env = ImmutableMap.of("BAD", "f00d");
     final Map<String, String> volumes = Maps.newHashMap();
@@ -162,7 +162,7 @@ public class CliJobCreationTest extends SystemTestBase {
         "foo", PortMapping.of(4711),
         "bar", PortMapping.of(5000, externalPort));
     final Map<ServiceEndpoint, ServicePorts> registration = ImmutableMap.of(
-        ServiceEndpoint.of("foo-service", "hm"), ServicePorts.of("foo"),
+        ServiceEndpoint.of("foo-service", "tcp"), ServicePorts.of("foo"),
         ServiceEndpoint.of("bar-service", "http"), ServicePorts.of("bar"));
     final Map<String, String> env = ImmutableMap.of(redundantEnvKey, "f00d");
     final Map<String, String> volumes = Maps.newHashMap();

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ConfigFileJobCreationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ConfigFileJobCreationTest.java
@@ -57,7 +57,7 @@ public class ConfigFileJobCreationTest extends SystemTestBase {
         "foo", PortMapping.of(4711),
         "bar", PortMapping.of(5000, externalPort));
     final Map<ServiceEndpoint, ServicePorts> registration = ImmutableMap.of(
-        ServiceEndpoint.of("foo-service", "hm"), ServicePorts.of("foo"),
+        ServiceEndpoint.of("foo-service", "tcp"), ServicePorts.of("foo"),
         ServiceEndpoint.of("bar-service", "http"), ServicePorts.of("bar"));
     final Map<String, String> env = ImmutableMap.of("BAD", "f00d");
 


### PR DESCRIPTION
Hermes is a proprietary Spotify protocol that is only used internally. It
doesn't make sense to mention it here.