### PR TITLE
solo: Block on starting ZooKeeper

### DIFF
--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -24,7 +24,7 @@ curl -XPUT http://127.0.0.1:4001/v2/keys/skydns/local/solo \
 
 skydns $SKYDNS_OPTS &
 
-/usr/share/zookeeper/bin/zkServer.sh start &
+/usr/share/zookeeper/bin/zkServer.sh start
 
 # Start agent
 mkdir -p /agent


### PR DESCRIPTION
Ensure that ZooKeeper is started before starting the agent or master. This
will help mitigate issues where the agent or master starts up too soon and
can't connect to ZK.