### PR TITLE
Fail job creation if job config file doesn't exist

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -224,8 +224,8 @@ public class JobCreateCommand extends ControlCommand {
       throw new IllegalArgumentException("Please use only one of -t/--template and -f/--file");
     }
 
-    if (file != null && file.exists()) {
-      if (!file.isFile() || !file.canRead()) {
+    if (file != null) {
+      if (!file.exists() || !file.isFile() || !file.canRead()) {
         throw new IllegalArgumentException("Cannot read file " + file);
       }
       final byte[] bytes = Files.readAllBytes(file.toPath());

--- a/helios-tools/src/main/resources/job_config.json
+++ b/helios-tools/src/main/resources/job_config.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "JVM_ARGS": "-Ddw.feature.randomFeatureFlagEnabled=true"
+  },
+  "gracePeriod": 100
+}


### PR DESCRIPTION
Fail fast so users that fat-finger this don't waste time
debugging.

Fixes #489