### PR TITLE
debian: Depend on headless versions of Java

### DIFF
--- a/src/deb/helios-agent/control
+++ b/src/deb/helios-agent/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime, helios-services (= [[version]])
+Depends: java7-runtime-headless, helios-services (= [[version]])
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios Agent
 Distribution: development

--- a/src/deb/helios-master/control
+++ b/src/deb/helios-master/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime, helios-services (= [[version]])
+Depends: java7-runtime-headless, helios-services (= [[version]])
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios Master
 Distribution: development

--- a/src/deb/helios-services/control
+++ b/src/deb/helios-services/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime
+Depends: java7-runtime-headless
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios services common files
 Distribution: development

--- a/src/deb/helios/control
+++ b/src/deb/helios/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: java7-runtime
+Depends: java7-runtime-headless
 Maintainer: Daniel Norberg <dano@spotify.com>
 Description: Helios Command Line Tools
 Distribution: development


### PR DESCRIPTION
No need to force people to install UI kits and fonts and a bunch of other
crap just to run Helios.