### PR TITLE
TemporaryJobs: Add instrumentation (test reports)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 target/
 pom.xml.versionsBackup
 docker/tmp/
+helios-test-reports/
 
 # Stuff from various IDE's and editors
 *.iml

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Deployer.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Deployer.java
@@ -28,9 +28,11 @@ import java.util.Set;
 
 public interface Deployer {
 
-  TemporaryJob deploy(Job job, List<String> hosts, Set<String> waitPorts, Prober prober);
+  TemporaryJob deploy(Job job, List<String> hosts, Set<String> waitPorts, Prober prober,
+                      TemporaryJobReports.ReportWriter reportWriter);
 
-  TemporaryJob deploy(Job job, String hostFilter, Set<String> waitPorts, Prober prober);
+  TemporaryJob deploy(Job job, String hostFilter, Set<String> waitPorts, Prober prober,
+                      TemporaryJobReports.ReportWriter reportWriter);
 
   void readyToDeploy();
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -69,13 +69,15 @@ public class TemporaryJobBuilder {
   private final Deployer deployer;
   private final String jobNamePrefix;
   private final Map<String, String> env;
+  private final TemporaryJobReports.ReportWriter reportWriter;
   
   private String hostFilter;
   private Prober prober;
   private TemporaryJob job;
 
   public TemporaryJobBuilder(final Deployer deployer, final String jobNamePrefix,
-                             final Prober defaultProber, final Map<String, String> env) {
+                             final Prober defaultProber, final Map<String, String> env,
+                             final TemporaryJobReports.ReportWriter reportWriter) {
     checkNotNull(deployer, "deployer");
     checkNotNull(jobNamePrefix, "jobNamePrefix");
     checkNotNull(defaultProber, "defaultProber");
@@ -84,6 +86,7 @@ public class TemporaryJobBuilder {
     this.prober = defaultProber;
     this.builder.setRegistrationDomain(jobNamePrefix);
     this.env = env;
+    this.reportWriter = reportWriter;
   }
 
   public TemporaryJobBuilder name(final String jobName) {
@@ -279,14 +282,15 @@ public class TemporaryJobBuilder {
         waitPorts.clear();
       }
 
+      boolean success = false;
       if (this.hosts.isEmpty()) {
         if (isNullOrEmpty(hostFilter)) {
           hostFilter = env.get("HELIOS_HOST_FILTER");
         }
 
-        job = deployer.deploy(builder.build(), hostFilter, waitPorts, prober);
+        job = deployer.deploy(builder.build(), hostFilter, waitPorts, prober, reportWriter);
       } else {
-        job = deployer.deploy(builder.build(), this.hosts, waitPorts, prober);
+        job = deployer.deploy(builder.build(), this.hosts, waitPorts, prober, reportWriter);
       }
     }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobReports.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobReports.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.google.common.collect.Maps;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.testing.descriptors.TemporaryJobEvent;
+
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * Reports a stream of TemporaryJobEvent events to a JSON file.
+ */
+public class TemporaryJobReports {
+  private static final Logger log = LoggerFactory.getLogger(TemporaryJobReports.class);
+
+  private final Path outputDir;
+
+  TemporaryJobReports(final Path outputDir) {
+    this.outputDir = outputDir;
+    this.outputDir.toFile().mkdirs();
+  }
+
+  public ReportWriter getWriterForTest(final Description testDescription) throws IOException {
+    return new ReportWriter(outputDir, testDescription.getClassName(),
+                            testDescription.getMethodName());
+  }
+
+  public static class ReportWriter implements Closeable {
+
+    private final JsonGenerator jg;
+
+    private final String testClassName;
+    private final String testName;
+
+    private ReportWriter(final Path outputDir, final String testClassName, final String testName)
+      throws IOException {
+      this.testClassName = testClassName;
+      this.testName = testName;
+
+      final String logFilename = format("%s.%s.json", testClassName, testName).replace('$', '_');
+      final File logFile = outputDir.resolve(logFilename).toFile();
+
+      jg = new JsonFactory().createGenerator(logFile, JsonEncoding.UTF8);
+      jg.writeStartArray();
+    }
+
+    public Step step(final String step) {
+      return new Step(this, step);
+    }
+
+    private void writeEvent(final String step, final double timestamp, final double duration,
+                            final Boolean success, final Map<String, Object> tags) {
+      final TemporaryJobEvent event = new TemporaryJobEvent(
+          timestamp,
+          duration,
+          testClassName,
+          testName,
+          step,
+          success,
+          tags
+      );
+
+      writeEvent(event);
+    }
+
+    private void writeEvent(final TemporaryJobEvent event) {
+      try {
+        Json.writer().writeValue(jg, event);
+      } catch (IOException e) {
+        log.error("exception writing event to log: {} - {}", event, e);
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      jg.close();
+    }
+
+  }
+
+  public static class Step {
+
+    private final ReportWriter reportWriter;
+    private final String step;
+    private final long timestampMillis;
+    private final Map<String, Object> tags;
+
+    private boolean success = false;
+
+    Step(final ReportWriter reportWriter, final String step) {
+      this.reportWriter = reportWriter;
+      this.step = step;
+      this.timestampMillis = System.currentTimeMillis();
+      this.tags = Maps.newHashMap();
+    }
+
+    public Step tag(final String key, final Object value) {
+      tags.put(key, value);
+      return this;
+    }
+
+    public Step markSuccess() {
+      this.success = true;
+      return this;
+    }
+
+    public void finish() {
+      final long durationMillis = System.currentTimeMillis() -  timestampMillis;
+      final double timestamp = timestampMillis / 1000.;
+      final double duration = durationMillis / 1000.;
+
+      reportWriter.writeEvent(step, timestamp, duration, success, tags);
+    }
+  }
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/descriptors/TemporaryJobEvent.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/descriptors/TemporaryJobEvent.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing.descriptors;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Represents an event that will be collected for logging purposes.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonPropertyOrder({"step", "timestamp", "duration", "success", "testClassName", "testName"})
+public class TemporaryJobEvent {
+  private final double timestamp;
+  private final double duration;
+  private final String testClassName;
+  private final String testName;
+  private final String step;
+  private final Boolean success;
+  private final Map<String, Object> tags;
+
+  public TemporaryJobEvent(@JsonProperty("timestamp") final double timestamp,
+                           @JsonProperty("duration") final double duration,
+                           @JsonProperty("testClassName") final String testClassName,
+                           @JsonProperty("testName") final String testName,
+                           @JsonProperty("step") final String step,
+                           @Nullable @JsonProperty("success") final Boolean success,
+                           @Nullable @JsonProperty("tags") final Map<String, Object> tags) {
+    this.timestamp = timestamp;
+    this.duration = duration;
+    this.testClassName = testClassName;
+    this.testName = testName;
+    this.step = step;
+    this.success = success;
+
+    if (tags != null) {
+      this.tags = ImmutableMap.copyOf(tags);
+    } else {
+      this.tags = ImmutableMap.of();
+    }
+  }
+
+  public double getDuration() {
+    return duration;
+  }
+
+  public double getTimestamp() {
+    return timestamp;
+  }
+
+  public String getTestClassName() {
+    return testClassName;
+  }
+
+  public String getTestName() {
+    return testName;
+  }
+
+  public String getStep() {
+    return step;
+  }
+
+  public Boolean isSuccess() {
+    return success;
+  }
+
+  public Map<String, Object> getTags() {
+    return tags;
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("timestamp", timestamp)
+        .add("duration", duration)
+        .add("testClassName", testClassName)
+        .add("testName", testName)
+        .add("step", step)
+        .add("success", success)
+        .add("tags", tags)
+        .toString();
+  }
+}

--- a/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
@@ -91,7 +91,8 @@ public class ConfigTest {
     }
 
     @Override
-    public TemporaryJob deploy(Job job, List<String> hosts, Set<String> waitPorts, Prober prober) {
+    public TemporaryJob deploy(Job job, List<String> hosts, Set<String> waitPorts, Prober prober,
+                               TemporaryJobReports.ReportWriter reportWriter) {
       // This is called when the first job is deployed
       assertThat(hosts, equalTo((List<String>) newArrayList("test-host")));
       parameters.validate(job, temporaryJobs.prefix());
@@ -99,7 +100,8 @@ public class ConfigTest {
     }
 
     @Override
-    public TemporaryJob deploy(Job job, String hostFilter, Set<String> waitPorts, Prober prober) {
+    public TemporaryJob deploy(Job job, String hostFilter, Set<String> waitPorts, Prober prober,
+                               TemporaryJobReports.ReportWriter reportWriter) {
       // This is called when the second job is deployed
       assertThat(hostFilter, equalTo(parameters.hostFilter));
       parameters.validate(job, temporaryJobs.prefix());

--- a/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
@@ -23,16 +23,22 @@ package com.spotify.helios.testing;
 
 import com.google.common.base.Optional;
 
+import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
+import com.spotify.helios.testing.descriptors.TemporaryJobEvent;
 
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.net.Socket;
+import java.nio.file.Files;
 import java.util.Map;
 
 import static com.google.common.base.Charsets.UTF_8;
@@ -42,6 +48,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -50,11 +57,27 @@ import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 
 public class SimpleTest extends TemporaryJobsTestBase {
 
+  @ClassRule
+  public static final TemporaryFolder reportDir = new TemporaryFolder();
+
   @Test
   public void simpleTest() throws Exception {
     assertThat(testResult(SimpleTestImpl.class), isSuccessful());
     assertTrue("jobs are running that should not be",
                client.jobs().get(15, SECONDS).isEmpty());
+
+    // Ensure test reports were written and everything was successful
+    final File[] reportFiles = reportDir.getRoot().listFiles();
+    assertNotEquals(reportFiles.length, 0);
+
+    for (File reportFile : reportFiles) {
+      final byte[] testReport = Files.readAllBytes(reportFile.toPath());
+      final TemporaryJobEvent[] events = Json.read(testReport, TemporaryJobEvent[].class);
+
+      for (final TemporaryJobEvent event : events) {
+        assertTrue(event.isSuccess());
+      }
+    }
   }
 
   public static class SimpleTestImpl {
@@ -67,6 +90,7 @@ public class SimpleTest extends TemporaryJobsTestBase {
             "Logs Link: http://${host}:8150/${name}%3A${version}%3A${hash}?cid=${containerId}")
         .jobPrefix(Optional.of(testTag).get())
         .deployTimeoutMillis(MINUTES.toMillis(3))
+        .testReportDirectory(reportDir.getRoot().getAbsolutePath())
         .build();
 
     private TemporaryJob job1;

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TempJobFailureTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TempJobFailureTest.java
@@ -23,15 +23,27 @@ package com.spotify.helios.testing;
 
 import com.google.common.base.Optional;
 
+import com.spotify.helios.common.Json;
+import com.spotify.helios.testing.descriptors.TemporaryJobEvent;
+
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;
 
 public class TempJobFailureTest extends TemporaryJobsTestBase {
+
+  @ClassRule
+  public static final TemporaryFolder reportDir = new TemporaryFolder();
 
   @Test
   public void testDeploymentFailure() throws Exception {
@@ -41,6 +53,15 @@ public class TempJobFailureTest extends TemporaryJobsTestBase {
                hasSingleFailureContaining("AssertionError: Unexpected job state"));
     final long end = System.currentTimeMillis();
     assertTrue("Test should not time out", (end-start) < Jobs.TIMEOUT_MILLIS);
+
+    final byte[] testReport = Files.readAllBytes(reportDir.getRoot().listFiles()[0].toPath());
+    final TemporaryJobEvent[] events = Json.read(testReport, TemporaryJobEvent[].class);
+
+    for (final TemporaryJobEvent event : events) {
+      if (event.getStep().equals("test")) {
+        assertFalse("test should be reported as failed", event.isSuccess());
+      }
+    }
   }
 
   public static class TempJobFailureTestImpl {
@@ -50,6 +71,7 @@ public class TempJobFailureTest extends TemporaryJobsTestBase {
         .hostFilter(".*")
         .client(client)
         .prober(new TestProber())
+        .testReportDirectory(reportDir.getRoot().getAbsolutePath())
         .prefixDirectory(prefixDirectory.toString())
         .jobPrefix(Optional.of(testTag).get())
         .build();


### PR DESCRIPTION
Instrument the following steps:

* determine hosts
* create job
* deploy job
* start container
* probe
* undeploy

The timing and duration of these steps will be output to JSON log files in
the helios-test-reports directory by default.