### PR TITLE
[TempJobs] Made deploy timeout configurable

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
@@ -52,16 +52,18 @@ public class DefaultDeployer implements Deployer {
   private final List<TemporaryJob> jobs;
   private final HostPickingStrategy hostPicker;
   private final String jobDeployedMessageFormat;
+  private final long deployTimeoutMillis;
 
   private boolean readyToDeploy;
 
   public DefaultDeployer(final HeliosClient client, final List<TemporaryJob> jobs,
                          final HostPickingStrategy hostPicker,
-                         final String jobDeployedMessageFormat) {
+                         final String jobDeployedMessageFormat, final long deployTimeoutMillis) {
     this.client = client;
     this.jobs = jobs;
     this.hostPicker = hostPicker;
     this.jobDeployedMessageFormat = jobDeployedMessageFormat;
+    this.deployTimeoutMillis = deployTimeoutMillis;
   }
 
   @Override
@@ -128,7 +130,7 @@ public class DefaultDeployer implements Deployer {
 
     log.info("Deploying {} to {}", job.getImage(), Joiner.on(", ").skipNulls().join(hosts));
     final TemporaryJob temporaryJob = new TemporaryJob(client, prober, job, hosts, waitPorts,
-        jobDeployedMessageFormat);
+        jobDeployedMessageFormat, deployTimeoutMillis);
     jobs.add(temporaryJob);
     temporaryJob.deploy();
     return temporaryJob;

--- a/helios-testing/src/test/java/com/spotify/helios/testing/DefaultDeployerTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/DefaultDeployerTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.DOWN;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static java.util.Collections.emptyMap;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -59,6 +60,7 @@ public class DefaultDeployerTest {
   private static final ListenableFuture<HostStatus> UP_STATUS = Futures.immediateFuture(
       makeDummyStatusBuilder().setStatus(UP).build());
   private static final List<String> HOSTS = ImmutableList.of(HOSTA, HOSTB);
+  private static final long TIMEOUT = MINUTES.toMillis(5);
   
   /** Pick the first host in the list */
   private static final HostPickingStrategy PICK_FIRST = new HostPickingStrategy() {
@@ -72,7 +74,8 @@ public class DefaultDeployerTest {
   
   @Test
   public void testTryAgainOnHostDown() throws Exception {
-    final DefaultDeployer sut = new DefaultDeployer(client, EMPTY_JOBS_LIST, PICK_FIRST, "");
+    final DefaultDeployer sut =
+        new DefaultDeployer(client, EMPTY_JOBS_LIST, PICK_FIRST, "", TIMEOUT);
     
     // hosta is down, hostb is up. 
     when(client.hostStatus(HOSTA)).thenReturn(DOWN_STATUS);
@@ -83,7 +86,7 @@ public class DefaultDeployerTest {
 
   @Test
   public void testFailsOnAllDown() throws Exception {
-    final DefaultDeployer sut = new DefaultDeployer(client, EMPTY_JOBS_LIST, PICK_FIRST, "");
+    final DefaultDeployer sut = new DefaultDeployer(client, EMPTY_JOBS_LIST, PICK_FIRST, "", TIMEOUT);
     
     // hosta is down, hostb is down too. 
     when(client.hostStatus(HOSTA)).thenReturn(DOWN_STATUS);

--- a/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
@@ -65,6 +66,7 @@ public class SimpleTest extends TemporaryJobsTestBase {
         .jobDeployedMessageFormat(
             "Logs Link: http://${host}:8150/${name}%3A${version}%3A${hash}?cid=${containerId}")
         .jobPrefix(Optional.of(testTag).get())
+        .deployTimeoutMillis(MINUTES.toMillis(3))
         .build();
 
     private TemporaryJob job1;

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TempJobsProfileOverrideTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TempJobsProfileOverrideTest.java
@@ -31,7 +31,8 @@ import static com.spotify.helios.testing.TemporaryJobs.HELIOS_TESTING_PROFILE;
 import static org.junit.Assert.assertEquals;
 
 public class TempJobsProfileOverrideTest {
-  @Test public void foo() throws Exception {
+  @Test
+  public void foo() throws Exception {
     final Properties oldProperties = System.getProperties();
     final Config c;
     try {

--- a/helios-testing/src/test/resources/helios-base.conf
+++ b/helios-testing/src/test/resources/helios-base.conf
@@ -17,6 +17,7 @@ helios.testing.profiles : {
     image: busybox
     domain: "shared.cloud.spotify.net"
     hostFilter: ".+\\.helios-ci\\.cloud"
+    deployTimeoutMillis: 120000
     env: {
       SPOTIFY_DOMAIN: ${prefix}".services.helios-ci.cloud.spotify.net"
       SPOTIFY_POD: ${prefix}".services.helios-ci.cloud.spotify.net"


### PR DESCRIPTION
Also changed the default from 5 min to 10 min because
we've been seeing image pulls taking ~8 min. This caused
test failures even though they would have passed otherwise.