### PR TITLE
CircleCI: Use separate node for deployment tests

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -3,8 +3,8 @@
 case "$1" in
   pre_machine)
     # ensure correct level of parallelism
-    expected_nodes=5
-    if [ "$CIRCLE_NODE_TOTAL" -ne "$expected_nodes" ]
+    expected_nodes=6
+    if [ "$CIRCLE_NODE_TOTAL" -lt "$expected_nodes" ]
     then
         echo "Parallelism is set to ${CIRCLE_NODE_TOTAL}x, but we need ${expected_nodes}x."
         exit 1
@@ -50,6 +50,7 @@ case "$1" in
       1)
         # run helios-system-tests that start with A-G
         echo "%regex[com.spotify.helios.system.[H-Z].*]" >> .test-excludes
+        echo "%regex[com.spotify.helios.system.Deployment.*]" >> .test-excludes
         mvn test -B -pl helios-system-tests
 
         ;;
@@ -57,6 +58,7 @@ case "$1" in
       2)
         # run helios-system-tests that start with H-R
         echo "%regex[com.spotify.helios.system.[A-GS-Z].*]" >> .test-excludes
+        echo "%regex[com.spotify.helios.system.Deployment.*]" >> .test-excludes
         mvn test -B -pl helios-system-tests
 
         ;;
@@ -64,11 +66,18 @@ case "$1" in
       3)
         # run helios-system-tests that starts with S-Z
         echo "%regex[com.spotify.helios.system.[A-R].*]" >> .test-excludes
+        echo "%regex[com.spotify.helios.system.Deployment.*]" >> .test-excludes
         mvn test -B -pl helios-system-tests
 
         ;;
 
       4)
+        # run DeploymentGroupTest
+        mvn test -B -pl helios-system-tests -Dtest='com.spotify.helios.system.Deployment*'
+
+        ;;
+
+      5)
         sudo apt-get install -y jq
 
         # build images for integration tests


### PR DESCRIPTION
Since DeploymentTest and DeploymentGroupTest take so long to run, do them
in their own container.