### PR TITLE
Ignore unknown JSON in deserialization

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/AgentInfo.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/AgentInfo.java
@@ -21,6 +21,7 @@
 
 package com.spotify.helios.common.descriptors;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -48,6 +49,7 @@ import java.util.List;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AgentInfo extends Descriptor {
   private final String name;
   private final String vmName;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupStatus.java
@@ -34,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * The state of a deployment group.
  */
-@JsonIgnoreProperties({"version"})
+@JsonIgnoreProperties(value = {"version"}, ignoreUnknown = true)
 public class DeploymentGroupStatus extends Descriptor {
 
   public enum State {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DockerVersion.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DockerVersion.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerVersion {
 
   private final String apiVersion;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HealthCheck.java
@@ -21,6 +21,7 @@
 
 package com.spotify.helios.common.descriptors;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -65,6 +66,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
     @JsonSubTypes.Type(value = HttpHealthCheck.class, name = HealthCheck.HTTP),
     @JsonSubTypes.Type(value = TcpHealthCheck.class, name = HealthCheck.TCP),
 })
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class HealthCheck extends Descriptor {
 
   public static final String EXEC = "exec";

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -56,6 +57,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * },
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class HostInfo extends Descriptor {
 
   private final String hostname;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
@@ -21,6 +21,7 @@
 
 package com.spotify.helios.common.descriptors;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
@@ -32,6 +33,7 @@ import java.util.regex.Pattern;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class HostSelector extends Descriptor {
 
   // Use java.util.function.BiPredicate when available (java 8)

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostStatus.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Joiner;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
@@ -69,6 +70,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class HostStatus extends Descriptor {
 
   public static enum Status {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HttpHealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HttpHealthCheck.java
@@ -23,10 +23,12 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class HttpHealthCheck extends HealthCheck {
 
   private final String path;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobId.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobId.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Ordering;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
@@ -49,6 +50,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * colon and hash value.
  */
 @JsonSerialize
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class JobId extends Descriptor implements Comparable<JobId> {
 
   private final String name;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobStatus.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
@@ -58,6 +59,7 @@ import static com.google.common.collect.ImmutableMap.copyOf;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class JobStatus {
 
   private final Job job;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
@@ -40,6 +41,7 @@ import org.jetbrains.annotations.Nullable;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PortMapping extends Descriptor {
 
   public static final String TCP = "tcp";

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Resources.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Resources.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Resources extends Descriptor {
   private final Long memory;
   private final Long memorySwap;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutTask.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutTask.java
@@ -23,10 +23,12 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RolloutTask extends Descriptor {
 
   public enum Action {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
@@ -21,9 +21,12 @@
 
 package com.spotify.helios.common.descriptors;
 
+import com.google.common.base.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -56,6 +59,7 @@ import java.util.List;
  * </pre>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServicePortParameters extends Descriptor {
   private final List<String> tags;
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
@@ -24,6 +24,7 @@ package com.spotify.helios.common.descriptors;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
@@ -41,6 +42,7 @@ import static java.util.Arrays.asList;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServicePorts extends Descriptor {
 
   private final Map<String, ServicePortParameters> ports;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Task.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Task.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
@@ -33,6 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Basically, a pair of {@link Job} and {@link Goal}.  This is different than {@link Deployment}
  * which has a {@link JobId} and not a {@link Job}
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Task extends Descriptor {
   public static final String EMPTY_DEPLOYER_USER = null;
   public static final String EMPTY_DEPLOYER_MASTER = null;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
@@ -25,6 +25,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
@@ -63,6 +64,7 @@ import static java.util.Collections.emptyMap;
  * },
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskStatus extends Descriptor {
 
   private static final Map<String, PortMapping> EMPTY_PORTS = emptyMap();

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -37,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * }
  * </pre>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TaskStatusEvent {
   private final TaskStatus status;
   private final long timestamp;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TcpHealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TcpHealthCheck.java
@@ -23,10 +23,12 @@ package com.spotify.helios.common.descriptors;
 
 import com.google.common.base.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TcpHealthCheck extends HealthCheck {
 
   private final String port;


### PR DESCRIPTION
This allows us to add fields to JSON read by the masters
without our integration tests breaking.