### PR TITLE
solo: Don't use domain from /etc/resolv.conf

### DIFF
--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -52,6 +52,7 @@ java -cp '/*' \
 -Djava.net.preferIPv4Stack=true \
 com.spotify.helios.master.MasterMain \
 --service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
+--domain '' \
 &
 
 # Sleep or execute command line


### PR DESCRIPTION
Don't use the domain from /etc/resolv.conf when starting the service
registrar in helios-solo.

This fixes an issue where having a domain present in /etc/resolv.conf
caused helios-solo to fail to start, since helios-skydns isn't capable of
creating a registrar for a specific domain.