### PR TITLE
README: Clarify helios-solo installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,32 @@ Install & Run
 
 ### Quick start
 Use [helios-solo](https://github.com/spotify/helios/blob/master/docs/helios_solo.md)
-to launch a local environment with a Helios master and agent:
+to launch a local environment with a Helios master and agent.
+
+First, ensure you have [Docker installed locally](https://docs.docker.com/installation/). Then
+install helios-solo:
 
 ```bash
-# install helios-solo (pick one of the below)
+# install helios-solo on Debian/Ubuntu
+$ curl -sSL https://spotify.github.io/helios-apt/go | sudo sh -
 $ sudo apt-get install helios-solo
-$ brew tap spotify/public && brew install helios-solo
 
+# install helios-solo on OS X
+$ brew tap spotify/public && brew install helios-solo
+```
+
+Once you've got it installed, bring up the helios-solo cluster:
+
+```bash
 # launch a helios cluster in a Docker container
 $ helios-up
 
 # check if it worked and the solo agent is registered
 $ helios-solo hosts
 ```
+
+You can now [use helios-solo](https://github.com/spotify/helios/blob/master/docs/helios_solo.md#usage)
+as your local Helios cluster.
 
 ### Production on Debian, Ubuntu, etc.
 

--- a/docs/helios_solo.md
+++ b/docs/helios_solo.md
@@ -19,6 +19,7 @@ $ helios-up
 ### Linux
 
 ```bash
+$ curl -sSL https://spotify.github.io/helios-apt/go | sudo sh -
 $ sudo apt-get install spotify-helios-solo
 $ helios-up
 ```


### PR DESCRIPTION
* Explicitly mention that Docker needs to be installed locally.

* Add the helios-apt/go script as a step for Debian/Ubuntu.

* Split out the installation instructions for OS X more clearly.