### PR TITLE
HeliosSoloIT: Add back hostFilter pattern

### DIFF
--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
@@ -130,6 +130,7 @@ public class HeliosSoloIT {
 
     @Rule
     public final TemporaryJobs soloTemporaryJobs = TemporaryJobs.builder("local")
+        .hostFilter(TEST_HOST)
         .client(soloClient)
         .prefixDirectory("/tmp/helios-solo-jobs")
         .build();


### PR DESCRIPTION
Accidentally deleted this as part of some other changes. This is necessary
to run HeliosSoloIT against a remote Helios cluster.