### PR TITLE
Ensure all ZooKeeper ops are namespace-aware

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/DefaultZooKeeperClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/DefaultZooKeeperClient.java
@@ -21,6 +21,8 @@
 
 package com.spotify.helios.servicescommon.coordination;
 
+import com.google.common.collect.ImmutableList;
+
 import com.fasterxml.jackson.databind.JavaType;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -31,6 +33,7 @@ import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.utils.EnsurePath;
+import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
@@ -47,6 +50,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.google.common.base.Strings.emptyToNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.base.Throwables.propagateIfInstanceOf;
 import static com.google.common.collect.Lists.reverse;
@@ -234,8 +239,35 @@ public class DefaultZooKeeperClient implements ZooKeeperClient {
   @Override
   public List<String> listRecursive(final String path) throws KeeperException {
     assertClusterIdFlagTrue();
+
+    // namespace the path since we're using zookeeper directly
+    final String namespace = emptyToNull(client.getNamespace());
+    final String namespacedPath = ZKPaths.fixForNamespace(namespace, path);
+
     try {
-      return ZKUtil.listSubTreeBFS(client.getZookeeperClient().getZooKeeper(), path);
+      final List<String> paths = ZKUtil.listSubTreeBFS(
+          client.getZookeeperClient().getZooKeeper(), namespacedPath);
+
+      if (isNullOrEmpty(namespace)) {
+        return paths;
+      } else {
+        // hide the namespace in the paths returned from zookeeper
+        final ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (final String p : paths) {
+          final String fixed;
+          if (p.startsWith("/" + namespace)) {
+            fixed = (p.length() > namespace.length() + 1)
+                    ? p.substring(namespace.length() + 1)
+                    : "/";
+          } else {
+            fixed = p;
+          }
+
+          builder.add(fixed);
+        }
+
+        return builder.build();
+      }
     } catch (Exception e) {
       propagateIfInstanceOf(e, KeeperException.class);
       throw propagate(e);
@@ -256,8 +288,11 @@ public class DefaultZooKeeperClient implements ZooKeeperClient {
   @Override
   public void delete(final String path, final int version) throws KeeperException {
     assertClusterIdFlagTrue();
+
+    final String namespace = emptyToNull(client.getNamespace());
+    final String namespacedPath = ZKPaths.fixForNamespace(namespace, path);
     try {
-      client.getZookeeperClient().getZooKeeper().delete(path, version);
+      client.getZookeeperClient().getZooKeeper().delete(namespacedPath, version);
     } catch (Exception e) {
       propagateIfInstanceOf(e, KeeperException.class);
       throw propagate(e);

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperNamespacingTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperNamespacingTest.java
@@ -21,6 +21,15 @@
 
 package com.spotify.helios.system;
 
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.protocol.CreateJobResponse;
+import com.spotify.helios.common.protocol.JobDeleteResponse;
+import com.spotify.helios.common.protocol.JobDeployResponse;
+import com.spotify.helios.common.protocol.JobUndeployResponse;
+
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -31,9 +40,11 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 
+import static com.spotify.helios.common.descriptors.Goal.START;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ZooKeeperNamespacingTest extends SystemTestBase {
   private static final String NAMESPACE = "testing";
@@ -63,5 +74,44 @@ public class ZooKeeperNamespacingTest extends SystemTestBase {
     assertEquals(2, result.size());
     assertEquals(NAMESPACE, result.get(0));
     assertEquals("zookeeper", result.get(1)); // we'll always find this
+  }
+
+  @Test
+  public void testDeployment() throws Exception {
+    startDefaultMaster("--zk-namespace", NAMESPACE);
+    startDefaultAgent(testHost(), "--zk-namespace", NAMESPACE);
+
+    final HeliosClient client = defaultClient();
+
+    // Create a job
+    final Job job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(IDLE_COMMAND)
+        .setCreatingUser(TEST_USER)
+        .build();
+    final JobId jobId = job.getId();
+    final CreateJobResponse created = client.createJob(job).get();
+    assertEquals(CreateJobResponse.Status.OK, created.getStatus());
+
+    // Deploy the job on the agent
+    final Deployment deployment = Deployment.of(jobId, START, TEST_USER);
+    final JobDeployResponse deployed = client.deploy(deployment, testHost()).get();
+    assertEquals(JobDeployResponse.Status.OK, deployed.getStatus());
+
+    // Undeploy the job
+    final JobUndeployResponse undeployed = client.undeploy(jobId, testHost()).get();
+    assertEquals(JobUndeployResponse.Status.OK, undeployed.getStatus());
+
+    // Make sure that it is no longer in the desired state
+    final Deployment undeployedJob = client.deployment(testHost(), jobId).get();
+    assertTrue(undeployedJob == null);
+
+    // Wait for the task to disappear
+    awaitTaskGone(client, testHost(), jobId, LONG_WAIT_SECONDS, SECONDS);
+
+    // Verify that the job can be deleted
+    assertEquals(JobDeleteResponse.Status.OK, client.deleteJob(jobId).get().getStatus());
   }
 }


### PR DESCRIPTION
A couple of the methods in DefaultZooKeeperClient were using the ZooKeeper
client directly without taking into account the ZK namespace.

Fixes #322.