### PR TITLE
Bind JMX connect port, and the RMI data port, to the same port

### DIFF
--- a/bin/helios-agent
+++ b/bin/helios-agent
@@ -29,6 +29,7 @@ fi
 if [ $JMXPORT ]; then
     args=("${args[@]}"
           -Dcom.sun.management.jmxremote.port=$JMXPORT
+          -Dcom.sun.management.jmxremote.rmi.port=$JMXPORT
           -Dcom.sun.management.jmxremote.ssl=false
           -Dcom.sun.management.jmxremote.authenticate=false )
 fi

--- a/bin/helios-master
+++ b/bin/helios-master
@@ -29,6 +29,7 @@ fi
 if [ $JMXPORT ]; then
     args=("${args[@]}"
           -Dcom.sun.management.jmxremote.port=$JMXPORT
+          -Dcom.sun.management.jmxremote.rmi.port=$JMXPORT
           -Dcom.sun.management.jmxremote.ssl=false
           -Dcom.sun.management.jmxremote.authenticate=false )
 fi


### PR DESCRIPTION
This commit makes the process of firewalling JMX access much easier.
Also, SSH tunneling becomes much simpler to do.

See http://realjenius.com/2012/11/21/java7-jmx-tunneling-freedom/ for
more details.

http://www.accuvant.com/blog/exploiting-jmx-rmi explains how to get RCE
with JMX RMI.

Related upstream bugs (and RFEs),

http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6425769
https://bugzilla.redhat.com/show_bug.cgi?id=1183014
https://bugs.openjdk.java.net/browse/JDK-6425769