### PR TITLE
Show better errors for bad HELIOS_MASTER env vars

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -157,6 +157,11 @@ public class CliConfig {
 
     // TODO (dxia) Remove DEPRECATED_SITE_SCHEME after a period of time
     final String scheme = uri.getScheme();
+    if (scheme == null) {
+      throw new RuntimeException("Your environment variable HELIOS_MASTER=" + master +
+                                 " is not a valid URI with a scheme.");
+    }
+
     switch (scheme) {
       case DOMAIN_SCHEME:
       case DEPRECATED_SITE_SCHEME:
@@ -166,8 +171,8 @@ public class CliConfig {
         builder.put(MASTER_ENDPOINTS_KEY, ImmutableList.of(master));
         break;
       default:
-        throw new RuntimeException("Unknown Scheme " + scheme
-                                   + " in HELIOS_MASTER env variable setting of [" + master + "]");
+        throw new RuntimeException("Your environment variable HELIOS_MASTER=" + master +
+                                   " does not have a valid scheme.");
     }
 
     return fromMap(builder.build());


### PR DESCRIPTION
Instead of just showing NullPointerException,
tell user what's actually wrong.