### PR TITLE
Add support for tags in service registration ports

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
@@ -21,27 +21,56 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * A class that used to do something, but now is just effectively a placeholder in a Map
  * that is treated as a Set.  It is represented by the empty map in JSON.
  */
-@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServicePortParameters extends Descriptor {
+  private final List<String> tags;
+
+  public ServicePortParameters(@JsonProperty("tags") @Nullable final List<String> tags) {
+    this.tags = tags;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
 
   @Override
-  public boolean equals(final Object obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ServicePortParameters that = (ServicePortParameters) o;
+
+    if (tags != null ? !tags.equals(that.tags) : that.tags != null) {
+      return false;
+    }
+
     return true;
   }
 
   @Override
   public int hashCode() {
-    return 0;
+    return tags != null ? tags.hashCode() : 0;
   }
 
   @Override
   public String toString() {
-    return "{}";
+    return Objects.toStringHelper(this)
+        .add("tags", tags)
+        .toString();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
@@ -29,8 +29,31 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**
- * A class that used to do something, but now is just effectively a placeholder in a Map
- * that is treated as a Set.  It is represented by the empty map in JSON.
+ * Stores metadata for a service port. Currently, only tags are supported.
+ *
+ * The tags can be used in service registration plugins trough ServiceRegistration.Endpoint.
+ *
+ * An example expression of a Helios job with service port metadata might be:
+ * <pre>
+ * {
+ *   "ports" : {
+ *     "http" : {
+ *       "externalPort" : 8060,
+ *       "internalPort" : 8080,
+ *       "protocol" : "tcp"
+ *     }
+ *   },
+ *   "registration" : {
+ *     "service/http" : {
+ *       "ports" : {
+ *         "http" : {
+ *           "tags" : ["tag-1", "tag-2"]
+ *         }
+ *       }
+ *     }
+ *   }
+ * }
+ * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServicePortParameters extends Descriptor {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
@@ -90,7 +90,7 @@ public class ServicePorts extends Descriptor {
   private static ServicePorts of(final Iterable<String> ports) {
     final ImmutableMap.Builder<String, ServicePortParameters> builder = ImmutableMap.builder();
     for (final String port : ports) {
-      builder.put(port, new ServicePortParameters());
+      builder.put(port, new ServicePortParameters(null));
     }
     return new ServicePorts(builder.build());
   }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
@@ -31,8 +31,8 @@ import java.util.Map;
 import static java.util.Arrays.asList;
 
 /**
- * Effectively a set of port names, that is the map keys, as ServicePortParameters is just
- * an empty JSON object.
+ * A set of port names, that is map keys, together with ServicePortParameters containing optional
+ * metadata for a port.
  *
  * A typical JSON representation might be:
  * <pre>

--- a/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
+++ b/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
@@ -55,7 +55,7 @@ public class ServiceRegistration {
     public Builder endpoint(final String name,
                             final String protocol,
                             final int port) {
-      endpoints.add(new Endpoint(name, protocol, port, "", ""));
+      endpoints.add(new Endpoint(name, protocol, port, "", "", null));
       return this;
     }
 
@@ -64,7 +64,17 @@ public class ServiceRegistration {
                             final int port,
                             final String domain,
                             final String host) {
-      endpoints.add(new Endpoint(name, protocol, port, domain, host));
+      endpoints.add(new Endpoint(name, protocol, port, domain, host, null));
+      return this;
+    }
+
+    public Builder endpoint(final String name,
+                            final String protocol,
+                            final int port,
+                            final String domain,
+                            final String host,
+                            final List<String> tags) {
+      endpoints.add(new Endpoint(name, protocol, port, domain, host, tags));
       return this;
     }
 
@@ -84,14 +94,16 @@ public class ServiceRegistration {
     private final String domain;
     /** The hostname on which we will advertise this service in service discovery */
     private final String host;
+    private final List<String> tags;
 
     public Endpoint(final String name, final String protocol, final int port,
-                    final String domain, final String host) {
+                    final String domain, final String host, final List<String> tags) {
       this.name = name;
       this.protocol = protocol;
       this.port = port;
       this.domain = domain;
       this.host = host;
+      this.tags = tags;
     }
 
     public String getHost() {
@@ -114,6 +126,9 @@ public class ServiceRegistration {
       return port;
     }
 
+    public List<String> getTags() {
+      return tags;
+    }
 
     @Override
     public String toString() {
@@ -123,6 +138,7 @@ public class ServiceRegistration {
           .add("port", port)
           .add("domain", domain)
           .add("host", host)
+          .add("tags", tags)
           .toString();
     }
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -39,6 +39,7 @@ import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.common.descriptors.Resources;
 import com.spotify.helios.common.descriptors.ServiceEndpoint;
+import com.spotify.helios.common.descriptors.ServicePortParameters;
 import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
 
@@ -165,7 +166,10 @@ public class TaskConfig {
         job.getRegistration().entrySet()) {
       final ServiceEndpoint registration = entry.getKey();
       final ServicePorts servicePorts = entry.getValue();
-      for (String portName : servicePorts.getPorts().keySet()) {
+      for (final Entry<String, ServicePortParameters> portEntry :
+          servicePorts.getPorts().entrySet()) {
+        final String portName = portEntry.getKey();
+        final ServicePortParameters portParameters = portEntry.getValue();
         final PortMapping mapping = job.getPorts().get(portName);
         if (mapping == null) {
           log.error("no '{}' port mapped for registration: '{}'", portName, registration);
@@ -184,7 +188,7 @@ public class TaskConfig {
           continue;
         }
         builder.endpoint(registration.getName(), registration.getProtocol(), externalPort,
-            fullyQualifiedRegistrationDomain(), host);
+            fullyQualifiedRegistrationDomain(), host, portParameters.getTags());
       }
     }
 


### PR DESCRIPTION
Context: #367 

This is one way to do it, don't now if there are better alternatives. In helios-consul we map a registered Helios port to a Consul service, so therefore I think it makes sense to add tags to the ports. I used the mysterious ServicePortParameters class for the tags, and then expose them to helios-consul through ServiceRegistration.Endpoint.

A Helios job with "port tags" looks like this in this implementation:
```
{
  "ports": {
    "my-port": {
      "internalPort": 8080,
      "protocol": "tcp"
    },
    "another-port": {
      "internalPort": 8081,
      "protocol": "tcp"
    }
  },
  "registration": {
    "redis/master": {
      "ports": {
        "my-port": {
          "tags": [
            "master",
            "web-scale"
          ]
        }
      }
    },
    "redis/slave": {
      "ports": {
        "my-port": {
          "tags": [
            "slave",
            "web-scale",
            "meh"
          ]
        }
      }
    }
  }
}
```

What do you think?