### PR TITLE
[WIP] History Event Listeners

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -55,12 +55,14 @@ import com.spotify.helios.common.protocol.HostDeregisterResponse;
 import com.spotify.helios.common.protocol.JobDeleteResponse;
 import com.spotify.helios.common.protocol.JobDeployResponse;
 import com.spotify.helios.common.protocol.JobUndeployResponse;
+import com.spotify.helios.common.protocol.ListenerResponse;
 import com.spotify.helios.common.protocol.SetGoalResponse;
 import com.spotify.helios.common.protocol.TaskStatusEvents;
 import com.spotify.helios.common.protocol.VersionResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -539,9 +541,9 @@ public class HeliosClient implements AutoCloseable {
                                      ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND)));
   }
 
-  public ListenableFuture<TaskStatusEvents> listeners(final String listenerUrl) {
+  public ListenableFuture<ListenerResponse> listeners(final String listenerUrl) {
     return transform(request(uri("/history/listeners"), "POST", listenerUrl),
-                     ConvertResponseToPojo.create(TaskStatusEvents.class, 
+                     ConvertResponseToPojo.create(ListenerResponse.class,
                                                   ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND)));
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -539,6 +539,12 @@ public class HeliosClient implements AutoCloseable {
                                      ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND)));
   }
 
+  public ListenableFuture<TaskStatusEvents> listeners(final String listenerUrl) {
+    return transform(request(uri("/history/listeners"), "POST", listenerUrl),
+                     ConvertResponseToPojo.create(TaskStatusEvents.class, 
+                                                  ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND)));
+  }
+
   public ListenableFuture<JobStatus> jobStatus(final JobId jobId) {
     return get(uri(path("/jobs/%s/status", jobId)), JobStatus.class);
   }

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/ListenerResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/ListenerResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.protocol;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import com.spotify.helios.common.Json;
+
+public class ListenerResponse {
+
+  public enum Status {OK, NOT_FOUND, DUPLICATE_LISTENER, INVALID_LISTENER}
+
+  private final Status status;
+  private final String url;
+
+  public ListenerResponse(@JsonProperty("status") Status status,
+                          @JsonProperty("url") String url) {
+    this.status = status;
+    this.url = url;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+  public String getUrl() {
+    return url;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(getClass())
+        .add("status", status)
+        .add("url", url)
+        .toString();
+  }
+
+  public String toJsonString() {
+    return Json.asStringUnchecked(this);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/QueueingHistoryWriter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/QueueingHistoryWriter.java
@@ -300,7 +300,7 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
           try {
             urls.add(new String(nodeData, "UTF-8"));
           } catch (UnsupportedEncodingException e) {
-              continue;
+              log.error("Unable to parse listener endpoint: {}", e);
           }
         }
 
@@ -317,6 +317,8 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
                       (HttpURLConnection) new URL(url).openConnection();
 
               connection.setRequestMethod("POST");
+              connection.setConnectTimeout(1000);
+              connection.setReadTimeout(1000);
 
               for (Map.Entry<String, List<String>> header : headers.entrySet()) {
                   for (final String value : header.getValue()) {
@@ -336,7 +338,6 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
               }
             } catch (IOException e) {
                 log.error("Unable to communicate with listener endpoint {}: {}", url, e);
-                continue;
             }
         }
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/QueueingHistoryWriter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/QueueingHistoryWriter.java
@@ -325,7 +325,7 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
             return Optional.of(new URL(new String(
                 client.getData(Paths.historyListener(listener)), "UTF-8")));
           } catch (KeeperException | UnsupportedEncodingException | MalformedURLException e) {
-            log.error("Unable to fetch listener endpoint for {}", listener, e);
+            log.error("Unable to fetch endpoint for listener {}", listener, e);
             return Optional.empty();
           }
         }
@@ -337,7 +337,7 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
           }
 
           URL url = possibleUrl.get();
-          log.info("Pushing task status event to listener endpoint {}", url);
+          log.info("Pushing task status event to listener {}", url);
 
           try {
             final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -354,10 +354,10 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
             connection.getOutputStream().write(Json.asBytes(item));
 
             if (connection.getResponseCode() / 100 != 2) {
-              log.error("Got non-200 response code while communicating with listener endpoint {}", url);
+              log.error("Got non-200 response code while communicating with listener {}", url);
             }
           } catch (IOException e) {
-            log.error("Unable to communicate with listener endpoint {}", url, e);
+            log.error("Unable to communicate with listener {}", url, e);
           }
         }
       });

--- a/helios-services/src/main/java/com/spotify/helios/agent/QueueingHistoryWriter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/QueueingHistoryWriter.java
@@ -23,6 +23,7 @@ package com.spotify.helios.agent;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -31,6 +32,7 @@ import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -42,21 +44,24 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.KeeperException.NodeExistsException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.Path;
+
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
@@ -64,7 +69,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -318,49 +322,48 @@ public class QueueingHistoryWriter extends AbstractIdleService implements Runnab
         log.error("Unable to fetch listener names", e);
       }
 
