### PR TITLE
Use onescience/alpine instead of uggedal/alpine

### DIFF
--- a/helios-system-tests/src/main/resources/syslog-test-image/Dockerfile
+++ b/helios-system-tests/src/main/resources/syslog-test-image/Dockerfile
@@ -1,6 +1,5 @@
-FROM uggedal/alpine-3.0
+FROM onescience/alpine
 
-RUN apk update && apk add curl
 RUN curl -L -o /tmp/syslog-redirector.zip https://github.com/spotify/syslog-redirector/releases/download/0.0.5/syslog-redirector.zip
 RUN unzip /tmp/syslog-redirector.zip syslog-redirector -d / && rm /tmp/syslog-redirector.zip
 


### PR DESCRIPTION
Switch to a better-maintained Alpine image. We already use this for most of
our tests. It also comes with curl preinstalled, which makes the syslog
redirection test faster and more reliable.