### PR TITLE
Bump jacoco jar to earlier version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <autoReleaseAfterClose>true</autoReleaseAfterClose>
-    <jacoco.version>0.7.3.201502191951</jacoco.version>
+    <jacoco.version>0.7.1.201405082137</jacoco.version>
     <surefireArgLine>-Xmx128m -XX:+TieredCompilation -XX:TieredStopAtLevel=1</surefireArgLine>
   </properties>
 


### PR DESCRIPTION
The most recent one is not compatible with the v1.8 of the Jenkins
jacoco plugin. So use this one until this fix is released.
https://issues.jenkins-ci.org/browse/JENKINS-27088