### PR TITLE
MultipleJobsTest: Wait for agent to come up

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/MultipleJobsTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/MultipleJobsTest.java
@@ -42,8 +42,10 @@ public class MultipleJobsTest extends SystemTestBase {
   @Test
   public void jobStatusBulk() throws Exception {
     startDefaultMaster();
-    final HeliosClient client = defaultClient();
     startDefaultAgent(testHost());
+    awaitHostRegistered(testHost(), LONG_WAIT_SECONDS, SECONDS);
+
+    final HeliosClient client = defaultClient();
     
     final Job job = Job.newBuilder()
         .setName(testJobName)


### PR DESCRIPTION
MultipleJobsTest was trying to deploy to an agent before the agent was even
up or registered. This would occasionally result in test failures.