### PR TITLE
Put jacoco reports in target/jacoco/report

### DIFF
--- a/helios-api-documentation/pom.xml
+++ b/helios-api-documentation/pom.xml
@@ -121,11 +121,11 @@
                           </sourcefiles>
                         </group>
                       </structure>
-                      <html destdir="${project.build.directory}/jacoco"
+                      <html destdir="${project.build.directory}/jacoco/report/html"
                             footer="Code Coverage Report for Helios ${project.version}"
                             locale="en"/>
-                      <csv destfile="${project.build.directory}/jacoco/coverage.csv"/>
-                      <xml destfile="${project.build.directory}/jacoco/coverage.xml"/>
+                      <csv destfile="${project.build.directory}/jacoco/report/coverage.csv"/>
+                      <xml destfile="${project.build.directory}/jacoco/report/coverage.xml"/>
                     </report>
                   </target>
                 </configuration>


### PR DESCRIPTION
This is so we can easily make artifacts out of reports without pulling in
other files like the jacoco ant jar which is downloaded into target/jacoco.