### PR TITLE
Remove name method from TempJobs

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -89,11 +89,6 @@ public class TemporaryJobBuilder {
     this.reportWriter = reportWriter;
   }
 
-  public TemporaryJobBuilder name(final String jobName) {
-    this.builder.setName(jobName);
-    return this;
-  }
-
   public TemporaryJobBuilder version(final String jobVersion) {
     this.builder.setVersion(jobVersion);
     return this;
@@ -282,7 +277,6 @@ public class TemporaryJobBuilder {
         waitPorts.clear();
       }
 
-      boolean success = false;
       if (this.hosts.isEmpty()) {
         if (isNullOrEmpty(hostFilter)) {
           hostFilter = env.get("HELIOS_HOST_FILTER");

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -217,9 +217,6 @@ public class TemporaryJobs implements TestRule {
       }
     }
 
-    if (config.hasPath("name")) {
-      builder.name(config.getString("name"));
-    }
     if (config.hasPath("version")) {
       builder.version(config.getString("version"));
     }


### PR DESCRIPTION
TempJobs creates its own job hash. User shouldn't be able to set it.

Fixes #473