### PR TITLE
ZooKeeperMasterModel: Fix log level for a message

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -799,7 +799,7 @@ public class ZooKeeperMasterModel implements MasterModel {
   @Override
   public List<String> getDeploymentGroupHosts(final String name)
       throws DeploymentGroupDoesNotExistException {
-    log.error("getting deployment group hosts: {}", name);
+    log.debug("getting deployment group hosts: {}", name);
     final ZooKeeperClient client = provider.get("getDeploymentGroupHosts");
 
     final DeploymentGroup deploymentGroup = getDeploymentGroup(client, name);


### PR DESCRIPTION
The log message for getDeploymentGroupHosts was incorrectly at ERROR
instead of DEBUG.