### PR TITLE
Fix destination filename for the helios-solo zip

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -422,6 +422,8 @@
           <descriptors>
             <descriptor>${project.basedir}/src/assembly/helios-solo.xml</descriptor>
           </descriptors>
+          <finalName>helios-solo</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Instead of having the filename be a long string containing the Maven
project name and version, just go with "helios-solo.zip". This matches what
we do for "helios-debs.tar.gz".