### PR TITLE
HealthCheckTest: Fix intermittent failures

### DIFF
--- a/helios-testing/src/test/java/com/spotify/helios/testing/HealthCheckTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HealthCheckTest.java
@@ -64,7 +64,8 @@ public class HealthCheckTest extends TemporaryJobsTestBase {
       // running netcat twice on different ports lets us verify the health check actually executed
       // because otherwise we wouldn't be able to connect to the second port.
       final TemporaryJob job = temporaryJobs.job()
-          .command("sh", "-c", "nc -l -p 4711 && nc -l -p 4712")
+          .image(ALPINE)
+          .command("sh", "-c", "nc -l -p 4711 && nc -kl -p 4712 -e true")
           .port(HEALTH_CHECK_PORT, 4711)
           .port(QUERY_PORT, 4712)
           .tcpHealthCheck(HEALTH_CHECK_PORT)
@@ -109,7 +110,8 @@ public class HealthCheckTest extends TemporaryJobsTestBase {
       // object instead of the tcpHealthCheck convenience method
       final HealthCheck healthCheck = TcpHealthCheck.of(HEALTH_CHECK_PORT);
       final TemporaryJob job = temporaryJobs.job()
-          .command("sh", "-c", "nc -l -p 4711 && nc -l -p 4712")
+          .image(ALPINE)
+          .command("sh", "-c", "nc -l -p 4711 && nc -kl -p 4712 -e true")
           .port(HEALTH_CHECK_PORT, 4711)
           .port(QUERY_PORT, 4712)
           .healthCheck(healthCheck)


### PR DESCRIPTION
The HealthCheckTest runs netcat in some containers via TemporaryJobs and
then probes those netcat instances to make sure they're reachable. When
netcat is probed, it usually exits immediately. Generally we wouldn't care
since the test ends right after the probe.

However, if TemporaryJobs noticed that the job exited while the test was
still running, it would throw an exception due to the job being unhealthy.
The test would then fail.

So now, we run netcat with `-k` so it sticks around as a persistent server
and the container doesn't exit prematurely.

Fixes #529.