### PR TITLE
Improve CLI error message for bad host labels

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -76,7 +76,13 @@ public class AgentParser extends ServiceParser {
         options.getString(dockerCertPathArg.getDest()));
 
     final Map<String, String> envVars = argToStringMap(options, envArg);
-    final Map<String, String> labels = argToStringMap(options, labelsArg);
+    final Map<String, String> labels;
+    try {
+      labels = argToStringMap(options, labelsArg);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(e.getMessage() +
+                                         "\nLabels need to be in the format key=value.");
+    }
 
     final InetSocketAddress httpAddress = parseSocketAddress(options.getString(httpArg.getDest()));
 
@@ -217,7 +223,7 @@ public class AgentParser extends ServiceParser {
         .action(append())
         .setDefault(new ArrayList<String>())
         .nargs("+")
-        .help("labels to apply to this agent");
+        .help("labels to apply to this agent. Labels need to be in the format key=value.");
   }
 
   public AgentConfig getAgentConfig() {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -94,7 +94,8 @@ public class HostListCommand extends ControlCommand {
         .action(append())
         .setDefault(new ArrayList<String>())
         .nargs("+")
-        .help("Only include hosts that match all of these labels");
+        .help("Only include hosts that match all of these labels. Labels need to be in the format "
+              + "key=value.");
   }
 
   @Override
@@ -119,7 +120,14 @@ public class HostListCommand extends ControlCommand {
     }
 
     final List<String> sortedHosts = natural().sortedCopy(hosts);
-    final Map<String, String> selectedLabels = argToStringMap(options, labelsArg);
+
+    final Map<String, String> selectedLabels;
+    try {
+      selectedLabels = argToStringMap(options, labelsArg);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(e.getMessage() +
+                                         "\nLabels need to be in the format key=value.");
+    }
 
     if (selectedLabels != null && !selectedLabels.isEmpty() && json) {
       System.err.println("Warning: filtering by label is not supported for JSON output. Not doing"


### PR DESCRIPTION
Tell user labels must be in the format key=value.