### PR TITLE
Fix bug where agent stops fetching data from zookeeper

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCache.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCache.java
@@ -169,7 +169,9 @@ public class PersistentPathChildrenCache<T> extends AbstractIdleService {
         try {
           update();
           return;
-        } catch (KeeperException e) {
+        } catch (Exception e) {
+          // If an exception is thrown we must set the synced flag to false. Otherwise the next run
+          // of update might not fetch data from zookeeper because it thinks everything is synced.
           synced = false;
           log.warn("update failed: {}", e.getMessage());
           Thread.sleep(retryScheduler.nextMillis());


### PR DESCRIPTION
This happened because the agent machine was unable to resolve the ZK host
name into an IP address, which caused the ZK client to throw an
IllegalArgumentException. The agent did not handle this exception properly,
and PersistentPathChildrenCache always thought it was in a synced state.