### PR TITLE
Update maven-replacer-plugin

### DIFF
--- a/helios-api-documentation/pom.xml
+++ b/helios-api-documentation/pom.xml
@@ -36,6 +36,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.10</version>
             <executions>
               <execution>
                 <id>jacoco-dependency-ant</id>

--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -11,8 +11,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.template.file>src/main/java/com/spotify/helios/common/Version.java.template</version.template.file>
-    <version.file>src/main/java/com/spotify/helios/common/Version.java</version.file>
+    <version.template.file>helios-client/src/main/java/com/spotify/helios/common/Version.java.template</version.template.file>
+    <version.file>helios-client/src/main/java/com/spotify/helios/common/Version.java</version.file>
   </properties>
 
   <dependencies>
@@ -69,8 +69,8 @@
     <plugins>
       <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>maven-replacer-plugin</artifactId>
-        <version>1.4.0</version>
+        <artifactId>replacer</artifactId>
+        <version>1.5.3</version>
         <executions>
           <execution>
             <phase>process-sources</phase>


### PR DESCRIPTION
Newer version is marked thread safe so parallel builds don't show
a warning.