### PR TITLE
[Kafka] Make it possible to actually use Kafka.

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -286,7 +286,8 @@ public class AgentConfig extends Configuration {
     return kafkaBrokers;
   }
 
-  public void setKafkaBrokers(List<String> kafkaBrokers) {
+  public AgentConfig setKafkaBrokers(List<String> kafkaBrokers) {
     this.kafkaBrokers = kafkaBrokers;
+    return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -64,6 +64,7 @@ public class AgentParser extends ServiceParser {
   private Argument agentIdArg;
   private Argument dnsArg;
   private Argument bindArg;
+  private Argument kafkaArg;
 
   public AgentParser(final String... args) throws ArgumentParserException {
     super("helios-agent", "Spotify Helios Agent", args);
@@ -106,6 +107,8 @@ public class AgentParser extends ServiceParser {
       throw new IllegalArgumentException("Bad port range: " + portRangeString);
     }
 
+    final List<String> kafkaBrokers = options.getList(kafkaArg.getDest());
+
     this.agentConfig = new AgentConfig()
         .setName(getName())
         .setZooKeeperConnectionString(getZooKeeperConnectString())
@@ -127,7 +130,8 @@ public class AgentParser extends ServiceParser {
         .setServiceRegistrarPlugin(getServiceRegistrarPlugin())
         .setAdminPort(options.getInt(adminArg.getDest()))
         .setHttpEndpoint(httpAddress)
-        .setNoHttp(options.getBoolean(noHttpArg.getDest()));
+        .setNoHttp(options.getBoolean(noHttpArg.getDest()))
+        .setKafkaBrokers(kafkaBrokers.isEmpty() ? null : kafkaBrokers);
 
     final String explicitId = options.getString(agentIdArg.getDest());
     if (explicitId != null) {
@@ -212,6 +216,11 @@ public class AgentParser extends ServiceParser {
         .action(append())
         .setDefault(new ArrayList<String>())
         .help("volumes to bind to all containers");
+
+    kafkaArg = parser.addArgument("--kafka")
+        .action(append())
+        .setDefault(new ArrayList<String>())
+        .help("Kafka brokers to bootstrap with");
   }
 
   public AgentConfig getAgentConfig() {


### PR DESCRIPTION
There's no way to actually specify any Kafka nodes in the previous PR since it appears
that there's no way to specify a configuration file for Helios Agent. So, this PR adds
command line argument to provide Kafka bootstrap broker list.