### PR TITLE
Fix NPE in TempJobs

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/Jobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Jobs.java
@@ -21,6 +21,7 @@
 
 package com.spotify.helios.testing;
 
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import com.spotify.helios.client.HeliosClient;
@@ -57,7 +58,9 @@ class Jobs {
   }
 
   static String getJobDescription(final Job job) {
-    final String shortHash = job.getId().getHash().substring(0, 7);
+    final String hash = job.getId().getHash();
+    final String shortHash =
+        (Strings.isNullOrEmpty(hash) || hash.length() < 8) ? "" : hash.substring(0, 7);
     return String.format("%s (Job %s)", job.getImage(), shortHash);
   }
 


### PR DESCRIPTION
The job hash can be null or empty when user sets the TempJob name.
Check for null or empty job hashes when trying to get a description.