### PR TITLE
Fix helios-use version listing to be crossplatform

### DIFF
--- a/solo/helios-use
+++ b/solo/helios-use
@@ -64,9 +64,14 @@ else
 
 	set +e
 	versions=$(curl -sSL https://index.docker.io/v1/repositories/$REPO/tags \
-		| jq  --exit-status --raw-output '.[].name')
+		| jq  --raw-output '.[].name')
 	versions_ok=$?
 	set -e
+
+    if [[ ! "$versions" =~ 'latest' ]]; then
+        # if "latest" isn't an available version, something went wrong
+        versions_ok=1
+    fi
 
 	if [ $versions_ok -ne 0 ]; then
 		echo 'Error fetching available versions.'


### PR DESCRIPTION
The `jq` on some systems doesn't support `--exit-status`. Instead, inspect
the return value to make sure it's got what we want.

Fixes #439.