### PR TITLE
More flexible host selectors for deployment groups

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
@@ -21,7 +21,7 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -29,8 +29,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -57,7 +59,7 @@ public class DeploymentGroup extends Descriptor {
   public static final JobId EMPTY_JOB = null;
 
   private final String name;
-  private final Map<String, String> labels;
+  private final List<HostSelector> hostSelectors;
   private final JobId job;
   private final RolloutOptions rolloutOptions;
 
@@ -66,15 +68,16 @@ public class DeploymentGroup extends Descriptor {
    *
    * @param name The docker name to use.
    * @param job The job for the deployment group.
-   * @param labels The labels that are selected for the deployment group.
+   * @param hostSelectors The selectors that determine which agents are part of the deployment
+   *                       group.
    */
   public DeploymentGroup(
       @JsonProperty("name") final String name,
-      @JsonProperty("labels") final Map<String, String> labels,
+      @JsonProperty("hostSelectors") final List<HostSelector> hostSelectors,
       @JsonProperty("job") @Nullable final JobId job,
       @JsonProperty("rolloutOptions") @Nullable final RolloutOptions rolloutOptions) {
     this.name = name;
-    this.labels = labels;
+    this.hostSelectors = hostSelectors;
     this.job = job;
     this.rolloutOptions = rolloutOptions;
   }
@@ -87,8 +90,8 @@ public class DeploymentGroup extends Descriptor {
     return job;
   }
 
-  public Map<String, String> getLabels() {
-    return labels;
+  public List<HostSelector> getHostSelectors() {
+    return hostSelectors;
   }
 
   public RolloutOptions getRolloutOptions() {
@@ -113,14 +116,15 @@ public class DeploymentGroup extends Descriptor {
     if (job != null ? !job.equals(that.job) : that.job != null) {
       return false;
     }
-    if (labels != null ? !labels.equals(that.labels) : that.labels != null) {
+    if (hostSelectors != null ? !hostSelectors.equals(that.hostSelectors)
+                               : that.hostSelectors != null) {
       return false;
     }
     if (name != null ? !name.equals(that.name) : that.name != null) {
       return false;
     }
     if (rolloutOptions != null ? !rolloutOptions.equals(that.rolloutOptions)
-                              : that.rolloutOptions != null) {
+                               : that.rolloutOptions != null) {
       return false;
     }
 
@@ -130,7 +134,7 @@ public class DeploymentGroup extends Descriptor {
   @Override
   public int hashCode() {
     int result = name != null ? name.hashCode() : 0;
-    result = 31 * result + (labels != null ? labels.hashCode() : 0);
+    result = 31 * result + (hostSelectors != null ? hostSelectors.hashCode() : 0);
     result = 31 * result + (job != null ? job.hashCode() : 0);
     result = 31 * result + (rolloutOptions != null ? rolloutOptions.hashCode() : 0);
     return result;
@@ -140,7 +144,7 @@ public class DeploymentGroup extends Descriptor {
   public String toString() {
     return "DeploymentGroup{" +
            "name='" + name + '\'' +
-           ", labels=" + labels +
+           ", hostSelectors=" + hostSelectors +
            ", job=" + job +
            ", rolloutOptions=" + rolloutOptions +
            '}';
@@ -151,7 +155,7 @@ public class DeploymentGroup extends Descriptor {
 
     return builder.setName(name)
         .setJob(job)
-        .setLabels(labels)
+        .setHostSelectors(hostSelectors)
         .setRolloutOptions(rolloutOptions);
   }
 
@@ -167,13 +171,13 @@ public class DeploymentGroup extends Descriptor {
 
       public String name;
       public JobId job;
-      public Map<String, String> labels;
+      public List<HostSelector> hostSelectors;
       public RolloutOptions rolloutOptions;
 
       private Parameters() {
         this.name = EMPTY_NAME;
         this.job = EMPTY_JOB;
-        this.labels = Maps.newHashMap(EMPTY_LABELS);
+        this.hostSelectors = emptyList();
         this.rolloutOptions = null;
       }
     }
@@ -188,8 +192,8 @@ public class DeploymentGroup extends Descriptor {
       return this;
     }
 
-    public Builder setLabels(final Map<String, String> labels) {
-      p.labels = Maps.newHashMap(labels);
+    public Builder setHostSelectors(final List<HostSelector> hostSelectors) {
+      p.hostSelectors = Lists.newArrayList(hostSelectors);
       return this;
     }
 
@@ -203,7 +207,7 @@ public class DeploymentGroup extends Descriptor {
     }
 
     public DeploymentGroup build() {
-      return new DeploymentGroup(p.name, p.labels, p.job, p.rolloutOptions);
+      return new DeploymentGroup(p.name, p.hostSelectors, p.job, p.rolloutOptions);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+public class HostSelector extends Descriptor {
+
+  // Use java.util.function.BiPredicate when available (java 8)
+  private interface BiPredicate<T, U> {
+    boolean test(T t, U u);
+  }
+
+  public enum Operator {
+    EQUALS("=", new BiPredicate<String, Object>() {
+      @Override
+      public boolean test(final String a, final Object b) {
+        return Objects.equals(a, b);
+      }
+    }),
+    NOT_EQUALS("!=", new BiPredicate<String, Object>() {
+      @Override
+      public boolean test(final String a, final Object b) {
+        return !Objects.equals(a, b);
+      }
+    });
+
+    final String operatorName;
+    final BiPredicate<String, Object> predicate;
+
+    Operator(final String operatorName,
+             final BiPredicate<String, Object> predicate) {
+      this.operatorName = operatorName;
+      this.predicate = predicate;
+    }
+  }
+
+  private static final String LABEL_PATTERN = "[\\p{Alnum}\\._-]+";
+  private static final String OPERAND_PATTERN = "[\\p{Alnum}\\._-]+";
+  private static final Pattern PATTERN = Pattern.compile(
+      format("^(%s)\\s*(!=|=)\\s*(%s)$", LABEL_PATTERN, OPERAND_PATTERN));
+
+  private final String label;
+  private final Operator operator;
+  private final Object operand;
+
+  public static HostSelector parse(final String str) {
+    checkNotNull(str);
+
+    final Matcher matcher = PATTERN.matcher(str);
+    if (matcher.matches()) {
+      final String label = matcher.group(1);
+      final String opStr = matcher.group(2);
+      final String value = matcher.group(3);
+
+      Operator operator = null;
+      for (final Operator op : Operator.values()) {
+        if (op.operatorName.equals(opStr)) {
+          operator = op;
+        }
+      }
+
+      if (operator == null) {
+        throw new IllegalArgumentException(format("Unknown operator '%s'", opStr));
+      }
+
+      return new HostSelector(label, operator, value);
+    } else {
+      return null;
+    }
+  }
+
+  public HostSelector(
+      @JsonProperty("label") final String label,
+      @JsonProperty("operator") final Operator operator,
+      @JsonProperty("operand") final Object operand) {
+    this.label = label;
+    this.operator = operator;
+    this.operand = operand;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public Operator getOperator() {
+    return operator;
+  }
+
+  public Object getOperand() {
+    return operand;
+  }
+
+  /**
+   * Check if the given value matches the host selectors.
+   *
+   * @param value Label value to test against.
+   * @return True iff the value matches the host selector condition.
+   */
+  public boolean matches(@Nullable final String value) {
+    return operator.predicate.test(value, operand);
+  }
+
+  /**
+   * Return a human-readable string representation of the host selector. E.g. "A = B".
+   *
+   * @return A human-readable representation of the host selector.
+   */
+  public String toPrettyString() {
+    return format("%s %s %s", label, operator.operatorName, operand.toString());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final HostSelector that = (HostSelector) o;
+
+    if (label != null ? !label.equals(that.label) : that.label != null) {
+      return false;
+    }
+    if (operand != null ? !operand.equals(that.operand) : that.operand != null) {
+      return false;
+    }
+    if (operator != that.operator) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = label != null ? label.hashCode() : 0;
+    result = 31 * result + (operator != null ? operator.hashCode() : 0);
+    result = 31 * result + (operand != null ? operand.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "HostSelector{" +
+           "label='" + label + '\'' +
+           ", operator=" + operator +
+           ", operand=" + operand +
+           '}';
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/HostSelectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/HostSelectorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class HostSelectorTest {
+
+  @Test
+  public void testParseEquals() {
+    assertEquals(new HostSelector("A", HostSelector.Operator.EQUALS, "B"),
+                 HostSelector.parse("A=B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.EQUALS, "B"),
+                 HostSelector.parse("A = B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.EQUALS, "B"),
+                 HostSelector.parse("A =B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.EQUALS, "B"),
+                 HostSelector.parse("A= B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.EQUALS, "B"),
+                 HostSelector.parse("A\t\t=  B"));
+  }
+
+  @Test
+  public void testParseNotEquals() {
+    assertEquals(new HostSelector("A", HostSelector.Operator.NOT_EQUALS, "B"),
+                 HostSelector.parse("A!=B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.NOT_EQUALS, "B"),
+                 HostSelector.parse("A != B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.NOT_EQUALS, "B"),
+                 HostSelector.parse("A !=B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.NOT_EQUALS, "B"),
+                 HostSelector.parse("A!= B"));
+    assertEquals(new HostSelector("A", HostSelector.Operator.NOT_EQUALS, "B"),
+                 HostSelector.parse("A\t\t!=  B"));
+  }
+
+  @Test
+  public void testParseAllowedCharacters() {
+    assertEquals(new HostSelector("foo", HostSelector.Operator.EQUALS, "123"),
+                 HostSelector.parse("foo=123"));
+    assertEquals(new HostSelector("_abc", HostSelector.Operator.NOT_EQUALS, "d-e"),
+                 HostSelector.parse("_abc!=d-e"));
+  }
+
+  @Test
+  public void testParseDisallowedCharacters() {
+    assertNull(HostSelector.parse("foo = @123"));
+    assertNull(HostSelector.parse("f/oo = 123"));
+    // Verify equal not allowed in label and operand
+    assertNull(HostSelector.parse("f=oo = 123"));
+    assertNull(HostSelector.parse("foo = 12=3"));
+    // Verify spaces not allowed in label and operand
+    assertNull(HostSelector.parse("fo o = 123"));
+    assertNull(HostSelector.parse("foo = 1 23"));
+    // Verify ! not allowed in label and operand
+    assertNull(HostSelector.parse("foo=!123"));
+    assertNull(HostSelector.parse("!foo=bar"));
+    // Verify fails on unknown operators
+    assertNull(HostSelector.parse("foo or 123"));
+    assertNull(HostSelector.parse("foo==123"));
+    assertNull(HostSelector.parse("foo&&123"));
+    // Verify fails on empty label or operand
+    assertNull(HostSelector.parse("=123"));
+    assertNull(HostSelector.parse(" =123"));
+    assertNull(HostSelector.parse(" = 123"));
+    assertNull(HostSelector.parse("foo="));
+    assertNull(HostSelector.parse("foo= "));
+    assertNull(HostSelector.parse("foo = "));
+  }
+
+  @Test
+  public void testEqualsMatch() {
+    final HostSelector hostSelector = HostSelector.parse("A=B");
+    assertTrue(hostSelector.matches("B"));
+    assertFalse(hostSelector.matches("Bb"));
+    assertFalse(hostSelector.matches("b"));
+    assertFalse(hostSelector.matches("A"));
+  }
+
+  @Test
+  public void testNotEqualsMatch() {
+    final HostSelector hostSelector = HostSelector.parse("A!=B");
+    assertFalse(hostSelector.matches("B"));
+    assertTrue(hostSelector.matches("Bb"));
+    assertTrue(hostSelector.matches("b"));
+    assertTrue(hostSelector.matches("A"));
+  }
+
+  @Test
+  public void testToPrettyString() {
+    assertEquals("A != B", HostSelector.parse("A!=B").toPrettyString());
+    assertEquals("A = B", HostSelector.parse("A=B").toPrettyString());
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
@@ -44,6 +44,7 @@ import com.spotify.helios.master.MasterModel;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
@@ -91,7 +92,7 @@ public class DeploymentGroupResource {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
       }
 
-      if (!existing.getLabels().equals(deploymentGroup.getLabels())) {
+      if (!Objects.equals(existing.getHostSelectors(), deploymentGroup.getHostSelectors())) {
         return Response.ok(DEPLOYMENT_GROUP_ALREADY_EXISTS_RESPONSE).build();
       }
 

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateService.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateService.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.master.MasterModel;
 import com.spotify.helios.servicescommon.Reactor;
@@ -38,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.spotify.helios.servicescommon.Reactor.Callback;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -114,15 +114,14 @@ public class RollingUpdateService extends AbstractIdleService {
           final String host = entry.getKey();
           final Map<String, String> hostLabels = entry.getValue();
 
-          for (Map.Entry<String, String> desiredLabel : dg.getLabels().entrySet()) {
-            final String key = desiredLabel.getKey();
+          for (final HostSelector hostSelector : dg.getHostSelectors()) {
+            final String key = hostSelector.getLabel();
             if (!hostLabels.containsKey(key)) {
               continue hostLoop;
             }
 
-            final String value = desiredLabel.getValue();
             final String hostValue = hostLabels.get(key);
-            if (isNullOrEmpty(value) ? !isNullOrEmpty(hostValue) : !value.equals(hostValue)) {
+            if (!hostSelector.matches(hostValue)) {
               continue hostLoop;
             }
           }

--- a/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
@@ -22,12 +22,12 @@
 package com.spotify.helios;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.Goal;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.master.DeploymentGroupDoesNotExistException;
@@ -275,7 +275,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   @Test
   public void testAddDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "my_group", ImmutableMap.of("role", "foo"), null, null);
+        "my_group", ImmutableList.of(HostSelector.parse("role=foo")), null, null);
     model.addDeploymentGroup(dg);
     assertEquals(dg, model.getDeploymentGroup("my_group"));
   }
@@ -283,7 +283,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   @Test
   public void testAddExistingDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "my_group", ImmutableMap.of("role", "foo"), null, null);
+        "my_group", ImmutableList.of(HostSelector.parse("role=foo")), null, null);
     model.addDeploymentGroup(dg);
     exception.expect(DeploymentGroupExistsException.class);
     model.addDeploymentGroup(dg);
@@ -292,7 +292,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   @Test
   public void testRemoveDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "my_group", ImmutableMap.of("role", "foo"), null, null);
+        "my_group", ImmutableList.of(HostSelector.parse("role=foo")), null, null);
     model.addDeploymentGroup(dg);
     model.removeDeploymentGroup("my_group");
     exception.expect(DeploymentGroupDoesNotExistException.class);

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -23,11 +23,13 @@ package com.spotify.helios.cli;
 
 import com.google.common.base.Function;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.HostSelector;
 
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -40,6 +42,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
+import static java.lang.String.format;
 
 public class Utils {
 
@@ -123,5 +127,23 @@ public class Utils {
     if (first) {
       out.println();
     }
+  }
+
+  public static List<HostSelector> parseHostSelectors(final Namespace namespace,
+                                                      final Argument arg) {
+    final List<List<String>> args = namespace.getList(arg.getDest());
+    final List<HostSelector> ret = Lists.newArrayList();
+    if (args != null) {
+      for (final List<String> group : args) {
+        for (final String s : group) {
+          final HostSelector hostSelector = HostSelector.parse(s);
+          if (hostSelector == null) {
+            throw new IllegalArgumentException(format("Bad host selector expression: '%s'", s));
+          }
+          ret.add(hostSelector);
+        }
+      }
+    }
+    return ret;
   }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommand.java
@@ -21,13 +21,12 @@
 
 package com.spotify.helios.cli.command;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
 
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.HostSelector;
 
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -76,28 +75,14 @@ public class DeploymentGroupInspectCommand extends ControlCommand {
       out.println(Json.asPrettyStringUnchecked(deploymentGroup));
     } else {
       out.printf("Name: %s%n", deploymentGroup.getName());
-      printMap(out, "Labels: ", deploymentGroup.getLabels());
+      out.printf("Host selectors:%n");
+      for (final HostSelector hostSelector : deploymentGroup.getHostSelectors()) {
+        out.printf("  %s%n", hostSelector.toPrettyString());
+      }
       out.printf("Job: %s%n", deploymentGroup.getJob());
     }
 
     return 0;
-  }
-
-  private <K extends Comparable<K>, V> void printMap(final PrintStream out, final String name,
-                                                     final Map<K, V> values) {
-    out.print(name);
-    boolean first = true;
-    for (final K key : Ordering.natural().sortedCopy(values.keySet())) {
-      if (!first) {
-        out.print(Strings.repeat(" ", name.length()));
-      }
-      final V value = values.get(key);
-      out.printf("%s=%s%n", key, value);
-      first = false;
-    }
-    if (first) {
-      out.println();
-    }
   }
 }
 

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommandTest.java
@@ -21,7 +21,7 @@
 
 package com.spotify.helios.cli.command;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
@@ -43,6 +44,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -55,11 +57,12 @@ public class DeploymentGroupInspectCommandTest {
 
   private static final String NAME = "foo-group";
   private static final String NON_EXISTENT_NAME = "bar-group";
-  private static final Map<String, String> LABELS_MAP = ImmutableMap.of("foo", "bar", "baz", "qux");
   private static final JobId JOB = new JobId("foo-job", "0.1.0");
-
-  private static final DeploymentGroup DEPLOYMENT_GROUP =
-      DeploymentGroup.newBuilder().setName(NAME).setLabels(LABELS_MAP).setJob(JOB).build();
+  private static final List<HostSelector> HOST_SELECTORS = ImmutableList.of(
+      HostSelector.parse("foo=bar"),
+      HostSelector.parse("baz=qux"));
+  private static final DeploymentGroup DEPLOYMENT_GROUP = DeploymentGroup.newBuilder()
+      .setName(NAME).setHostSelectors(HOST_SELECTORS).setJob(JOB).build();
 
   private final Namespace options = mock(Namespace.class);
   private final HeliosClient client = mock(HeliosClient.class);
@@ -92,8 +95,9 @@ public class DeploymentGroupInspectCommandTest {
     assertEquals(0, ret);
     final String output = baos.toString();
     assertThat(output, containsString("Name: " + NAME));
-    assertThat(output, containsString("Labels: baz=qux"));
-    assertThat(output, containsString("foo=bar"));
+    assertThat(output, containsString("Host selectors:"));
+    assertThat(output, containsString("  foo = bar"));
+    assertThat(output, containsString("  baz = qux"));
     assertThat(output, containsString("Job: " + JOB.toString()));
   }
 


### PR DESCRIPTION
 * Support inequality conditions. E.g. 'role=my_role canary!=yes'
 * Use a more storage format for host selectors, enabling implementing
   more advanced host selectors in the future.

Note that the host list command has not be updated (yet!), and currently
does not support the != operator.