### PR TITLE
Don't log warning when stopping container by name

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -117,7 +117,12 @@ class TaskRunner extends InterruptingExecutionThreadService {
     try {
       docker.stopContainer(container, SECONDS_TO_WAIT_BEFORE_KILL);
     } catch (DockerException e) {
-      log.warn("Stopping container {} failed", container, e);
+      if ((e instanceof ContainerNotFoundException) && !containerId.isPresent()) {
+        // we tried to stop the container by name but no container of the given name existed.
+        // this isn't surprising or exceptional, just means the container wasn't started yet.
+      } else {
+        log.warn("Stopping container {} failed", container, e);
+      }
     }
   }
 


### PR DESCRIPTION
If a TaskRunner is told to stop a container before it's gotten back the
container ID from starting the container, it will instead try to stop the
container by name. However, this might throw a ContainerNotFoundException
if the underlying container actually hasn't been started yet.

In this case, don't log a warning like we normally would.