### PR TITLE
Ignore unknown fields when deserializing Job object

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 
@@ -90,6 +91,7 @@ import static java.util.Collections.emptyMap;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Job extends Descriptor implements Comparable<Job> {
 
   public static final Map<String, String> EMPTY_ENV = emptyMap();


### PR DESCRIPTION
Without this, masters will reject calls from newer clients which have
additional fields. This allows us to deploy new helios jobs on older
clusters when running helios integration tests using TempJobs.