### PR TITLE
Fix a couple more issues with the HeliosSoloIT

### DIFF
--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
@@ -114,11 +114,11 @@ public class HeliosSoloIT {
 
   public static class HeliosSoloITImpl {
 
-    private TemporaryJob nginx;
     private TemporaryJob alpine;
 
     @Rule
     public final TemporaryJobs soloTemporaryJobs = TemporaryJobs.builder()
+        .hostFilter(TEST_HOST)
         .client(soloClient)
         .prefixDirectory("/tmp/helios-solo-jobs")
         .build();
@@ -127,7 +127,7 @@ public class HeliosSoloIT {
     @Before
     public void setup() throws Exception {
       // start a container that runs nginx and registers with SkyDNS
-      nginx = soloTemporaryJobs.job()
+      soloTemporaryJobs.job()
           .image(NGINX)
           .port("http", 80, 59980)
           .registration("nginx", "http", "http")


### PR DESCRIPTION
* Get rid of an unused member variable.

* Explicitly specify the host filter for the TemporaryJobs that deploys
  to the helios-solo instance that we bring up. This is to prevent the
  host filter set by the user for deploying temporary jobs to the base
  Helios cluster from applying to our helios-solo cluster.

  For example, if a user specifies `HELIOS_HOST_FILTER=my-host`, then the
  helios-solo job itself should only be deployed to my-host. However, the
  jobs that are deployed to helios-solo should be deployed to solo.local.