### PR TITLE
TempJobs unit tests no longer use actual env vars

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -53,7 +53,6 @@ import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Integer.toHexString;
-import static java.lang.System.getenv;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.fail;
 
@@ -66,13 +65,14 @@ public class TemporaryJobBuilder {
   private final Set<String> waitPorts = Sets.newHashSet();
   private final Deployer deployer;
   private final String jobNamePrefix;
+  private final Map<String, String> env;
   
   private String hostFilter;
   private Prober prober;
   private TemporaryJob job;
 
   public TemporaryJobBuilder(final Deployer deployer, final String jobNamePrefix,
-                             final Prober defaultProber) {
+                             final Prober defaultProber, final Map<String, String> env) {
     checkNotNull(deployer, "deployer");
     checkNotNull(jobNamePrefix, "jobNamePrefix");
     checkNotNull(defaultProber, "defaultProber");
@@ -80,6 +80,7 @@ public class TemporaryJobBuilder {
     this.jobNamePrefix = jobNamePrefix;
     this.prober = defaultProber;
     this.builder.setRegistrationDomain(jobNamePrefix);
+    this.env = env;
   }
 
   public TemporaryJobBuilder name(final String jobName) {
@@ -237,7 +238,7 @@ public class TemporaryJobBuilder {
 
       if (this.hosts.isEmpty()) {
         if (isNullOrEmpty(hostFilter)) {
-          hostFilter = getenv("HELIOS_HOST_FILTER");
+          hostFilter = env.get("HELIOS_HOST_FILTER");
         }
 
         job = deployer.deploy(builder.build(), hostFilter, waitPorts, prober);
@@ -250,11 +251,11 @@ public class TemporaryJobBuilder {
   }
 
   public TemporaryJobBuilder imageFromBuild() {
-    final String envPath = getenv("IMAGE_INFO_PATH");
+    final String envPath = env.get("IMAGE_INFO_PATH");
     if (envPath != null) {
       return imageFromInfoFile(envPath);
     } else {
-      final String name = fromNullable(getenv("IMAGE_INFO_NAME")).or("image_info.json");
+      final String name = fromNullable(env.get("IMAGE_INFO_NAME")).or("image_info.json");
       URL info;
       try {
         info = Resources.getResource(name);

--- a/helios-testing/src/test/java/com/spotify/helios/testing/BadTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/BadTest.java
@@ -43,7 +43,7 @@ public class BadTest extends TemporaryJobsTestBase {
   public static class BadTestImpl {
 
     @Rule
-    public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
+    public final TemporaryJobs temporaryJobs = temporaryJobsBuilder()
         .client(client)
         .prober(new TestProber())
         .jobPrefix(Optional.of(testTag).get())

--- a/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.spotify.helios.testing.TemporaryJobsTestBase.temporaryJobsBuilder;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -128,7 +129,8 @@ public class ConfigTest {
 
     // The local profile is the default, so we don't specify it explicitly so we can test
     // the default loading mechanism.
-    parameters = new TestParameters(TemporaryJobs.builder(), ".*", validator);
+    parameters = new TestParameters(temporaryJobsBuilder(),
+                                    ".*", validator);
     assertThat(testResult(ProfileTest.class), isSuccessful());
   }
 
@@ -149,7 +151,7 @@ public class ConfigTest {
     };
 
     // Specify the helios-ci profile explicitly
-    parameters = new TestParameters(TemporaryJobs.builder("helios-ci"),
+    parameters = new TestParameters(temporaryJobsBuilder("helios-ci"),
                                 ".+\\.helios-ci\\.cloud",
                                 validator);
     assertThat(testResult(ProfileTest.class), isSuccessful());

--- a/helios-testing/src/test/java/com/spotify/helios/testing/JobNamePrefixTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/JobNamePrefixTest.java
@@ -123,7 +123,7 @@ public class JobNamePrefixTest extends TemporaryJobsTestBase {
   public static class JobNamePrefixTestImpl {
 
     @Rule
-    public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
+    public final TemporaryJobs temporaryJobs = temporaryJobsBuilder()
         .client(client)
         .prober(new TestProber())
         .prefixDirectory(prefixDirectory.toString())

--- a/helios-testing/src/test/java/com/spotify/helios/testing/ProberTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ProberTest.java
@@ -58,7 +58,7 @@ public class ProberTest extends TemporaryJobsTestBase {
     private MockProber overrideProber = new MockProber();
 
     @Rule
-    public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
+    public final TemporaryJobs temporaryJobs = temporaryJobsBuilder()
         .client(client)
         .prober(defaultProber)
         .jobPrefix(Optional.of(testTag).get())

--- a/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
@@ -59,7 +59,7 @@ public class SimpleTest extends TemporaryJobsTestBase {
   public static class SimpleTestImpl {
 
     @Rule
-    public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
+    public final TemporaryJobs temporaryJobs = temporaryJobsBuilder()
         .client(client)
         .prober(new TestProber())
         .jobDeployedMessageFormat(

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TempJobFailureTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TempJobFailureTest.java
@@ -46,7 +46,7 @@ public class TempJobFailureTest extends TemporaryJobsTestBase {
   public static class TempJobFailureTestImpl {
 
     @Rule
-    public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
+    public final TemporaryJobs temporaryJobs = temporaryJobsBuilder()
         .hostFilter(".*")
         .client(client)
         .prober(new TestProber())

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTestBase.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTestBase.java
@@ -27,6 +27,8 @@ import com.spotify.helios.system.SystemTestBase;
 import org.junit.Before;
 
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
 
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -70,5 +72,17 @@ public abstract class TemporaryJobsTestBase extends SystemTestBase {
     awaitHostStatus(client, testHost2, UP, LONG_WAIT_SECONDS, SECONDS);
 
     prefixDirectory = temporaryFolder.newFolder().toPath();
+  }
+
+  public static Map<String, String> emptyEnv() {
+    return Collections.emptyMap();
+  }
+
+  public static TemporaryJobs.Builder temporaryJobsBuilder() {
+    return TemporaryJobs.builder(emptyEnv());
+  }
+
+  public static TemporaryJobs.Builder temporaryJobsBuilder(final String profile) {
+    return TemporaryJobs.builder(profile, emptyEnv());
   }
 }


### PR DESCRIPTION
Previously having certain env vars set (e.g. HELIOS_HOST_FITLER) would cause
the tests to fail. The tests now inject the environment variables they want
used during the test so the tests aren't affected by the environment.