### PR TITLE
Add helios-solo (formerly named helios-standalone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,33 +130,20 @@ Install & Run
 -------------
 
 ### Quick start
-If you have [Vagrant](http://www.vagrantup.com/) installed locally, just
-clone the repo and run:
+Use [helios-solo](https://github.com/spotify/helios/blob/master/docs/helios_solo.md)
+to launch a local environment with a Helios master and agent:
 
-    $ vagrant up
+```bash
+# install helios-solo (pick one of the below)
+$ sudo apt-get install helios-solo
+$ brew tap spotify/public && brew install helios-solo
 
-This will start a virtual machine, install the prereqs, build the project, and install and run
-the Helios agent and master. You can then use the Vagrant environment:
+# launch a helios cluster in a Docker container
+$ helios-up
+
+# check if it worked and the solo agent is registered
+$ helios-solo hosts
 ```
-$ vagrant ssh
-vagrant@ubuntu-14:~$ helios hosts
-HOST             STATUS    DEPLOYED    RUNNING    CPUS    MEM     LOAD AVG    MEM USAGE    OS       VERSION
-192.168.33.10    Down      0           0          2       0 gb    0.09        0.81         Linux    3.13.0-24-generic
-```
-
-Note that the included Vagrantfile doesn't run the test suite when building Helios. This is so
-we can get you up and running with a VM as quickly as possible. You should run `mvn package`
-yourself to run the test suite.
-
-### Manual approach
-
-The launcher scripts are in [bin/](bin).
-After you've run `mvn package`, you should be able to start the agent and master:
-
-    $ bin/helios-master &
-    $ bin/helios-agent &
-
-If you see any issues, make sure you have the prerequisites (Docker and Zookeeper) installed.
 
 ### Production on Debian, Ubuntu, etc.
 
@@ -196,18 +183,22 @@ $ sudo apt-get install helios helios-agent helios-master
 $ helios -z http://localhost:5801 hosts
 ```
 
+### Manual approach
+
+The launcher scripts are in [bin/](bin).
+After you've run `mvn package`, you should be able to start the agent and master:
+
+    $ bin/helios-master &
+    $ bin/helios-agent &
+
+If you see any issues, make sure you have the prerequisites (Docker and Zookeeper) installed.
+
 Build & Test
 ------------
 
-First, make sure you have Docker installed locally. If you're using OS X, you can use
-the included Vagrantfile to bring up Docker inside of a VM:
-
-```sh
-$ vagrant up
-
-# set DOCKER_HOST to use the Docker instance inside the VM
-$ export DOCKER_HOST=tcp://192.168.33.10:2375
-```
+First, make sure you have Docker installed locally. If you're using OS X, we
+recommend using [Boot2Docker](http://boot2docker.io/) or
+[docker-machine](https://docs.docker.com/machine/).
 
 Actually building Helios and running its tests should be a simple matter
 of running:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,20 @@
 Helios Documentation
 --------------------
 
-* [User Manual](user_manual.md) -- How to create and deploy jobs in a Helios cluster.
-* [How To Deploy Helios](how_to_deploy.md) -- How to setup and install a Helios cluster.
-* [Helios Testing Framework](testing_framework.md) -- How to write integration tests to spin up (dependent) containers so you can run tests against them.
-* [Simplified Master Lookup](automatic_master_lookup.md) -- don't want to type `-z http://foo.bar:5801`, but rather something more like `-d prod` or `-d awsuse1` or `-d testing` to specify which cluster to connect to?  Then read this.
-* [Registering Containers with Service Discovery](service_registration.md) -- Everything you wanted to know about how to use Helios and whatever service discovery system you have. 
+* **[User Manual](user_manual.md)**<br />
+  How to create and deploy jobs in a Helios cluster.
+
+* **[Using helios-solo](helios_solo.md)**<br />
+  Use helios-solo to start a local Helios cluster in a Docker container.
+
+* **[Deploying Helios](how_to_deploy.md)**<br />
+  How to setup and install a real Helios cluster.
+
+* **[Helios Testing Framework](testing_framework.md)**<br />
+  How to write JUnit integration tests to spin up (dependent) containers so you can run tests against them.
+
+* **[Simplified Master Lookup](automatic_master_lookup.md)**<br />
+  Don't want to type `helios -z http://foo.bar:5801`, but rather something more like `helios -d prod` or `-d testing`? Then read this.
+
+* **[Registering Containers with Service Discovery](service_registration.md)**
+  Everything you wanted to know about how to use Helios and whatever service discovery system you have.

--- a/docs/helios_solo.md
+++ b/docs/helios_solo.md
@@ -1,0 +1,109 @@
+Using helios-solo
+===
+
+helios-solo provides a local Helios cluster running in a Docker container. This
+gives you a single Helios master and agent to play around with. All Helios jobs
+are run on the local Docker instance. The only prerequisite is
+[Docker](https://docs.docker.com/installation/).
+
+Install & Run
+---
+
+### OS X
+
+```bash
+$ brew tap spotify/public && brew install helios-solo
+$ helios-up
+```
+
+### Linux
+
+```bash
+$ sudo apt-get install spotify-helios-solo
+$ helios-up
+```
+
+If `helios-up` fails, ensure that Docker is running and your client is correctly
+configured. A good test is to run `docker info`.
+
+Usage
+---
+
+Here are some example commands:
+
+```bash
+# Start helios-solo
+$ helios-up
+
+# Upgrade to the latest version of Helios
+$ helios-use latest
+
+# Clean up all jobs & containers
+$ helios-cleanup
+```
+
+Once helios-solo is up, you can use the `helios-solo` command to talk to it. The
+usage is identical to the `helios` CLI. Here's an example:
+
+```bash
+# Make sure the helios-solo agent is up
+$ helios-solo hosts
+
+# Create a trivial helios job
+$ helios-solo create test:1 busybox -- sh -c "while :; do sleep 1; done"
+
+# Deploy the job on the (local) solo host
+$ helios-solo deploy test:1 solo
+
+# Check the job status
+$ helios-solo status
+
+# Undeploy job
+$ helios-solo undeploy -a -f test:1
+
+# Remove job
+$ helios-solo remove test:1
+```
+
+Commands
+--------
+
+* `helios-up`<br />
+  Brings up the helios-solo container.
+
+* `helios-down`<br />
+  Destroys the helios-solo container.
+
+* `helios-solo ...`<br />
+  Wrapper around the helios CLI for talking to helios-solo.
+  Essentially identical to `eval $(helios-env) && helios -z $HELIOS_URI ...`.
+
+* `helios-restart`<br />
+  Destroy and restart the helios-solo container.
+
+* `helios-cleanup`<br />
+  Remove all helios-solo jobs and containers.
+
+* `helios-env`<br />
+  Utility for setting `HELIOS_URI` environment variable in your
+  shell: `eval $(helios-env)`.
+
+* `helios-use`<br />
+  Switches the underlying Helios version (or upgrades to the latest version).
+
+Container Logging
+-----------------
+
+To see the logs for a container deployed by helios-solo, run:
+
+    $ docker logs <container_id>
+
+You can get the ID's of all running containers with `docker ps`.
+
+Debugging
+---------
+
+Use the `helios-enter` debug command to bring up the helios-solo container and
+get a bash shell inside it. Alternatively, use `helios-up` and then:
+
+    $ docker exec -it helios-solo-container bash

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <masterImageName>helios-master:${project.version}-${gitShortCommitId}</masterImageName>
     <agentImageName>helios-agent:${project.version}-${gitShortCommitId}</agentImageName>
+    <soloImageName>helios-solo:${project.version}</soloImageName>
   </properties>
 
   <profiles>
@@ -69,6 +70,38 @@
                   <entryPoint>["helios-agent"]</entryPoint>
                   <tagInfoFile>${project.build.testOutputDirectory}/agent-image.json</tagInfoFile>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>build-solo</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.1.1</version>
+            <configuration>
+              <dockerDirectory>solo/docker</dockerDirectory>
+              <imageName>${soloImageName}</imageName>
+              <resources>
+                <resource>
+                  <targetPath>/</targetPath>
+                  <directory>${project.build.directory}</directory>
+                  <include>${project.build.finalName}-shaded.jar</include>
+                </resource>
+              </resources>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>
@@ -372,6 +405,24 @@
       </plugin>
 
       <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <descriptors>
+            <descriptor>${project.basedir}/src/assembly/helios-solo.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>jdeb</artifactId>
         <groupId>org.vafer</groupId>
         <version>1.1.1</version>
@@ -496,6 +547,40 @@
                   <mapper>
                     <type>perm</type>
                     <prefix>/usr/share/helios/lib/services</prefix>
+                  </mapper>
+                </data>
+              </dataSet>
+            </configuration>
+          </execution>
+
+          <!--helios-solo-->
+          <execution>
+            <id>helios-solo</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jdeb</goal>
+            </goals>
+            <configuration>
+              <deb>${project.build.directory}/helios-solo_${project.version}_all.deb</deb>
+              <controlDir>${project.parent.basedir}/src/deb/helios-solo</controlDir>
+              <dataSet>
+                <data>
+                  <type>files</type>
+                  <paths>
+                    <path>solo/helios-cleanup</path>
+                    <path>solo/helios-down</path>
+                    <path>solo/helios-enter</path>
+                    <path>solo/helios-env</path>
+                    <path>solo/helios-restart</path>
+                    <path>solo/helios-solo</path>
+                    <path>solo/helios-up</path>
+                    <path>solo/helios-use</path>
+                  </paths>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/usr/bin</prefix>
+                    <filemode>0755</filemode>
+                    <strip>1</strip>
                   </mapper>
                 </data>
               </dataSet>

--- a/helios-services/src/assembly/helios-solo.xml
+++ b/helios-services/src/assembly/helios-solo.xml
@@ -1,0 +1,24 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>helios-solo</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>../solo</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>helios-*</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+  <files>
+    <file>
+      <source>../docs/helios_solo.md</source>
+      <outputDirectory>/</outputDirectory>
+      <destName>README.md</destName>
+    </file>
+  </files>
+</assembly>

--- a/solo/docker/Dockerfile
+++ b/solo/docker/Dockerfile
@@ -1,0 +1,44 @@
+FROM netflixoss/java:7
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y curl zookeeper
+
+# Install helios-skydns plugin
+ENV SKYDNS_PLUGIN_VERSION 0.1
+ENV SKYDNS_PLUGIN_DEB helios-skydns_${SKYDNS_PLUGIN_VERSION}_all.deb
+ENV SKYDNS_PLUGIN_DEB_URI https://github.com/spotify/helios-skydns/releases/download/$SKYDNS_PLUGIN_VERSION/$SKYDNS_PLUGIN_DEB
+RUN curl -o $SKYDNS_PLUGIN_DEB -L $SKYDNS_PLUGIN_DEB_URI \
+    && dpkg -i $SKYDNS_PLUGIN_DEB
+
+# Install Go (from the official golang Dockerfile)
+ENV GOLANG_VERSION 1.3.3
+ENV PATH /go/bin:/usr/src/go/bin:$PATH
+ENV GOPATH /go
+
+RUN apt-get install -y --no-install-recommends gcc libc6-dev make
+RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
+    | tar v -C /usr/src -xz
+RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
+RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
+
+RUN apt-get install -y git mercurial
+
+# Install etcd
+RUN git clone https://github.com/coreos/etcd
+WORKDIR /etcd
+RUN git checkout v0.4.5
+RUN git fetch origin pull/899/head:pull-899 && git merge pull-899
+RUN ./build && cp bin/etcd /usr/bin
+
+# Install skydns
+RUN mkdir -p /go/src/github.com/skynetservices
+WORKDIR /go/src/github.com/skynetservices
+RUN git clone https://github.com/skynetservices/skydns.git
+RUN cd skydns && git checkout 829cce8 && go get && go build
+
+EXPOSE 5801
+
+WORKDIR /
+ADD start.sh /
+ADD *.jar /
+ENTRYPOINT ["/start.sh"]

--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -xe
+
+# Look up the ip address of
+IPADDRESS=$(ip addr | grep inet | grep eth0 | tr '/' ' ' |  awk '{ print $2 }')
+
+# Start etcd
+etcd $ETCD_OPTS &
+
+NAMESERVERS=$(cat /etc/resolv.conf | grep nameserver |
+              python -c "import json, sys; ns=['%s:53' % (l.strip().split()[1], ) for l in sys.stdin]; print json.dumps(ns or ['8.8.8.8:53', '8.8.4.4:53']);")
+
+# Write skydns configuration and retry for 30 seconds until successful
+for i in {1..30}; do
+	if curl --retry 30 -XPUT http://127.0.0.1:4001/v2/keys/skydns/config \
+		-d value="{\"dns_addr\":\"0.0.0.0:53\", \"ttl\":3600, \"nameservers\": $NAMESERVERS, \"domain\":\"local.\"}"; then
+		break
+	fi
+	sleep 1
+done
+
+# Create A record for the solo host
+curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/solo \
+    -d value="{\"host\":\"$HOST_ADDRESS\"}"
+
+skydns $SKYDNS_OPTS &
+
+/usr/share/zookeeper/bin/zkServer.sh start &
+
+# Start agent
+mkdir -p /agent
+cd /agent
+java -cp '/*' \
+-Xmx128m \
+-Djava.net.preferIPv4Stack=true \
+com.spotify.helios.agent.AgentMain \
+--name ${HELIOS_NAME} \
+--service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
+--id solo-host \
+--dns $IPADDRESS \
+--domain 'local.' \
+--service-registry "http://127.0.0.1:4001" \
+--env SPOTIFY_POD='local.' \
+--env SPOTIFY_DOMAIN='local.' \
+--env HELIOS_HOST_ADDRESS=$HOST_ADDRESS \
+&
+
+# Start master
+mkdir -p /master
+cd /master
+java -cp '/*' \
+-Xmx128m \
+-Djava.net.preferIPv4Stack=true \
+com.spotify.helios.master.MasterMain \
+--service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
+&
+
+# Sleep or execute command line
+if [ -z "$HELIOS_INTERACTIVE" ]; then
+	while :; do sleep 1; done
+else
+	cd /
+	"$@"
+fi

--- a/solo/helios-cleanup
+++ b/solo/helios-cleanup
@@ -1,0 +1,23 @@
+#!/bin/bash
+echo 'Removing all helios-solo jobs and containers...'
+
+# Instruct helios to undeploy and remove all jobs
+RUNNING=$(docker inspect -f '{{ .State.Running }}' helios-solo-container 2>/dev/null)
+if [ "$RUNNING" == "true" ]; then
+	JOBS=$(PATH=.:$PATH helios-solo jobs -q)
+	for job in $JOBS; do
+		PATH=.:$PATH helios-solo undeploy -a -f $job
+		PATH=.:$PATH helios-solo remove --force $job
+	done
+fi
+
+# Kill containers until they're gone
+while true; do
+	CTRS=$(docker ps -a | grep helios-solo-host- | awk '{ print $(NF) }')
+	if [ -z "$CTRS" ]; then break; fi
+	for ctr in $CTRS; do
+		docker kill $ctr
+		docker rm $ctr
+	done
+	sleep 1
+done

--- a/solo/helios-down
+++ b/solo/helios-down
@@ -1,0 +1,9 @@
+#!/bin/bash
+if ! docker inspect helios-solo-container &> /dev/null; then
+	echo 'helios-solo not running'
+	exit 1
+fi
+
+docker kill helios-solo-container > /dev/null
+docker rm helios-solo-container > /dev/null
+echo 'helios-solo stopped'

--- a/solo/helios-enter
+++ b/solo/helios-enter
@@ -1,0 +1,26 @@
+#!/bin/bash -x
+if [ "x$DOCKER_HOST" == "x" ]; then echo "DOCKER_HOST need to be set"; exit 1; fi
+
+REPO=spotify/helios-solo
+HELIOS_IMAGE=$REPO:latest
+
+RUNNING=$(docker inspect -f '{{ .State.Running }}' helios-solo-container 2>/dev/null)
+
+if [ "$RUNNING" == "true" ] &> /dev/null; then
+	echo 'helios-solo already running'
+	exit 1
+fi
+
+docker rm helios-solo-container &> /dev/null
+
+eval $(PATH=.:$PATH helios-env)
+
+docker run -it \
+-e HELIOS_INTERACTIVE=1 \
+-e DOCKER_HOST=$DOCKER_HOST \
+-e HELIOS_NAME=solo.local. \
+-e HOST_ADDRESS=$DOCKER_HOST_ADDRESS \
+-p 5801:5801 \
+--name helios-solo-container \
+$HELIOS_IMAGE \
+bash -l

--- a/solo/helios-env
+++ b/solo/helios-env
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ "x$DOCKER_HOST" == "x" ]; then
+	if [ "$(uname -s)" == "Linux" ]; then
+		DOCKER_HOST=unix:///var/run/docker.sock
+		echo export DOCKER_HOST=$DOCKER_HOST
+	else
+		echo "DOCKER_HOST needs to be set"
+		exit 1
+	fi
+fi
+
+
+if [[ "$DOCKER_HOST" == unix:///* ]]; then
+	DOCKER_HOST_RAW=localhost
+	DOCKER_HOST_ADDRESS=127.0.0.1
+else
+	DOCKER_HOST_RAW=$(echo $DOCKER_HOST | sed 's/^[a-zA-Z]\{1,\}:\/\///')
+	DOCKER_HOST_ADDRESS=$(echo $DOCKER_HOST_RAW | cut -d: -f1)
+fi
+HELIOS_URI=http://$DOCKER_HOST_ADDRESS:5801
+
+echo export DOCKER_HOST_RAW=$DOCKER_HOST_RAW
+echo export DOCKER_HOST_ADDRESS=$DOCKER_HOST_ADDRESS
+echo export HELIOS_URI=$HELIOS_URI

--- a/solo/helios-restart
+++ b/solo/helios-restart
@@ -1,0 +1,5 @@
+#!/bin/bash
+PATH=.:$PATH
+helios-down
+echo
+helios-up

--- a/solo/helios-solo
+++ b/solo/helios-solo
@@ -1,0 +1,3 @@
+#!/bin/bash
+eval $(PATH=.:$PATH helios-env)
+helios -z $HELIOS_URI "$@"

--- a/solo/helios-up
+++ b/solo/helios-up
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Get HELIOS_URI and DOCKER_HOST_RAW
+eval $(PATH=.:$PATH helios-env)
+
+REPO=spotify/helios-solo
+HELIOS_IMAGE=$REPO:latest
+
+RUNNING=$(docker inspect -f '{{ .State.Running }}' helios-solo-container 2>/dev/null)
+
+if [ "$RUNNING" == "true" ]; then
+	echo 'helios-solo already running'
+else
+    # Horrible hack to presere some configuration internal to Spotify.
+    # Unfortunately, I don't have a better way to do this.
+    if grep spotify.net /etc/resolv.conf >/dev/null; then
+        # remember that you are a Spotify user
+        mkdir -p ~/.helios
+        touch ~/.helios/spotify
+    fi
+    if [ -f ~/.helios/spotify ]; then
+        # if you are a Spotify user, use our internal SRV record frmat
+        registrar_host_format='_spotify-${service}._${protocol}.services.${domain}'
+        DOCKER_OPTS="$DOCKER_OPTS -e REGISTRAR_HOST_FORMAT=$registrar_host_format"
+    fi
+
+	PROBE=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 32)
+
+	# figure out the CONTAINER_DOCKER_HOST and CONTINER_DOCKER_CERT_PATH, which are the DOCKER_HOST
+	# and DOCKER_CERT_PATH from the perspective of the helios-solo container. these differ
+	# from the local DOCKER_HOST/CERT_PATH in the case of using Boot2Docker.
+	if [[ "$(docker info | grep 'Operating System')" == *Boot2Docker* ]]; then
+		# when using Boot2Docker, just use the unix socket endpoint for talking to Docker from
+		# the Helios container
+		CONTAINER_DOCKER_HOST=unix:///var/run/docker.sock
+		CONTAINER_DOCKER_CERT_PATH=
+	else
+		CONTAINER_DOCKER_HOST="$DOCKER_HOST"
+		CONTAINER_DOCKER_CERT_PATH="$DOCKER_CERT_PATH"
+	fi
+
+	if [ -z "$CONTAINER_DOCKER_CERT_PATH" ]; then
+		PROTOCOL="http"
+	else
+		DOCKER_OPTS="$DOCKER_OPTS -v $CONTAINER_DOCKER_CERT_PATH:/certs -e DOCKER_CERT_PATH=/certs"
+		CURL_OPTS="--insecure --cert /certs/cert.pem --key /certs/key.pem"
+		PROTOCOL="https"
+	fi
+
+	if [[ "$CONTAINER_DOCKER_HOST" == unix:///* ]]; then
+		DOCKER_SOCKET_PATH=$(echo $CONTAINER_DOCKER_HOST | sed 's/^[a-zA-Z]\{1,\}:\/\///')
+		DOCKER_OPTS="$DOCKER_OPTS -v $DOCKER_SOCKET_PATH:/var/run/docker.sock"
+		CURL_OPTS="$CURL_OPTS --unix-socket $DOCKER_SOCKET_PATH"
+	fi
+
+	if type -p nmcli >/dev/null; then
+		# get DNS servers from NetworkManager when it's available, since /etc/resolv.conf is likely
+		# to just point to local dnsmasq
+		dns_servers="$(nmcli -terse -field IP4 device list | grep DNS | cut -d: -f2)"
+		for dns in $dns_servers; do
+			DOCKER_OPTS="$DOCKER_OPTS --dns $dns"
+		done
+	fi
+
+	# Check that CONTAINER_DOCKER_HOST is reachable from within the container by starting a container
+	# with a unique name and probing docker for the existence of this named container, from within the
+	# container itself. If CONTINER_DOCKER_CERT_PATH exists, we will connect using TLS, otherwise HTTP.
+	# We're using the onescience/alpine image, which has curl with Unix socket support.
+	docker run --rm --name $PROBE $DOCKER_OPTS onescience/alpine \
+		curl -f $CURL_OPTS $PROTOCOL://$DOCKER_HOST_RAW/containers/$PROBE/json &>/dev/null
+
+	DOCKER_HOST_OK=$?
+	if [ $DOCKER_HOST_OK -ne 0 ]; then
+		echo "Docker was not reachable using DOCKER_HOST=$DOCKER_HOST_RAW and DOCKER_CERT_PATH=$DOCKER_CERT_PATH from within a container."
+		echo "Please ensure that DOCKER_HOST contains a full hostname or ip address, not localhost or 127.0.0.1, etc."
+		exit 1
+	fi
+
+	HELIOS_HOST_ADDRESS="$DOCKER_HOST_ADDRESS"
+	if [ "$HELIOS_HOST_ADDRESS" == "127.0.0.1" ]; then
+		# HELIOS_HOST_ADDRESS must be addressable from both the physical host and containers.
+		# If Docker is running on the localhost, use the bridge address instead of 127.0.0.1.
+		HELIOS_HOST_ADDRESS=$(docker run --rm onescience/alpine \
+			sh -c "ip route | awk '/default/ { print \$3 }'")
+	fi
+
+	docker rm helios-solo-container &> /dev/null
+	docker inspect "$HELIOS_IMAGE" &>/dev/null || docker pull "$HELIOS_IMAGE"
+	if ! docker inspect "$HELIOS_IMAGE" &>/dev/null; then
+		echo "Failed to pull $HELIOS_IMAGE"
+		exit 1
+	fi
+	CID=$(docker run -d \
+		  -e DOCKER_HOST=$CONTAINER_DOCKER_HOST \
+		  -e HELIOS_NAME=solo.local. \
+		  -e HOST_ADDRESS=$HELIOS_HOST_ADDRESS \
+		  -p 5801:5801 \
+		  --name helios-solo-container \
+		  $DOCKER_OPTS \
+		  $HELIOS_IMAGE)
+    if [ $? -ne 0 ]; then
+        echo "The helios-solo container couldn't start."
+    else
+        echo 'helios-solo started'
+    fi
+fi
+
+INTERNAL_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' helios-solo-container)
+
+echo
+echo "helios-solo is reachable on: $HELIOS_URI (Internal IP: $INTERNAL_IP)"
+echo
+echo 'To easily interact with helios-solo, use the helios-solo wrapper: '
+echo
+echo '    helios-solo <cmd>'
+echo
+echo 'E.g.:'
+echo
+echo '    helios-solo create test:1 busybox -- sh -c "while :; do sleep 1; done"'
+echo '    helios-solo deploy test:1 solo'
+echo '    helios-solo status'
+echo
+echo 'Alternatively:'
+echo
+echo '    eval $(helios-env)'
+echo '    helios -z $HELIOS_URI <cmd>'
+echo '    ...'
+echo
+

--- a/solo/helios-use
+++ b/solo/helios-use
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+REPO=spotify/helios-solo
+HELIOS_IMAGE=$REPO:latest
+
+function get_helios_version() {
+	docker run --rm --entrypoint bash $HELIOS_IMAGE \
+		-c "ls *.jar | cut -d- -f3"
+}
+
+function get_cli_version() {
+	if type -p helios >/dev/null; then
+		helios --version | grep -oe '[0-9\.]\+'
+	fi
+}
+
+orig_version=$(get_helios_version)
+echo "Currently using Helios v$orig_version"
+echo
+
+if [ ! -z "$1" ]; then
+	requested_version="$1"
+	if [ "$orig_version" == "$requested_version" ]; then
+		echo "Already at v$requested_version"
+		exit 0
+	fi
+
+	echo "Switching to $requested_version"
+	docker pull "$REPO:$requested_version"
+	docker tag -f "$REPO:$requested_version" "$REPO:latest"
+	echo
+
+	new_version=$(get_helios_version)
+
+	if [ "$requested_version" == "latest" ] && [ "$new_version" == "$orig_version" ]; then
+		echo "Already at latest version (v$new_version)."
+		exit 0
+	fi
+
+	echo "Switched to v$new_version. To use it, please restart helios-solo:"
+	echo
+	echo '    helios-restart'
+	echo
+	echo 'Note that this will destroy all Helios jobs on helios-solo.'
+
+	cli_version=$(get_cli_version)
+	if [ ! -z "$cli_version" ] && [ "$cli_version" != "$new_version" ]; then
+		echo
+		echo "WARNING: Your Helios CLI version is different (v$cli_version)."
+		echo 'Upgrade or downgrade to the correct CLI version if you have issues.'
+		echo 'This is usually accomplished with `brew` or `apt-get`.'
+	fi
+else
+	echo 'Upgrade to the latest version with:'
+	echo
+	echo '    helios-use latest'
+	echo
+	echo 'You can also switch to a specific version with:'
+	echo
+	echo '    helios-use <version>'
+	echo
+fi

--- a/src/deb/helios-solo/control
+++ b/src/deb/helios-solo/control
@@ -1,0 +1,9 @@
+Package: helios-solo
+Version: [[version]]
+Section: non-free/net
+Priority: optional
+Architecture: all
+Depends: docker.io | lxc-docker, helios
+Maintainer: Rohan Singh <rohan@spotify.com>
+Description: Scripts for running Helios locally
+Distribution: development


### PR DESCRIPTION
This includes two things:

* Building the helios-solo Docker image as part of the helios-services build.

* Building a helios-solo Debian package, which contains helios-up and other
  scripts for launching and using helios-solo.