-      Iterables.transform(listeners, new Function<String, Optional<URL>>() {
+      final Iterable<Optional<URL>> possibleUrls =
+          Iterables.transform(listeners, new Function<String, Optional<URL>>()
+      {
         @Override
         public Optional<URL> apply(final String listener) {
+          Optional<URL> result = Optional.absent();
+
           try {
-            return Optional.of(new URL(new String(
+            result = Optional.of(new URL(new String(
                 client.getData(Paths.historyListener(listener)), "UTF-8")));
           } catch (KeeperException | UnsupportedEncodingException | MalformedURLException e) {
             log.error("Unable to fetch endpoint for listener {}", listener, e);
-            return Optional.empty();
-          }
-        }
-      }).forEach(new Consumer<Optional<URL>>() {
-        @Override
-        public void accept(Optional<URL> possibleUrl) {
-          if (!possibleUrl.isPresent()) {
-            return;
           }
 
-          URL url = possibleUrl.get();
-          log.info("Pushing task status event to listener {}", url);
-
-          try {
-            final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-
-            connection.setConnectTimeout(1000);
-            connection.setReadTimeout(1000);
-
-            connection.addRequestProperty("Content-Type", "application/json");
-            connection.addRequestProperty("Charset", "UTF-8");
-
-            connection.setRequestMethod("POST");
-
-            connection.setDoOutput(true);
-            connection.getOutputStream().write(Json.asBytes(item));
-
-            if (connection.getResponseCode() / 100 != 2) {
-              log.error("Got non-200 response code while communicating with listener {}", url);
-            }
-          } catch (IOException e) {
-            log.error("Unable to communicate with listener {}", url, e);
-          }
+          return result;
         }
       });
+
+      for (URL url: Optional.presentInstances(possibleUrls)) {
+        log.info("Pushing task status event to listener {}", url);
+
+        try {
+          final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+          connection.setConnectTimeout(1000);
+          connection.setReadTimeout(1000);
+
+          connection.addRequestProperty("Content-Type", "application/json");
+          connection.addRequestProperty("Charset", "UTF-8");
+
+          connection.setRequestMethod("POST");
+
+          connection.setDoOutput(true);
+          connection.getOutputStream().write(Json.asBytes(item));
+
+          if (connection.getResponseCode() / 100 != 2) {
+            log.error("Got non-200 response code while communicating with listener {}", url);
+          }
+        } catch (IOException e) {
+          log.error("Unable to communicate with listener {}", url, e);
+        }
+      }
     }
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -98,4 +98,6 @@ public interface MasterModel {
   List<String> getRunningMasters();
 
   List<TaskStatusEvent> getJobHistory(JobId jobId) throws JobDoesNotExistException;
+
+  void addListener(String listenerUrl);
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterZooKeeperRegistrar.java
@@ -76,6 +76,7 @@ public class MasterZooKeeperRegistrar implements ZooKeeperRegistrarEventListener
     client.ensurePath(Paths.statusHosts());
     client.ensurePath(Paths.statusMasters());
     client.ensurePath(Paths.historyJobs());
+    client.ensurePath(Paths.historyListeners());
 
     if (upNode == null) {
       final String upPath = Paths.statusMasterUp(name);

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -958,12 +958,10 @@ public class ZooKeeperMasterModel implements MasterModel {
     final ZooKeeperClient client = provider.get("addListener");
 
     try {
-        final URL parsedUrl = new URL(listenerUrl);
-        client.ensurePath(Paths.historyListeners());
-        client.transaction(create(Paths.historyListener(parsedUrl.getHost())),
-                           set(Paths.historyListener(parsedUrl.getHost()), listenerUrl.getBytes()));
+        client.createAndSetData(
+            Paths.historyListener(new URL(listenerUrl).getHost()),
+            listenerUrl.getBytes());
     } catch (KeeperException | MalformedURLException e) {
-        log.error("{}", e);
         throw new HeliosRuntimeException("Adding new listener URL failed", e);
     }
   }

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -58,6 +58,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -948,6 +950,21 @@ public class ZooKeeperMasterModel implements MasterModel {
     checkNotNull(token, "token");
     if (!token.equals(job.getToken())) {
       throw new TokenVerificationException(job.getId());
+    }
+  }
+
+  @Override
+  public void addListener(String listenerUrl) {
+    final ZooKeeperClient client = provider.get("addListener");
+
+    try {
+        final URL parsedUrl = new URL(listenerUrl);
+        client.ensurePath(Paths.historyListeners());
+        client.transaction(create(Paths.historyListener(parsedUrl.getHost())),
+                           set(Paths.historyListener(parsedUrl.getHost()), listenerUrl.getBytes()));
+    } catch (KeeperException | MalformedURLException e) {
+        log.error("{}", e);
+        throw new HeliosRuntimeException("Adding new listener URL failed", e);
     }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HistoryResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HistoryResource.java
@@ -23,6 +23,7 @@ package com.spotify.helios.master.resources;
 
 import com.google.common.collect.ImmutableList;
 
+import javax.ws.rs.POST;
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatusEvent;
@@ -33,6 +34,7 @@ import com.spotify.helios.servicescommon.statistics.MasterMetrics;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.validation.Valid;
@@ -78,4 +80,16 @@ public class HistoryResource {
       return new TaskStatusEvents(ImmutableList.<TaskStatusEvent>of(), JOB_ID_NOT_FOUND);
     }
   }
+  
+  
+  @POST
+  @Path("listeners")
+  @Produces(APPLICATION_JSON)
+  @Timed
+  @ExceptionMetered
+  public TaskStatusEvents listeners(final String listenerUrls) {
+    System.out.println( "[[[[" + listenerUrls + "]]]]" );
+    return new TaskStatusEvents( Collections.<TaskStatusEvent>emptyList(), OK);
+  }
+    
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
@@ -41,6 +41,7 @@ public class Paths {
   private static final String PORTS = "ports";
   private static final String ENVIRONMENT = "environment";
   private static final String ID = "id";
+  private static final String LISTENERS = "listeners";
 
   private static final PathFactory CONFIG_ID = new PathFactory("/", CONFIG, ID);
   private static final PathFactory CONFIG_JOBS = new PathFactory("/", CONFIG, JOBS);
@@ -49,6 +50,7 @@ public class Paths {
   private static final PathFactory STATUS_HOSTS = new PathFactory("/", STATUS, HOSTS);
   private static final PathFactory STATUS_MASTERS = new PathFactory("/", STATUS, MASTERS);
   private static final PathFactory HISTORY_JOBS = new PathFactory("/", HISTORY, JOBS);
+  private static final PathFactory HISTORY_LISTENERS = new PathFactory("/", HISTORY, LISTENERS);
   private static final String CREATION_PREFIX = "creation-";
 
   public static String configHosts() {
@@ -198,5 +200,13 @@ public class Paths {
 
   public static String historyJobs() {
     return HISTORY_JOBS.path();
+  }
+
+  public static String historyListener(final String url) {
+    return HISTORY_LISTENERS.path(url);
+  }
+
+  public static String historyListeners() {
+    return HISTORY_LISTENERS.path();
   }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -40,6 +40,7 @@ import com.spotify.helios.cli.command.JobStatusCommand;
 import com.spotify.helios.cli.command.JobStopCommand;
 import com.spotify.helios.cli.command.JobUndeployCommand;
 import com.spotify.helios.cli.command.JobWatchCommand;
+import com.spotify.helios.cli.command.ListenersCommand;
 import com.spotify.helios.cli.command.MasterListCommand;
 import com.spotify.helios.cli.command.VersionCommand;
 import com.spotify.helios.common.LoggingConfig;
@@ -204,6 +205,7 @@ public class CliParser {
     new JobListCommand(p("jobs"));
     new JobStatusCommand(p("status"));
     new JobWatchCommand(p("watch"));
+    new ListenersCommand(p("listener"));
 
     // Host commands
     new HostListCommand(p("hosts"));

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/ListenersCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/ListenersCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.cli.command;
+
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.common.protocol.TaskStatusEvents;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+import java.io.BufferedReader;
+import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
+
+public class ListenersCommand extends ControlCommand {
+
+  private final Argument listenerUrl;
+
+  public ListenersCommand ( Subparser parser ) {
+    super(parser);
+
+    parser.help("register event listeners");
+
+    listenerUrl = parser.addArgument("listener").
+                      help("Listener URL");
+  }
+
+  @Override
+  int run(final Namespace options, final HeliosClient client, final PrintStream out,
+          final boolean json, final BufferedReader stdin)
+      throws ExecutionException, InterruptedException {
+
+    String url = options.getString(listenerUrl.getDest());
+    TaskStatusEvents result = client.listeners(url).get();
+
+    if (json) {
+      out.println(Json.asPrettyStringUnchecked(result));
+    }
+    
+    return 0;
+  }
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/ListenersCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/ListenersCommand.java
@@ -23,6 +23,7 @@ package com.spotify.helios.cli.command;
 
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
+import com.spotify.helios.common.protocol.ListenerResponse;
 import com.spotify.helios.common.protocol.TaskStatusEvents;
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -42,7 +43,8 @@ public class ListenersCommand extends ControlCommand {
     parser.help("register event listeners");
 
     listenerUrl = parser.addArgument("listener").
-                      help("Listener URL");
+                         type(String.class).
+                         help("Listener URL");
   }
 
   @Override
@@ -51,7 +53,7 @@ public class ListenersCommand extends ControlCommand {
       throws ExecutionException, InterruptedException {
 
     String url = options.getString(listenerUrl.getDest());
-    TaskStatusEvents result = client.listeners(url).get();
+    ListenerResponse result = client.listeners(url).get();
 
     if (json) {
       out.println(Json.asPrettyStringUnchecked(result));


### PR DESCRIPTION
WIP.

Enable external HTTP endpoint subscriptions in Helios. Such endpoints would be POST-ed with a JSON made from each Job state transition event happening in the cluster, for example RUNNING -> STOPPED.