### PR TITLE
helios-solo: Create and collect helios-solo.zip

### DIFF
--- a/create_artifacts.sh
+++ b/create_artifacts.sh
@@ -9,6 +9,9 @@ mkdir target/debs
 find . -name *.deb -type f -not -path "./target/*" -exec cp {} target/debs/ \;
 tar -C target/debs -zcf target/helios-debs.tar.gz .
 
+# Copy helios-solo script archive into target/helios-solo.zip
+cp helios-services/target/helios-solo.zip ./target
+
 # Output build version into file for later Jenkins items
 VERSION=$(egrep -o '<version>.*</version>' -m 1 pom.xml | sed 's/<version>\(.*\)<\/version>/\1/')
 echo ${VERSION} > target/version


### PR DESCRIPTION
helios-solo.zip contains the helios-solo scripts, packaged up for use on
non-Debian platforms (like for Homebrew, or if for some reason you don't
want to `apt-get install helios-solo`).