### PR TITLE
CircleCI: Rerun failing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
               <forkCount>4</forkCount>
               <reuseForks>false</reuseForks>
               <argLine>${surefireArgLine}</argLine>
+              <rerunFailingTestsCount>2</rerunFailingTestsCount>
               <environmentVariables>
                 <HELIOS_CLUSTER_DEPLOYMENT_TEST_HOSTS>2</HELIOS_CLUSTER_DEPLOYMENT_TEST_HOSTS>
               </environmentVariables>


### PR DESCRIPTION
If an indivdual test fails, rerun it up to 2 times. If it passes on a
subsequent run, it will get reported as "flaky" but won't fail the build.