### PR TITLE
Implement docker exec healthchecks.

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -37,6 +37,7 @@ import com.spotify.helios.common.descriptors.TcpHealthCheck;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -384,7 +385,8 @@ public class JobValidator {
     final Set<String> errors = Sets.newHashSet();
 
     if (healthCheck instanceof ExecHealthCheck) {
-      if (isNullOrEmpty(((ExecHealthCheck) healthCheck).getCommand())) {
+      final List<String> command = ((ExecHealthCheck) healthCheck).getCommand();
+      if (command == null || command.isEmpty()) {
         errors.add("A command must be defined for `docker exec`-based health checks.");
       }
     } else if (healthCheck instanceof HttpHealthCheck || healthCheck instanceof TcpHealthCheck) {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ExecHealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ExecHealthCheck.java
@@ -25,13 +25,14 @@ import com.google.common.base.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import java.util.Arrays;
+import java.util.List;
 
 public class ExecHealthCheck extends HealthCheck {
 
-  private final String command;
+  private final List<String> command;
 
-  public ExecHealthCheck(@JsonProperty("command") final String command) {
+  public ExecHealthCheck(@JsonProperty("command") final List<String> command) {
     super(EXEC);
     this.command = command;
   }
@@ -41,12 +42,12 @@ public class ExecHealthCheck extends HealthCheck {
     command = builder.command;
   }
 
-  public String getCommand() {
+  public List<String> getCommand() {
     return command;
   }
 
-  public static ExecHealthCheck of(final String command) {
-    return newBuilder().setCommand(command).build();
+  public static ExecHealthCheck of(final String... command) {
+    return newBuilder().setCommand(Arrays.asList(command)).build();
   }
 
   @Override
@@ -86,19 +87,19 @@ public class ExecHealthCheck extends HealthCheck {
 
   public static class Builder {
 
-    private String command;
+    private List<String> command;
 
-    public String getCommand() {
+    public List<String> getCommand() {
       return command;
     }
 
-    public Builder setCommand(final String command) {
+    public Builder setCommand(final List<String> command) {
       this.command = command;
       return this;
     }
 
     public ExecHealthCheck build() {
-      if (isNullOrEmpty(command)) {
+      if (command == null || command.isEmpty()) {
         throw new IllegalArgumentException("You must specify a command for an exec health check.");
       }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HealthCheck.java
@@ -54,7 +54,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <pre>
  * {
  *   "type" : "exec",
- *   "command" : "bash -c '/usr/bin/curl 127.0.0.1:9200/_cluster/health?pretty=true | grep green'"
+ *   "command" : ["bash", "-c", "/usr/bin/curl 127.0.0.1:9200/_cluster/health | grep green"]
  * }
  * </pre>
  */

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/HealthCheckTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/HealthCheckTest.java
@@ -21,7 +21,11 @@
 
 package com.spotify.helios.common.descriptors;
 
+import com.google.common.collect.ImmutableList;
+
 import org.junit.Test;
+
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -73,8 +77,8 @@ public class HealthCheckTest {
   @Test
   public void testExecHealthCheckBuilder() {
     final ExecHealthCheck healthCheck = HealthCheck.newExecHealthCheck()
-        .setCommand("whoami").build();
-    assertEquals("cmd", "whoami", healthCheck.getCommand());
+        .setCommand(Collections.singletonList("whoami")).build();
+    assertEquals("cmd", healthCheck.getCommand(), ImmutableList.of("whoami"));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -286,7 +286,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.7.16</version>
+      <version>2.7.22</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>

--- a/helios-services/src/test/java/com/spotify/helios/agent/ExecHealthCheckerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/ExecHealthCheckerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.DockerClient.ExecParameter;
+import com.spotify.docker.client.DockerClient.ExecStartParameter;
+import com.spotify.docker.client.LogStream;
+import com.spotify.docker.client.messages.ExecState;
+import com.spotify.docker.client.messages.Info;
+import com.spotify.docker.client.messages.Version;
+import com.spotify.helios.agent.HealthCheckerFactory.ExecHealthChecker;
+import com.spotify.helios.common.descriptors.ExecHealthCheck;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExecHealthCheckerTest {
+
+  private static final String CONTAINER_ID = "abc123def";
+  private static final String EXEC_ID = "5678";
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  private ExecHealthCheck healthCheck;
+  private DockerClient docker;
+  private ExecHealthChecker checker;
+
+  @Before
+  public void setUp() throws Exception {
+    healthCheck = ExecHealthCheck.of("exit 0");
+
+    final Info info = mock(Info.class);
+    when(info.executionDriver()).thenReturn("native-0.2");
+
+    final Version version = mock(Version.class);
+    when(version.apiVersion()).thenReturn("1.18");
+
+    final ExecState execState = mock(ExecState.class);
+    when(execState.exitCode()).thenReturn(0);
+
+    final LogStream log = mock(LogStream.class);
+    when(log.readFully()).thenReturn("");
+
+    docker = mock(DockerClient.class);
+    when(docker.info()).thenReturn(info);
+    when(docker.version()).thenReturn(version);
+    when(docker.execCreate(eq(CONTAINER_ID), any(String[].class), (ExecParameter) anyVararg()))
+        .thenReturn(EXEC_ID);
+    when(docker.execStart(eq(EXEC_ID), (ExecStartParameter) anyVararg())).thenReturn(log);
+    when(docker.execInspect(EXEC_ID)).thenReturn(execState);
+
+    checker = new ExecHealthChecker(healthCheck, docker);
+  }
+
+  @Test
+  public void testHealthCheckSuccess() {
+    assertThat(checker.check(CONTAINER_ID), is(true));
+  }
+
+  @Test
+  public void testHealthCheckFailure() throws Exception {
+    final ExecState execState = mock(ExecState.class);
+    when(execState.exitCode()).thenReturn(2);
+    when(docker.execInspect(EXEC_ID)).thenReturn(execState);
+
+    assertThat(checker.check(CONTAINER_ID), is(false));
+  }
+
+  @Test
+  public void testIncompatibleVersion() throws Exception {
+    final Version version = mock(Version.class);
+    when(version.apiVersion()).thenReturn("1.15");
+    when(docker.version()).thenReturn(version);
+
+    exception.expect(UnsupportedOperationException.class);
+    checker.check(CONTAINER_ID);
+  }
+
+  @Test
+  public void testNotNativeDriver() throws Exception {
+    final Info info = mock(Info.class);
+    when(info.executionDriver()).thenReturn("lxc");
+    when(docker.info()).thenReturn(info);
+
+    exception.expect(UnsupportedOperationException.class);
+    checker.check(CONTAINER_ID);
+  }
+
+}

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/HealthCheckTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/HealthCheckTest.java
@@ -21,11 +21,14 @@
 
 package com.spotify.helios.system;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 
+import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.MockServiceRegistrarRegistry;
 import com.spotify.helios.Polling;
 import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.ExecHealthCheck;
 import com.spotify.helios.common.descriptors.HealthCheck;
 import com.spotify.helios.common.descriptors.HttpHealthCheck;
 import com.spotify.helios.common.descriptors.Job;
@@ -41,6 +44,8 @@ import com.spotify.helios.common.protocol.TaskStatusEvents;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
 
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +57,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -62,7 +68,9 @@ import static com.spotify.helios.common.descriptors.TaskStatus.State.RUNNING;
 import static com.spotify.helios.serviceregistration.ServiceRegistration.Endpoint;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -214,6 +222,82 @@ public class HealthCheckTest extends ServiceRegistrationTestBase {
 
     assertEquals("wrong service", "foo_service", registered.get("foo_service").getName());
     assertEquals("wrong protocol", "foo_proto", registered.get("foo_service").getProtocol());
+  }
+
+  @Test
+  public void testExec() throws Exception {
+    final DockerClient dockerClient = getNewDockerClient();
+    assumeThat(dockerClient, is(execCompatibleDockerVersion()));
+
+    startDefaultMaster();
+
+    final HeliosClient client = defaultClient();
+
+    startDefaultAgent(testHost(), "--service-registry=" + registryAddress);
+    awaitHostStatus(client, testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+    // check if "file" exists in the root directory as a healthcheck
+    final HealthCheck healthCheck = ExecHealthCheck.of("test", "-e", "file");
+
+    // start a container that listens on the service port
+    final String portName = "service";
+    final String serviceName = "foo_service";
+    final String serviceProtocol = "foo_proto";
+    final Job job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(asList("sh", "-c", "nc -l -p 4711"))
+        .addPort(portName, PortMapping.of(4711))
+        .addRegistration(ServiceEndpoint.of(serviceName, serviceProtocol),
+                         ServicePorts.of(portName))
+        .setHealthCheck(healthCheck)
+        .build();
+
+    final JobId jobId = createJob(job);
+    deployJob(jobId, testHost());
+    final TaskStatus jobState = awaitTaskState(jobId, testHost(), HEALTHCHECKING);
+
+    // wait a few seconds to see if the service gets registered
+    Thread.sleep(3000);
+    // shouldn't be registered, since we haven't created the file yet
+    verify(registrar, never()).register(any(ServiceRegistration.class));
+
+    // create the file in the container to make the healthcheck succeed
+    final String[] makeFileCmd = new String[]{"touch", "file"};
+    final String execId = dockerClient.execCreate(jobState.getContainerId(), makeFileCmd);
+    dockerClient.execStart(execId);
+
+    awaitTaskState(jobId, testHost(), RUNNING);
+    dockerClient.close();
+
+    verify(registrar, timeout((int) SECONDS.toMillis(LONG_WAIT_SECONDS)))
+        .register(registrationCaptor.capture());
+    final ServiceRegistration serviceRegistration = registrationCaptor.getValue();
+
+    assertEquals(1, serviceRegistration.getEndpoints().size());
+    final Endpoint registeredEndpoint = serviceRegistration.getEndpoints().get(0);
+
+    assertEquals("wrong service", serviceName, registeredEndpoint.getName());
+    assertEquals("wrong protocol", serviceProtocol, registeredEndpoint.getProtocol());
+  }
+
+  private static Matcher<DockerClient> execCompatibleDockerVersion() {
+    return new CustomTypeSafeMatcher<DockerClient>("docker version") {
+      @Override
+      protected boolean matchesSafely(final DockerClient client) {
+        try {
+          final String driver = client.info().executionDriver();
+          final Iterator<String> version =
+              Splitter.on('.').split(client.version().apiVersion()).iterator();
+          final int apiVersionMajor = Integer.parseInt(version.next());
+          final int apiVersionMinor = Integer.parseInt(version.next());
+          return driver.startsWith("native") && apiVersionMajor == 1 && apiVersionMinor >= 18;
+        } catch (Exception e) {
+          return false;
+        }
+      }
+    };
   }
 
   @Test

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -21,19 +21,21 @@
 
 package com.spotify.helios.system;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.google.common.io.Files;
 import com.google.common.util.concurrent.FutureFallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.spotify.docker.client.ContainerNotFoundException;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificates;
@@ -59,9 +61,7 @@ import com.spotify.helios.cli.CliMain;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.Deployment;
-import com.spotify.helios.common.descriptors.ExecHealthCheck;
 import com.spotify.helios.common.descriptors.HostStatus;
-import com.spotify.helios.common.descriptors.HttpHealthCheck;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
@@ -69,7 +69,6 @@ import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.common.descriptors.ServiceEndpoint;
 import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.common.descriptors.TaskStatus;
-import com.spotify.helios.common.descriptors.TcpHealthCheck;
 import com.spotify.helios.common.descriptors.ThrottleState;
 import com.spotify.helios.common.protocol.JobDeleteResponse;
 import com.spotify.helios.common.protocol.JobUndeployResponse;
@@ -92,6 +91,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.Socket;
@@ -124,7 +124,6 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_VOLUMES;
 import static java.lang.Integer.toHexString;
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -693,64 +692,13 @@ public abstract class SystemTestBase {
 
   protected JobId createJob(final Job job) throws Exception {
     final String name = job.getId().getName();
-    final String version = job.getId().getVersion();
     checkArgument(name.contains(testTag), "Job name must contain testTag to enable cleanup");
 
-    final List<String> args = Lists.newArrayList("-q", name + ':' + version, job.getImage());
+    final String serializedConfig = Json.asNormalizedString(job);
+    final File configFile = temporaryFolder.newFile();
+    Files.write(serializedConfig, configFile, Charsets.UTF_8);
 
-    for (Map.Entry<String, String> entry : job.getEnv().entrySet()) {
-      args.add("--env=" + entry.getKey() + "=" + entry.getValue());
-    }
-
-    for (final Map.Entry<String, PortMapping> entry : job.getPorts().entrySet()) {
-      args.add("--port");
-      String value = "" + entry.getValue().getInternalPort();
-      if (entry.getValue().getExternalPort() != null) {
-        value += ":" + entry.getValue().getExternalPort();
-      }
-      if (entry.getValue().getProtocol() != null) {
-        value += "/" + entry.getValue().getProtocol();
-      }
-      args.add(entry.getKey() + "=" + value);
-    }
-
-    for (final Map.Entry<ServiceEndpoint, ServicePorts> entry : job.getRegistration().entrySet()) {
-      final ServiceEndpoint r = entry.getKey();
-      for (String portName : entry.getValue().getPorts().keySet()) {
-          args.add("--register=" + ((r.getProtocol() == null)
-                                    ? format("%s=%s", r.getName(), portName)
-                                    : format("%s/%s=%s", r.getName(), r.getProtocol(), portName)));
-        }
-    }
-
-    for (Map.Entry<String, String> entry : job.getVolumes().entrySet()) {
-      if (isNullOrEmpty(entry.getKey())) {
-        // Data volume
-        args.add("--volume=" + entry.getKey());
-      } else {
-        // Bind mount
-        args.add("--volume=" + entry.getValue() + ":" + entry.getKey());
-      }
-    }
-
-    if (job.getExpires() != null) {
-      args.add("--expires=" + ISO8601Utils.format(job.getExpires()));
-    }
-
-    if (job.getHealthCheck() != null) {
-      if (job.getHealthCheck() instanceof ExecHealthCheck) {
-        args.add("--exec-check=" + ((ExecHealthCheck) job.getHealthCheck()).getCommand());
-      } else if (job.getHealthCheck() instanceof HttpHealthCheck) {
-        final HttpHealthCheck httpHealthCheck = (HttpHealthCheck) job.getHealthCheck();
-        args.add("--http-check=" + httpHealthCheck.getPort() + ":" + httpHealthCheck.getPath());
-      } else if (job.getHealthCheck() instanceof TcpHealthCheck) {
-        args.add("--tcp-check=" + ((TcpHealthCheck) job.getHealthCheck()).getPort());
-      }
-    }
-
-    args.add("--");
-    args.addAll(job.getCommand());
-
+    final List<String> args = ImmutableList.of("-q", "-f", configFile.getAbsolutePath());
     final String createOutput = cli("create", args);
     final String jobId = WHITESPACE.trimFrom(createOutput);
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -179,9 +179,8 @@ public class JobCreateCommand extends ControlCommand {
 
     healthCheckExecArg = parser.addArgument("--exec-check")
         .help("Run `docker exec` health check with the provided command. The service will not be " +
-              "registered in service discovery until the command executes successfully. " +
-              "E.g. --exec-check 'bash -c \"/usr/bin/curl " +
-              "127.0.0.1:9200/_cluster/health?pretty=true | grep green\"'");
+              "registered in service discovery until the command executes successfully in the " +
+              "container. E.g. --exec-check=/usr/locale/bin/myhealthcheck");
 
     healthCheckHttpArg = parser.addArgument("--http-check")
         .help("Run HTTP health check against the provided port name and path. The service will " +


### PR DESCRIPTION
* Only run exec healthcheck IT on compatible docker versions.
* Make the exec healthcheck command a list.
* Simplify system test by storing job config in a file.
* Don't allow multi-command exec healthchecks in CLI.