### PR TITLE
solo: Update deb to provide helios-standalone

### DIFF
--- a/src/deb/helios-solo/control
+++ b/src/deb/helios-solo/control
@@ -4,6 +4,9 @@ Section: non-free/net
 Priority: optional
 Architecture: all
 Depends: docker.io | lxc-docker, helios, jq
+Provides: helios-standalone
+Conflicts: helios-standalone
+Replaces: helios-standalone
 Maintainer: Rohan Singh <rohan@spotify.com>
 Description: helios-solo provides a local Helios cluster running in a Docker container
 Distribution: development


### PR DESCRIPTION
In its prior incarnation, helios-solo was known as helios-standalone. This
"Provides" line makes it so that helios-solo is installed in case anyone
still tries to `apt-get install helios-standalone`.