### PR TITLE
Fix race condition when fetching list of jobs

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -394,9 +394,14 @@ public class ZooKeeperMasterModel implements MasterModel {
       for (final String id : ids) {
         final JobId jobId = JobId.fromString(id);
         final String path = Paths.configJob(jobId);
-        final byte[] data = client.getData(path);
-        final Job descriptor = parse(data, Job.class);
-        descriptors.put(descriptor.getId(), descriptor);
+        try {
+          final byte[] data = client.getData(path);
+          final Job descriptor = parse(data, Job.class);
+          descriptors.put(descriptor.getId(), descriptor);
+        } catch (NoNodeException e) {
+          // Ignore, the job was deleted before we had a chance to read it.
+          log.debug("Ignoring deleted job {}", jobId);
+        }
       }
       return descriptors;
     } catch (KeeperException | IOException e) {


### PR DESCRIPTION
We would first get a list of all the job nodes, then retrieve details
about each indivdual job. If a job was deleted before we read the details,
NoNodeException would be thrown, and the request would fail. We now
ignore that exception.