### PR TITLE
TemporaryJobs: Change the test report output dir

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -87,7 +87,7 @@ public class TemporaryJobs implements TestRule {
   private static final Prober DEFAULT_PROBER = new DefaultProber();
   private static final String DEFAULT_LOCAL_HOST_FILTER = ".+";
   private static final String DEFAULT_PREFIX_DIRECTORY = "/tmp/helios-temp-jobs";
-  private static final String DEFAULT_TEST_REPORT_DIRECTORY = "./helios-test-reports";
+  private static final String DEFAULT_TEST_REPORT_DIRECTORY = "./helios-reports/test";
   private static final long JOB_HEALTH_CHECK_INTERVAL_MILLIS = SECONDS.toMillis(5);
   private static final long DEFAULT_DEPLOY_TIMEOUT_MILLIS = MINUTES.toMillis(10);
 


### PR DESCRIPTION
Instead of helios-test-reports/ use helios-reports/test/

We will also have other subdirs like helios-reports/deploy/ so this lets us
collect everything in one place.