### PR TITLE
[wip] Expose health checks to service registration plugins

### DIFF
--- a/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
+++ b/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
@@ -50,12 +50,11 @@ public class ServiceRegistration {
   public static class Builder {
 
     private List<Endpoint> endpoints = new ArrayList<>();
-
     @Deprecated
     public Builder endpoint(final String name,
                             final String protocol,
                             final int port) {
-      endpoints.add(new Endpoint(name, protocol, port, "", "", null));
+      endpoints.add(new Endpoint(name, protocol, port, "", "", null, null));
       return this;
     }
 
@@ -64,7 +63,7 @@ public class ServiceRegistration {
                             final int port,
                             final String domain,
                             final String host) {
-      endpoints.add(new Endpoint(name, protocol, port, domain, host, null));
+      endpoints.add(new Endpoint(name, protocol, port, domain, host, null, null));
       return this;
     }
 
@@ -74,13 +73,25 @@ public class ServiceRegistration {
                             final String domain,
                             final String host,
                             final List<String> tags) {
-      endpoints.add(new Endpoint(name, protocol, port, domain, host, tags));
+      endpoints.add(new Endpoint(name, protocol, port, domain, host, tags, null));
+      return this;
+    }
+
+    public Builder endpoint(final String name,
+                            final String protocol,
+                            final int port,
+                            final String domain,
+                            final String host,
+                            final List<String> tags,
+                            final EndpointHealthCheck healthCheck) {
+      endpoints.add(new Endpoint(name, protocol, port, domain, host, tags, healthCheck));
       return this;
     }
 
     public ServiceRegistration build() {
       return new ServiceRegistration(endpoints);
     }
+
   }
 
   /**
@@ -95,15 +106,18 @@ public class ServiceRegistration {
     /** The hostname on which we will advertise this service in service discovery */
     private final String host;
     private final List<String> tags;
+    private final EndpointHealthCheck healthCheck;
 
     public Endpoint(final String name, final String protocol, final int port,
-                    final String domain, final String host, final List<String> tags) {
+                    final String domain, final String host, final List<String> tags,
+                    final EndpointHealthCheck healthCheck) {
       this.name = name;
       this.protocol = protocol;
       this.port = port;
       this.domain = domain;
       this.host = host;
       this.tags = tags;
+      this.healthCheck = healthCheck;
     }
 
     public String getHost() {
@@ -130,6 +144,10 @@ public class ServiceRegistration {
       return tags;
     }
 
+    public EndpointHealthCheck getHealthCheck() {
+      return healthCheck;
+    }
+
     @Override
     public String toString() {
       return Objects.toStringHelper(this)
@@ -139,6 +157,44 @@ public class ServiceRegistration {
           .add("domain", domain)
           .add("host", host)
           .add("tags", tags)
+          .add("healthCheck", healthCheck)
+          .toString();
+    }
+  }
+
+  public static class EndpointHealthCheck {
+    public static final String HTTP = "http";
+    public static final String TCP = "tcp";
+
+    private final String type;
+    private final String path;
+
+    public EndpointHealthCheck(final String type, final String path) {
+      this.type = type;
+      this.path = path;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public static EndpointHealthCheck newHttpCheck(String path) {
+      return new EndpointHealthCheck(HTTP, path);
+    }
+
+    public static EndpointHealthCheck newTcpCheck() {
+      return new EndpointHealthCheck(TCP, null);
+    }
+
+    @Override
+    public String toString() {
+      return Objects.toStringHelper(this)
+          .add("type", type)
+          .add("path", path)
           .toString();
     }
   }

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
@@ -1,0 +1,81 @@
+package com.spotify.helios.agent;
+
+import com.spotify.helios.common.descriptors.HealthCheck;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.PortMapping;
+import com.spotify.helios.common.descriptors.ServiceEndpoint;
+import com.spotify.helios.common.descriptors.ServicePorts;
+import com.spotify.helios.serviceregistration.ServiceRegistration;
+import com.spotify.helios.serviceregistration.ServiceRegistration.EndpointHealthCheck;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TaskConfigTest {
+  private static final String HOST = "HOST";
+  private static final String IMAGE = "spotify:17";
+  private static final String PORT_NAME = "default-port";
+  private static final int EXTERNAL_PORT = 20000;
+  private static final Job JOB = Job.newBuilder()
+    .setName("foobar")
+    .setCommand(asList("foo", "bar"))
+    .setImage(IMAGE)
+    .setVersion("4711")
+    .addPort(PORT_NAME, PortMapping.of(8080, EXTERNAL_PORT))
+    .addRegistration(ServiceEndpoint.of("service", "http"), ServicePorts.of(PORT_NAME))
+    .build();
+
+  @Test
+  public void testRegistrationWithHttpHealthCheck() throws Exception {
+    final String path = "/health";
+
+    final Job job = JOB.toBuilder()
+      .setHealthCheck(HealthCheck.newHttpHealthCheck()
+        .setPath(path)
+        .setPort(PORT_NAME).build())
+      .build();
+
+    final TaskConfig taskConfig = TaskConfig.builder()
+      .namespace("test")
+      .host(HOST)
+      .job(job)
+      .build();
+
+    ServiceRegistration.Endpoint endpoint = taskConfig.registration().getEndpoints().get(0);
+    assertEquals(path, endpoint.getHealthCheck().getPath());
+    assertEquals(EndpointHealthCheck.HTTP, endpoint.getHealthCheck().getType());
+    assertEquals(EXTERNAL_PORT, endpoint.getPort());
+  }
+
+  @Test
+  public void testRegistrationWithTcpHealthCheck() throws Exception {
+    final Job job = JOB.toBuilder()
+      .setHealthCheck(HealthCheck.newTcpHealthCheck()
+        .setPort(PORT_NAME).build())
+      .build();
+
+    final TaskConfig taskConfig = TaskConfig.builder()
+      .namespace("test")
+      .host(HOST)
+      .job(job)
+      .build();
+
+    ServiceRegistration.Endpoint endpoint = taskConfig.registration().getEndpoints().get(0);
+    assertEquals(EndpointHealthCheck.TCP, endpoint.getHealthCheck().getType());
+    assertEquals(EXTERNAL_PORT, endpoint.getPort());
+  }
+
+  @Test
+  public void testRegistrationWithoutHealthCheck() throws Exception {
+    final TaskConfig taskConfig = TaskConfig.builder()
+      .namespace("test")
+      .host(HOST)
+      .job(JOB)
+      .build();
+
+    ServiceRegistration.Endpoint endpoint = taskConfig.registration().getEndpoints().get(0);
+    assertNull(endpoint.getHealthCheck());
+  }
+}


### PR DESCRIPTION
Hi!

In Consul it is possible to define service health checks:
https://www.consul.io/docs/agent/checks.html Since they are pretty similar to
the new health checking functionality in Helios I think it makes sense to
expose the health checks defined in Helios jobs to service registrar plugin.

The health checking plan looks like this:
* During deploy and app boot: Helios runs the health check
* After app boot: Consul runs the health check
* Profit!

It feels a bit strange to re-implement subsets of the job model in the
ServiceRegistration class, but I guess it also makes sense to have them that way.