### PR TITLE
Run integration tests in CircleCI

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -105,6 +105,7 @@
                 <configuration>
                   <dockerDirectory>solo/docker</dockerDirectory>
                   <imageName>${soloImageName}</imageName>
+                  <tagInfoFile>${project.build.testOutputDirectory}/solo-image.json</tagInfoFile>
                   <resources>
                     <resource>
                       <targetPath>/</targetPath>

--- a/solo/docker/Dockerfile
+++ b/solo/docker/Dockerfile
@@ -12,13 +12,11 @@ RUN curl -o $SKYDNS_PLUGIN_DEB -L $SKYDNS_PLUGIN_DEB_URI \
 
 # Install Go (from the official golang Dockerfile)
 ENV GOLANG_VERSION 1.3.3
-ENV PATH /go/bin:/usr/src/go/bin:$PATH
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
-RUN apt-get install -y --no-install-recommends gcc libc6-dev make
-RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
-    | tar v -C /usr/src -xz
-RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
+RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \
+    | tar -C /usr/local -xz
 RUN mkdir -p /go/src /go/bin && chmod -R 777 /go
 
 RUN apt-get install -y git mercurial


### PR DESCRIPTION
Run the integration tests in CircleCI, using helios-solo as the Helios
cluster. This gives us better test coverage and also works out helios-solo.

Also switch to using golang binary archive instead of building from source.
This speeds up the helios-solo image build a bit.