### PR TITLE
Use the 3.5.0-alpha ZooKeeper client

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>2.5.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -133,6 +133,21 @@
       <version>17.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.5.0-alpha</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
       <version>2.7.1</version>

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>2.5.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperBadNodeTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperBadNodeTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.system;
+
+import com.spotify.helios.ZooKeeperTestManager;
+import com.spotify.helios.ZooKeeperTestingClusterManager;
+import com.spotify.helios.client.HeliosClient;
+
+import org.junit.Test;
+
+public class ZooKeeperBadNodeTest extends SystemTestBase {
+
+  /**
+   * This is a testing cluster that has one peer that can't be resolved. Note that this is different
+   * from a cluster where a peer is down (that's tested in {@link ZooKeeperHeliosFailoverTest}).
+   */
+  private final ZooKeeperTestManager zkc = new ZooKeeperTestingClusterManager() {
+    @Override
+    public String connectString() {
+      return super.connectString() + ",node-that-doesnt-exist:1738";
+    }
+  };
+
+  @Test
+  public void testGetJobsWithBadNode() throws Exception {
+    startDefaultMaster("--zk-cluster-id=" + zkClusterId);
+
+    final HeliosClient client = defaultClient();
+    client.jobs().get();
+  }
+
+  @Override
+  protected ZooKeeperTestManager zooKeeperTestManager() {
+    return zkc;
+  }
+
+}

--- a/helios-testing-common/pom.xml
+++ b/helios-testing-common/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-recipes</artifactId>
-      <version>2.5.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
-      <version>2.5.0</version>
+      <version>2.7.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Fixes #359.

Normally I'd be wary of using a version marked "3.5.0-alpha". But given the pace of ZooKeeper releases and also judging from messages from the maintainers on the mailing list, I believe:

1. This version should be stable, especially the client bits.
2. It could literally be months/years until we see the next official "stable" release.

Given that we've already been bitten by #359 in production at Spotify, I'd rather just go ahead with this. Especially since all the tests pass and we're not upgrading any ZooKeeper servers, just the client.