### PR TITLE
Explicitly use :latest images for system tests

### DIFF
--- a/helios-integration-tests/src/test/java/com/spotify/helios/BasicFunctionalityITCase.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/BasicFunctionalityITCase.java
@@ -62,7 +62,7 @@ public class BasicFunctionalityITCase {
 
   static final List<String> IDLE_COMMAND = asList(
       "sh", "-c", "trap 'exit 0' SIGINT SIGTERM; while :; do sleep 1; done");
-  public static final String BUSYBOX = "busybox";
+  public static final String BUSYBOX = "busybox:latest";
 
   private HeliosClient client;
   private String deployHost;

--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosIT.java
@@ -78,7 +78,8 @@ public class HeliosIT {
 
   @Test
   public void test() throws Exception {
-    final CreateJobResponse create = cli(CreateJobResponse.class, "create", "test:1", "busybox");
+    final CreateJobResponse create = cli(CreateJobResponse.class, "create", "test:1",
+                                         "busybox:latest");
     assertThat(create.getStatus(), equalTo(CreateJobResponse.Status.OK));
 
     final JobDeployResponse deploy = cli(JobDeployResponse.class, "deploy", "test:1", TEST_HOST);

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
@@ -52,7 +52,7 @@ public class IdMismatchJobCreateTest extends SystemTestBase {
     final HeliosClient client = defaultClient();
 
     final CreateJobResponse createIdMismatch = client.createJob(
-        new Job(JobId.fromString("bad:job:deadbeef"), "busyBox", IDLE_COMMAND,
+        new Job(JobId.fromString("bad:job:deadbeef"), BUSYBOX, IDLE_COMMAND,
                 EMPTY_ENV, EMPTY_RESOURCES, EMPTY_PORTS, EMPTY_REGISTRATION,
                 EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                 EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/PredefinedPortImageDeploymentTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/PredefinedPortImageDeploymentTest.java
@@ -51,7 +51,7 @@ public class PredefinedPortImageDeploymentTest extends SystemTestBase {
     final Job job1 = Job.newBuilder()
         .setName(testTag + "memcached")
         .setVersion("v1")
-        .setImage("rohan/memcached-mini")
+        .setImage(MEMCACHED)
         .build();
     final JobId jobId1 = job1.getId();
     client.createJob(job1).get();
@@ -60,7 +60,7 @@ public class PredefinedPortImageDeploymentTest extends SystemTestBase {
     final Job job2 = Job.newBuilder()
         .setName(testTag + "memcached")
         .setVersion("v2")
-        .setImage("rohan/memcached-mini")
+        .setImage(MEMCACHED)
         .setPorts(ImmutableMap.of("tcp", PortMapping.of(11211, externalPort)))
         .build();
     final JobId jobId2 = job2.getId();

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -140,10 +140,11 @@ public abstract class SystemTestBase {
   public static final int WAIT_TIMEOUT_SECONDS = 40;
   public static final int LONG_WAIT_SECONDS = 400;
 
-  public static final String BUSYBOX = "busybox";
-  public static final String NGINX = "rohan/nginx-alpine";
-  public static final String UHTTPD = "fnichol/docker-uhttpd";
-  public static final String ALPINE = "onescience/alpine";
+  public static final String BUSYBOX = "busybox:latest";
+  public static final String NGINX = "rohan/nginx-alpine:latest";
+  public static final String UHTTPD = "fnichol/docker-uhttpd:latest";
+  public static final String ALPINE = "onescience/alpine:latest";
+  public static final String MEMCACHED = "rohan/memcached-mini:latest";
   public static final List<String> IDLE_COMMAND = asList(
       "sh", "-c", "trap 'exit 0' SIGINT SIGTERM; while :; do sleep 1; done");
 
@@ -963,12 +964,6 @@ public abstract class SystemTestBase {
         }
       }
     });
-    try {
-      // This should fail with an exception if the container still exists
-      dockerClient.inspectContainer(containerId);
-      fail();
-    } catch (DockerException ignore) {
-    }
   }
 
   protected List<Container> listContainers(final DockerClient dockerClient, final String needle)

--- a/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ConfigTest.java
@@ -125,7 +125,7 @@ public class ConfigTest {
             "SPOTIFY_POD", local);
 
         assertThat(job.getEnv(), equalTo(map));
-        assertThat(job.getImage(), equalTo("busybox"));
+        assertThat(job.getImage(), equalTo("busybox:latest"));
       }
     };
 
@@ -147,7 +147,7 @@ public class ConfigTest {
             "SPOTIFY_POD", domain,
             "SPOTIFY_SYSLOG_HOST", "10.99.0.1");
         assertThat(job.getEnv(), equalTo(map));
-        assertThat(job.getImage(), equalTo("busybox"));
+        assertThat(job.getImage(), equalTo("busybox:latest"));
 
       }
     };

--- a/helios-testing/src/test/java/com/spotify/helios/testing/JobsTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/JobsTest.java
@@ -34,7 +34,7 @@ public class JobsTest {
 
   @Test
   public void testGetJobDescription() {
-    final String image = "busybox";
+    final String image = "busybox:latest";
 
     final Job job = Job.newBuilder()
         .setImage(image)

--- a/helios-testing/src/test/resources/helios-base.conf
+++ b/helios-testing/src/test/resources/helios-base.conf
@@ -3,7 +3,7 @@ helios.testing.profile : "some totally bogus profile"
 helios.testing.profiles : {
 
   local : {
-    image : busybox
+    image : "busybox:latest"
     hostFilter : ".*"
     env : {
       SPOTIFY_TEST_THING: "See, we used the prefix here -->"${prefix}"<--"
@@ -13,7 +13,7 @@ helios.testing.profiles : {
   }
 
   helios-ci: {
-    image: busybox
+    image: "busybox:latest"
     domain: "shared.cloud.spotify.net"
     hostFilter: ".+\\.helios-ci\\.cloud"
     deployTimeoutMillis: 120000

--- a/helios-testing/src/test/resources/image_info.json
+++ b/helios-testing/src/test/resources/image_info.json
@@ -1,3 +1,3 @@
 {
-    "image": "busybox"
+    "image": "busybox:latest"
 }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
@@ -85,7 +85,7 @@ public class JobCreateCommandTest {
   @Test
   public void testValidJobCreateCommand() throws Exception {
     when(options.getString("id")).thenReturn(JOB_ID);
-    when(options.getString("image")).thenReturn("busybox");
+    when(options.getString("image")).thenReturn("busybox:latest");
     when(options.getString("exec_check")).thenReturn(EXEC_HEALTH_CHECK);
     // For some reason the mocked options.getInt() returns 0 by default.
     // Explicitly return null to check that the value from the JSON file doesn't get overwritten.
@@ -109,7 +109,7 @@ public class JobCreateCommandTest {
   @Test
   public void testInvalidJobCreateCommand() throws Exception {
     when(options.getString("id")).thenReturn(JOB_NAME);
-    when(options.getString("image")).thenReturn("busybox");
+    when(options.getString("image")).thenReturn("busybox:latest");
     final int ret = command.run(options, client, out, false, null);
     assertEquals(1, ret);
   }
@@ -117,7 +117,7 @@ public class JobCreateCommandTest {
   @Test(expected=IllegalArgumentException.class)
   public void testJobCreateCommandFailsWithInvalidFilePath() throws Exception {
     when(options.getString("id")).thenReturn(JOB_ID);
-    when(options.getString("image")).thenReturn("busybox");
+    when(options.getString("image")).thenReturn("busybox:latest");
     doReturn(new File("non/existant/file")).when(options).get("file");
     command.run(options, client, out, false, null);
   }


### PR DESCRIPTION
By using X:latest images instead of just X, we avoid pulling all tags for
the given image. This should hopefully improve test speed and reliability,
since a lot of tests fail due to timeouts while pulling public images.