### PR TITLE
Add jq as dependency of helios-solo

### DIFF
--- a/src/deb/helios-solo/control
+++ b/src/deb/helios-solo/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: docker.io | lxc-docker, helios
+Depends: docker.io | lxc-docker, helios, jq
 Maintainer: Rohan Singh <rohan@spotify.com>
 Description: helios-solo provides a local Helios cluster running in a Docker container
 Distribution: development


### PR DESCRIPTION
It's used by `helios-use` to parse the tag list from the Docker registry.