### PR TITLE
README: Show build status badge for master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Helios [![Circle CI](https://circleci.com/gh/spotify/helios.png?style=badge)](https://circleci.com/gh/spotify/helios)
+Helios [![Circle CI](https://circleci.com/gh/spotify/helios/tree/master.png?style=badge)](https://circleci.com/gh/spotify/helios/tree/master)
 ======
 
 Helios is a Docker orchestration platform for deploying and managing


### PR DESCRIPTION
Rather than showing the build status for all branches, just show whether
master is building or not. This is what people actually care about.