### PR TITLE
More fixes for the HeliosSoloIT

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -286,12 +286,18 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.7.4</version>
+      <version>2.7.14</version>
+      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>logging</artifactId>
       <version>2.0.17</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
 
     <!--test deps-->

--- a/helios-testing-common/pom.xml
+++ b/helios-testing-common/pom.xml
@@ -74,11 +74,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.github.jnr</groupId>
-      <artifactId>jnr-posix</artifactId>
-      <version>3.0.1</version>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
* If the DOCKER_HOST is 127.0.0.1, fall back to Unix sockets instead.

* Use the latest version of docker-client, which supports checking the OS
  name directly rather than kernel version (for Boot2Docker detection).

Note that as part of the docker-client upgrade, we need to declare an
explicit dependency on commons-lang:commons-lang:2.6 to resolve a conflict
between docker-client and another package.