### PR TITLE
circleci: Reduce fork count for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
             <version>2.16</version>
             <configuration>
               <enableAssertions>false</enableAssertions>
-              <forkCount>16</forkCount>
+              <forkCount>4</forkCount>
               <reuseForks>false</reuseForks>
               <argLine>-Xmx128m -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
               <environmentVariables>


### PR DESCRIPTION
The hypothesis is that we have test failures because we are attempting to
run too many tests in parallel.