### PR TITLE
Implement labels for agents

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -160,6 +160,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>helios-tools</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.8</version>
@@ -304,12 +309,6 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>helios-testing-common</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.spotify</groupId>
-      <artifactId>helios-tools</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -61,6 +61,7 @@ public class AgentConfig extends Configuration {
   private boolean noHttp;
   private List<String> binds;
   private List<String> kafkaBrokers;
+  private Map<String, String> labels;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -288,6 +289,15 @@ public class AgentConfig extends Configuration {
 
   public AgentConfig setKafkaBrokers(List<String> kafkaBrokers) {
     this.kafkaBrokers = kafkaBrokers;
+    return this;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  public AgentConfig setLabels(Map<String, String> labels) {
+    this.labels = labels;
     return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -103,6 +103,7 @@ public class AgentService extends AbstractIdleService implements Managed {
   private final HostInfoReporter hostInfoReporter;
   private final AgentInfoReporter agentInfoReporter;
   private final EnvironmentVariableReporter environmentVariableReporter;
+  private final LabelReporter labelReporter;
   private final FileChannel stateLockFile;
   private final FileLock stateLock;
   private final ZooKeeperAgentModel model;
@@ -241,6 +242,9 @@ public class AgentService extends AbstractIdleService implements Managed {
                                                                        config.getEnvVars(),
                                                                        nodeUpdaterFactory);
 
+    this.labelReporter = new LabelReporter(config.getName(), config.getLabels(),
+        nodeUpdaterFactory);
+
     final String namespace = "helios-" + id;
 
     final List<ContainerDecorator> decorators = Lists.newArrayList();
@@ -340,6 +344,7 @@ public class AgentService extends AbstractIdleService implements Managed {
     hostInfoReporter.startAsync();
     agentInfoReporter.startAsync();
     environmentVariableReporter.startAsync();
+    labelReporter.startAsync();
     metrics.start();
     if (server != null) {
       try {
@@ -367,6 +372,7 @@ public class AgentService extends AbstractIdleService implements Managed {
     hostInfoReporter.stopAsync().awaitTerminated();
     agentInfoReporter.stopAsync().awaitTerminated();
     environmentVariableReporter.stopAsync().awaitTerminated();
+    labelReporter.stopAsync().awaitTerminated();
     agent.stopAsync().awaitTerminated();
 
     if (serviceRegistrar != null) {

--- a/helios-services/src/main/java/com/spotify/helios/agent/LabelReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/LabelReporter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.spotify.helios.common.Json;
+import com.spotify.helios.servicescommon.coordination.NodeUpdaterFactory;
+import com.spotify.helios.servicescommon.coordination.Paths;
+import com.spotify.helios.servicescommon.coordination.ZooKeeperNodeUpdater;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Puts the labels the agent has been assigned into ZK so they can be
+ * visible to the master and via the API.
+ */
+public class LabelReporter extends InterruptingScheduledService {
+
+  private static final int RETRY_INTERVAL_MILLIS = 1000;
+
+  private final Map<String, String> labels;
+  private final ZooKeeperNodeUpdater nodeUpdater;
+
+  public LabelReporter(final String host, final Map<String, String> labels,
+                       final NodeUpdaterFactory nodeUpdaterFactory) {
+    this.labels = labels;
+    this.nodeUpdater = nodeUpdaterFactory.create(Paths.statusHostLabels(host));
+  }
+
+
+  @Override
+  protected void runOneIteration() {
+    final boolean succesful = nodeUpdater.update(Json.asBytesUnchecked(labels));
+    if (succesful) {
+      stopAsync();
+    }
+  }
+
+  @Override
+  protected ScheduledFuture<?> schedule(final Runnable runnable,
+                                        final ScheduledExecutorService executorService) {
+    return executorService.scheduleWithFixedDelay(runnable, 0, RETRY_INTERVAL_MILLIS, MILLISECONDS);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -774,6 +774,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     final Map<JobId, Deployment> tasks = getTasks(client, host);
     final Map<JobId, TaskStatus> statuses = getTaskStatuses(client, host);
     final Map<String, String> environment = getEnvironment(client, host);
+    final Map<String, String> labels = getLabels(client, host);
 
     return HostStatus.newBuilder()
         .setJobs(tasks)
@@ -782,6 +783,7 @@ public class ZooKeeperMasterModel implements MasterModel {
         .setAgentInfo(agentInfo)
         .setStatus(up ? UP : DOWN)
         .setEnvironment(environment)
+        .setLabels(labels)
         .build();
   }
 
@@ -799,6 +801,10 @@ public class ZooKeeperMasterModel implements MasterModel {
 
   private Map<String, String> getEnvironment(final ZooKeeperClient client, final String host) {
     return tryGetEntity(client, Paths.statusHostEnvVars(host), STRING_MAP_TYPE, "environment");
+  }
+
+  private Map<String, String> getLabels(final ZooKeeperClient client, final String host) {
+    return tryGetEntity(client, Paths.statusHostLabels(host), STRING_MAP_TYPE, "labels");
   }
 
   private AgentInfo getAgentInfo(final ZooKeeperClient client, final String host) {

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
@@ -40,6 +40,7 @@ public class Paths {
   private static final String AGENTINFO = "agentinfo";
   private static final String PORTS = "ports";
   private static final String ENVIRONMENT = "environment";
+  private static final String LABELS = "labels";
   private static final String ID = "id";
 
   private static final PathFactory CONFIG_ID = new PathFactory("/", CONFIG, ID);
@@ -172,6 +173,10 @@ public class Paths {
 
   public static String statusHostEnvVars(final String host) {
     return STATUS_HOSTS.path(host, ENVIRONMENT);
+  }
+
+  public static String statusHostLabels(final String host) {
+    return STATUS_HOSTS.path(host, LABELS);
   }
 
   public static String historyJobHostEventsTimestamp(final JobId jobId,

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.system;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.spotify.helios.Polling;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.HostStatus;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class LabelTest extends SystemTestBase {
+
+  @Test
+  public void testHostStatus() throws Exception {
+    startDefaultMaster();
+    startDefaultAgent(testHost(), "--labels", "role=foo", "xyz=123");
+    awaitHostStatus(testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+    // Wait for the agent to report labels
+    final Map<String, String> labels = Polling.await(LONG_WAIT_SECONDS, SECONDS,
+       new Callable<Map<String, String>>() {
+         @Override
+         public Map<String, String> call()
+             throws Exception {
+           Map<String, HostStatus> status = Json.read(
+               cli("hosts", testHost(), "--json"),
+               new TypeReference<Map<String, HostStatus>>() {
+               });
+           final Map<String, String>
+               labels =
+               status.get(testHost()).getLabels();
+           if (labels != null && !labels.isEmpty()) {
+             return labels;
+           } else {
+             return null;
+           }
+         }
+       });
+
+    assertEquals(ImmutableMap.of("role", "foo", "xyz", "123"), labels);
+  }
+
+  @Test
+  public void testCliHosts() throws Exception {
+    startDefaultMaster();
+    startDefaultAgent(testHost(), "--labels", "role=foo", "xyz=123");
+    awaitHostStatus(testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+    // Wait for the agent to report labels
+    Polling.await(LONG_WAIT_SECONDS, SECONDS,
+       new Callable<Map<String, String>>() {
+         @Override
+         public Map<String, String> call()
+             throws Exception {
+           Map<String, HostStatus> status = Json.read(
+               cli("hosts", testHost(), "--json"),
+               new TypeReference<Map<String, HostStatus>>() {
+               });
+           final Map<String, String>
+               labels =
+               status.get(testHost()).getLabels();
+           if (labels != null && !labels.isEmpty()) {
+             return labels;
+           } else {
+             return null;
+           }
+         }
+       });
+
+    assertThat(cli("hosts", "--labels", "role=foo"), containsString(testHost()));
+    assertThat(cli("hosts", "--labels", "xyz=123"), containsString(testHost()));
+    assertThat(cli("hosts", "--labels", "role=foo", "xyz=123"), containsString(testHost()));
+
+    assertThat(cli("hosts", "--labels", "role=doesnt_exist"), not(containsString(testHost())));
+    assertThat(cli("hosts", "--labels", "role=doesnt_exist", "xyz=123"),
+               not(containsString(testHost())));
+  }
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -26,6 +26,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import com.spotify.helios.client.HeliosClient;
 
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.Namespace;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -82,5 +85,22 @@ public class Utils {
     }
 
     return true;
+  }
+
+  public static Map<String, String> argToStringMap(final Namespace namespace, final Argument arg) {
+    final List<List<String>> args = namespace.getList(arg.getDest());
+    final Map<String, String> map = Maps.newHashMap();
+    if (args != null) {
+      for (final List<String> group : args) {
+        for (final String s : group) {
+          final String[] parts = s.split("=", 2);
+          if (parts.length != 2) {
+            throw new IllegalArgumentException("Bad " + arg.textualName() + " value: " + s);
+          }
+          map.put(parts[0], parts[1]);
+        }
+      }
+    }
+    return map;
   }
 }


### PR DESCRIPTION
Agents can now have arbitrary labels. You can now list only agents that
match the label that you care about:

    helios hosts --label some_label

In the future, we can use labels for other batch operations against hosts.