### PR TITLE
No longer skip integration tests on Jenkins

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -11,6 +11,11 @@
   <artifactId>helios-services</artifactId>
   <packaging>jar</packaging>
 
+  <properties>
+    <masterImageName>helios-master:${project.version}-${gitShortCommitId}</masterImageName>
+    <agentImageName>helios-agent:${project.version}-${gitShortCommitId}</agentImageName>
+  </properties>
+
   <profiles>
     <profile>
       <id>build-images</id>
@@ -48,7 +53,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <imageName>helios-master:${project.version}-${gitShortCommitId}</imageName>
+                  <imageName>${masterImageName}</imageName>
                   <entryPoint>["helios-master"]</entryPoint>
                   <tagInfoFile>${project.build.testOutputDirectory}/master-image.json</tagInfoFile>
                 </configuration>
@@ -60,7 +65,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <imageName>helios-agent:${project.version}-${gitShortCommitId}</imageName>
+                  <imageName>${agentImageName}</imageName>
                   <entryPoint>["helios-agent"]</entryPoint>
                   <tagInfoFile>${project.build.testOutputDirectory}/agent-image.json</tagInfoFile>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -222,9 +222,6 @@
           <name>env.JENKINS</name>
         </property>
       </activation>
-      <properties>
-        <skipITs>true</skipITs>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
We now have integration tests which use TempJobs and can run on jenkins.
