### PR TITLE
Upgrade server side components to Java 8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,8 @@ test:
         parallel: true
 
 machine:
+  java:
+    version: oraclejdk8
   pre:
     - helios/circle.sh pre_machine
   post:

--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -120,6 +120,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>replacer</artifactId>
         <version>1.5.3</version>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -25,6 +25,9 @@
           <name>build-images</name>
         </property>
       </activation>
+      <properties>
+        <baseImage>java:8u66-jre</baseImage>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -39,7 +42,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <baseImage>java:7u71-jre</baseImage>
+                  <baseImage>${baseImage}</baseImage>
                   <resources>
                     <resource>
                       <targetPath>/usr/share/helios/lib/services/</targetPath>
@@ -64,7 +67,7 @@
                   <goal>build</goal>
                 </goals>
                 <configuration>
-                  <baseImage>java:7u71-jre</baseImage>
+                  <baseImage>${baseImage}</baseImage>
                   <resources>
                     <resource>
                       <targetPath>/usr/share/helios/lib/services/</targetPath>

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -67,6 +67,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -82,6 +82,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -580,10 +580,10 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>3.2</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
         <plugin>

--- a/solo/base/Dockerfile
+++ b/solo/base/Dockerfile
@@ -34,3 +34,13 @@ RUN mkdir /etcd \
     && cd /etcd \
     && curl -L $ETCD_ARCHIVE_URI | tar --strip-components 1 -xzvf - \
     && cp ./etcd /usr/bin
+
+# Install Java 8 from webupd8team PPA
+RUN \
+  echo deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main > /etc/apt/sources.list.d/webupd8team-java-trusty.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && \
+  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends oracle-java8-installer && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /var/cache/oracle-jdk8-installer

--- a/solo/docker/Dockerfile
+++ b/solo/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM spotify/helios-solo-base:0.2
+FROM spotify/helios-solo-base:0.3
 
 EXPOSE 5801
 

--- a/src/deb/helios-agent/control
+++ b/src/deb/helios-agent/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime-headless, helios-services (= [[version]])
+Depends: java8-runtime-headless, helios-services (= [[version]])
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios Agent
 Distribution: development

--- a/src/deb/helios-master/control
+++ b/src/deb/helios-master/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime-headless, helios-services (= [[version]])
+Depends: java8-runtime-headless, helios-services (= [[version]])
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios Master
 Distribution: development

--- a/src/deb/helios-services/control
+++ b/src/deb/helios-services/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime-headless
+Depends: java8-runtime-headless
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios services common files
 Distribution: development


### PR DESCRIPTION
Leave client side on Java 7 so we don't break projects using
TempJobs or HeliosClient.