### PR TITLE
Make checkstyle fail build for unused imports

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -55,6 +55,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
     <module name="AvoidStarImport"/>
     <module name="NoLineWrap"/>
+    <module name="UnusedImports"/>
 
     <!--
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/PollingDockerClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/PollingDockerClient.java
@@ -23,7 +23,6 @@ package com.spotify.helios.agent;
 
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificates;
-import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.messages.ContainerExit;
 import com.spotify.docker.client.messages.ContainerInfo;
@@ -31,7 +30,7 @@ import com.spotify.docker.client.messages.ContainerInfo;
 import java.net.URI;
 
 /**
- * A {@link DockerClient} that overrides {@link #waitContainer} to poll instead of block
+ * A {@code DockerClient} that overrides {@link #waitContainer} to poll instead of block
  * indefinitely.  See the source code for details as to why this needs to exist.
  */
 public class PollingDockerClient extends DefaultDockerClient {

--- a/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.Task;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -111,7 +110,7 @@ public class ZooKeeperAgentModel extends AbstractIdleService implements AgentMod
   }
 
   /**
-   * Returns the tasks (basically, a pair of {@link JobId} and {@link Goal}) for the current agent.
+   * Returns the tasks (basically, a pair of {@link JobId} and {@link Task}) for the current agent.
    */
   @Override
   public Map<JobId, Task> getTasks() {

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -33,7 +33,6 @@ import com.spotify.helios.common.HeliosRuntimeException;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.AgentInfo;
 import com.spotify.helios.common.descriptors.Deployment;
-import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.HostInfo;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.Job;
@@ -531,7 +530,7 @@ public class ZooKeeperMasterModel implements MasterModel {
 
   /**
    * Creates a config entry within the specified agent to un/deploy a job, or more generally, change
-   * the deployment status according to the {@link Goal} value in {@link Deployment}.
+   * the deployment status according to the {@code Goal} value in {@link Deployment}.
    */
   @Override
   public void deployJob(final String host, final Deployment deployment, final String token)

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
@@ -38,17 +38,16 @@ import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
- * A class that is similar to {@link AtomicReference} but is backed by a file, so can be
+ * A class that is similar to {@code AtomicReference} but is backed by a file, so can be
  * persisted across a server restart.  Assumes the underlying type can be serialized by Jackson.
  *
- * Strangely, this is not actually atomic in the {@link AtomicReference} way; i.e. not threadsafe,
+ * Strangely, this is not actually atomic in the {@code AtomicReference} way; i.e. not threadsafe,
  * nor does it do CAS.
  */
 public class PersistentAtomicReference<T> {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/HealthCheckTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/HealthCheckTest.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.system;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import com.spotify.helios.MockServiceRegistrarRegistry;


### PR DESCRIPTION
We try to keep unused imports out of our code anyway, so should we have checkstyle just enforce this for us?