### PR TITLE
status-deployment-group: Print host selectors

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
@@ -25,6 +25,7 @@ import com.google.common.base.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -100,30 +101,27 @@ public class DeploymentGroupStatusResponse {
     }
   }
 
-  private final String name;
+  private final DeploymentGroup deploymentGroup;
   private final Status status;
   private final String error;
-  private final JobId jobId;
   private final List<HostStatus> hostStatuses;
   private final DeploymentGroupStatus deploymentGroupStatus;
 
   public DeploymentGroupStatusResponse(
-      @JsonProperty("name") final String name,
+      @JsonProperty("deploymentGroup") final DeploymentGroup deploymentGroup,
       @JsonProperty("status") final Status status,
-      @JsonProperty("jobId") final JobId jobId,
       @JsonProperty("error") final String error,
       @JsonProperty("hostStatuses") final List<HostStatus> hostStatuses,
       @JsonProperty("deploymentGroupStatus") final DeploymentGroupStatus deploymentGroupStatus) {
-    this.name = name;
+    this.deploymentGroup = deploymentGroup;
     this.status = status;
     this.error = error;
-    this.jobId = jobId;
     this.hostStatuses = hostStatuses;
     this.deploymentGroupStatus = deploymentGroupStatus;
   }
 
-  public String getName() {
-    return name;
+  public DeploymentGroup getDeploymentGroup() {
+    return deploymentGroup;
   }
 
   public Status getStatus() {
@@ -138,10 +136,6 @@ public class DeploymentGroupStatusResponse {
     return error;
   }
 
-  public JobId getJobId() {
-    return jobId;
-  }
-
   public DeploymentGroupStatus getDeploymentGroupStatus() {
     return deploymentGroupStatus;
   }
@@ -149,10 +143,9 @@ public class DeploymentGroupStatusResponse {
   @Override
   public String toString() {
     return Objects.toStringHelper(getClass())
-        .add("name", name)
+        .add("deploymentGroup", deploymentGroup)
         .add("status", status)
         .add("error", error)
-        .add("jobId", jobId)
         .add("hostStatuses", hostStatuses)
         .add("deploymentGroupStatus", deploymentGroupStatus)
         .toString();
@@ -171,26 +164,25 @@ public class DeploymentGroupStatusResponse {
       return false;
     }
 
-    final DeploymentGroupStatusResponse that = (DeploymentGroupStatusResponse) o;
+    final DeploymentGroupStatusResponse response = (DeploymentGroupStatusResponse) o;
 
-    if (deploymentGroupStatus != null ? !deploymentGroupStatus.equals(that.deploymentGroupStatus)
-                                      : that.deploymentGroupStatus != null) {
+    if (deploymentGroup != null ? !deploymentGroup.equals(response.deploymentGroup)
+                                : response.deploymentGroup != null) {
       return false;
     }
-    if (error != null ? !error.equals(that.error) : that.error != null) {
+    if (deploymentGroupStatus != null ? !deploymentGroupStatus
+        .equals(response.deploymentGroupStatus)
+                                      : response.deploymentGroupStatus != null) {
       return false;
     }
-    if (hostStatuses != null ? !hostStatuses.equals(that.hostStatuses)
-                             : that.hostStatuses != null) {
+    if (error != null ? !error.equals(response.error) : response.error != null) {
       return false;
     }
-    if (jobId != null ? !jobId.equals(that.jobId) : that.jobId != null) {
+    if (hostStatuses != null ? !hostStatuses.equals(response.hostStatuses)
+                             : response.hostStatuses != null) {
       return false;
     }
-    if (name != null ? !name.equals(that.name) : that.name != null) {
-      return false;
-    }
-    if (status != that.status) {
+    if (status != response.status) {
       return false;
     }
 
@@ -199,10 +191,9 @@ public class DeploymentGroupStatusResponse {
 
   @Override
   public int hashCode() {
-    int result = name != null ? name.hashCode() : 0;
+    int result = deploymentGroup != null ? deploymentGroup.hashCode() : 0;
     result = 31 * result + (status != null ? status.hashCode() : 0);
     result = 31 * result + (error != null ? error.hashCode() : 0);
-    result = 31 * result + (jobId != null ? jobId.hashCode() : 0);
     result = 31 * result + (hostStatuses != null ? hostStatuses.hashCode() : 0);
     result = 31 * result + (deploymentGroupStatus != null ? deploymentGroupStatus.hashCode() : 0);
     return result;

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
@@ -222,7 +222,7 @@ public class DeploymentGroupResource {
       }
 
       return Response.ok(new DeploymentGroupStatusResponse(
-          name, status, deploymentGroup.getJobId(), deploymentGroupStatus.getError(),
+          deploymentGroup, status, deploymentGroupStatus.getError(),
           result, deploymentGroupStatus))
           .build();
     } catch (final DeploymentGroupDoesNotExistException e) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStatusCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStatusCommand.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Maps;
 import com.spotify.helios.cli.Table;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.protocol.DeploymentGroupStatusResponse;
 
@@ -92,12 +93,17 @@ public class DeploymentGroupStatusCommand extends ControlCommand {
     if (json) {
       out.println(Json.asPrettyStringUnchecked(status));
     } else {
-      final JobId jobId = status.getJobId();
+      final JobId jobId = status.getDeploymentGroup().getJobId();
       final String error = status.getError();
+      final List<HostSelector> hostSelectors = status.getDeploymentGroup().getHostSelectors();
 
       out.printf("Name: %s%n", name);
       out.printf("Job Id: %s%n", full ? jobId : jobId.toShortString());
       out.printf("Status: %s%n", status.getStatus());
+      out.printf("Host selectors:%n");
+      for (final HostSelector hostSelector : hostSelectors) {
+        out.printf("  %s%n", hostSelector.toPrettyString());
+      }
 
       if (!Strings.isNullOrEmpty(error)) {
         out.printf("Error: %s%n", error);

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -187,7 +187,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         break;
       }
 
-      if (!jobId.equals(status.getJobId())) {
+      if (!jobId.equals(status.getDeploymentGroup().getJobId())) {
         // Another rolling-update was started, overriding this one -- exit
         failed = true;
         error = "Deployment-group job id changed during rolling-update";

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -28,6 +28,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -46,6 +48,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -106,7 +109,9 @@ public class RollingUpdateCommandTest {
       final DeploymentGroupStatusResponse.Status status, final JobId jobId, final String error,
       DeploymentGroupStatusResponse.HostStatus... args) {
     return new DeploymentGroupStatusResponse(
-        GROUP_NAME, status, jobId, error, Arrays.asList(args), null);
+        new DeploymentGroup(GROUP_NAME, Collections.<HostSelector>emptyList(), jobId,
+                            RolloutOptions.newBuilder().build()),
+        status, error, Arrays.asList(args), null);
   }
 
   @Test


### PR DESCRIPTION
The deployment-group status endpoint now returns the DeploymentGroup
in its entirety, including host selectors.