### PR TITLE
Add HTTP timeout to client

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -228,7 +228,9 @@ public class Job extends Descriptor implements Comparable<Job> {
     return creatingUser;
   }
 
-  public String getToken() { return token; }
+  public String getToken() {
+    return token;
+  }
 
   public static Builder newBuilder() {
     return new Builder();


### PR DESCRIPTION
If a host was unreachable, it would take the client 2 minutes to timeout. This would
put it past the retry deadline, so it wouldn't try any other hosts. This sets the HTTP
timeout to 10s, and the retry timeout to 60s.