### PR TITLE
Kill container based on name if ID not available

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -109,18 +109,15 @@ class TaskRunner extends InterruptingExecutionThreadService {
    * Stops this container.
    */
   public void stop() throws InterruptedException {
-    if (containerId.isPresent()) {
-      final String container = containerId.get();
+    // Interrupt the thread blocking on waitContainer
+    stopAsync().awaitTerminated();
 
-      // Interrupt the thread blocking on waitContainer
-      stopAsync().awaitTerminated();
-
-      // Tell docker to stop or eventually kill the container
-      try {
-        docker.stopContainer(container, SECONDS_TO_WAIT_BEFORE_KILL);
-      } catch (DockerException e) {
-        log.warn("Stopping container {} failed", container, e);
-      }
+    // Tell docker to stop or eventually kill the container
+    final String container = containerId.or(config.containerName());
+    try {
+      docker.stopContainer(container, SECONDS_TO_WAIT_BEFORE_KILL);
+    } catch (DockerException e) {
+      log.warn("Stopping container {} failed", container, e);
     }
   }
 


### PR DESCRIPTION
If a job is undeploy right after it's deployed, we may have asked Docker to
create a container but still not gotten the ID back. In the past, we would
then leave this orphaned container around.

Now, if we don't have a container ID, we attempt to kill any container that
matches the predetermined container name to avoid this race condition.