### PR TITLE
Rename CLI command abort-rolling-update to stop-deployment-group

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -600,9 +600,9 @@ public class HeliosClient implements AutoCloseable {
                                      ImmutableSet.of(HTTP_OK, HTTP_BAD_REQUEST)));
   }
 
-  public ListenableFuture<Integer> abortRollingUpdate(final String deploymentGroupName) {
+  public ListenableFuture<Integer> stopDeploymentGroup(final String deploymentGroupName) {
     return status(request(
-        uri(path("/deployment-group/%s/rolling-update/abort", deploymentGroupName)), "POST"));
+        uri(path("/deployment-group/%s/stop", deploymentGroupName)), "POST"));
   }
 
   private static final class ConvertResponseToPojo<T> implements AsyncFunction<Response, T> {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -125,5 +125,5 @@ public interface MasterModel {
   void rollingUpdateStep(DeploymentGroup deploymentGroup, RolloutPlanner rolloutPlanner)
       throws DeploymentGroupDoesNotExistException;
 
-  void abortRollingUpdate(String deploymentGroupName) throws DeploymentGroupDoesNotExistException;
+  void stopDeploymentGroup(String deploymentGroupName) throws DeploymentGroupDoesNotExistException;
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -716,13 +716,13 @@ public class ZooKeeperMasterModel implements MasterModel {
   }
 
   @Override
-  public void abortRollingUpdate(final String deploymentGroupName)
+  public void stopDeploymentGroup(final String deploymentGroupName)
       throws DeploymentGroupDoesNotExistException {
     checkNotNull(deploymentGroupName, "name");
 
-    log.info("abort rolling-update on deployment-group: name={}", deploymentGroupName);
+    log.info("stop deployment-group: name={}", deploymentGroupName);
 
-    final ZooKeeperClient client = provider.get("abortRollingUpdate");
+    final ZooKeeperClient client = provider.get("stopDeploymentGroup");
 
     final DeploymentGroup deploymentGroup = getDeploymentGroup(deploymentGroupName);
 
@@ -730,7 +730,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     final DeploymentGroupStatus status = DeploymentGroupStatus.newBuilder()
         .setDeploymentGroup(deploymentGroup)
         .setState(FAILED)
-        .setError("Aborted by user")
+        .setError("Stopped by user")
         .build();
 
     try {
@@ -740,7 +740,7 @@ public class ZooKeeperMasterModel implements MasterModel {
       throw new DeploymentGroupDoesNotExistException(deploymentGroupName);
     } catch (final KeeperException e) {
       throw new HeliosRuntimeException(
-          "abort rolling-update on deployment-group " + deploymentGroupName + " failed", e);
+          "stop deployment-group " + deploymentGroupName + " failed", e);
     }
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
@@ -160,13 +160,13 @@ public class DeploymentGroupResource {
   }
 
   @POST
-  @Path("/{name}/rolling-update/abort")
+  @Path("/{name}/stop")
   @Produces(APPLICATION_JSON)
   @Timed
   @ExceptionMetered
-  public Response abortRollingUpdate(@PathParam("name") @Valid final String name) {
+  public Response stopDeploymentGroup(@PathParam("name") @Valid final String name) {
     try {
-      model.abortRollingUpdate(name);
+      model.stopDeploymentGroup(name);
       return Response.noContent().build();
     } catch (DeploymentGroupDoesNotExistException e) {
       return Response.status(Response.Status.NOT_FOUND).build();

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
@@ -275,21 +275,21 @@ public class DeploymentGroupTest extends SystemTestBase {
   }
 
   @Test
-  public void testAbortRollingUpdate() throws Exception {
+  public void testStopDeploymentGroup() throws Exception {
     cli("create-deployment-group", "--json", TEST_GROUP, "foo=bar", "baz=qux");
     cli("create", "my_job:2", "my_image");
-    assertThat(cli("abort-rolling-update", TEST_GROUP),
-               containsString("Aborted rolling-update on deployment-group my_group"));
+    assertThat(cli("stop-deployment-group", TEST_GROUP),
+               containsString("Deployment-group my_group stopped"));
     final DeploymentGroupStatusResponse status = Json.read(
         cli("deployment-group-status", "--json", TEST_GROUP), DeploymentGroupStatusResponse.class);
     assertEquals(DeploymentGroupStatusResponse.Status.FAILED, status.getStatus());
-    assertEquals("Aborted by user", status.getError());
+    assertEquals("Stopped by user", status.getError());
   }
 
 
   @Test
-  public void testAbortRollingUpdateGroupNotFound() throws Exception {
-    assertThat(cli("abort-rolling-update", TEST_GROUP),
+  public void testStopDeploymentGroupGroupNotFound() throws Exception {
+    assertThat(cli("stop-deployment-group", TEST_GROUP),
                containsString("Deployment-group my_group not found"));
   }
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -47,7 +47,7 @@ import com.spotify.helios.cli.command.JobStopCommand;
 import com.spotify.helios.cli.command.JobUndeployCommand;
 import com.spotify.helios.cli.command.JobWatchCommand;
 import com.spotify.helios.cli.command.MasterListCommand;
-import com.spotify.helios.cli.command.RollingUpdateAbortCommand;
+import com.spotify.helios.cli.command.DeploymentGroupStopCommand;
 import com.spotify.helios.cli.command.RollingUpdateCommand;
 import com.spotify.helios.cli.command.VersionCommand;
 import com.spotify.helios.common.LoggingConfig;
@@ -230,7 +230,7 @@ public class CliParser {
     new DeploymentGroupStatusCommand(p("deployment-group-status"));
     new DeploymentGroupWatchCommand(p("watch-deployment-group"));
     new RollingUpdateCommand(p("rolling-update"));
-    new RollingUpdateAbortCommand(p("abort-rolling-update"));
+    new DeploymentGroupStopCommand(p("stop-deployment-group"));
 
     // Version Command
     final Subparser version = p("version").help("print version of master and client");

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStopCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStopCommand.java
@@ -36,14 +36,14 @@ import javax.ws.rs.core.Response;
 
 import static java.lang.String.format;
 
-public class RollingUpdateAbortCommand extends ControlCommand {
+public class DeploymentGroupStopCommand extends ControlCommand {
 
   private final Argument nameArg;
 
-  public RollingUpdateAbortCommand(final Subparser parser) {
+  public DeploymentGroupStopCommand(final Subparser parser) {
     super(parser);
 
-    parser.help("Abort a rolling-update");
+    parser.help("Stop a deployment-group or abort a rolling-update");
 
     nameArg = parser.addArgument("name")
         .required(true)
@@ -56,18 +56,18 @@ public class RollingUpdateAbortCommand extends ControlCommand {
       throws ExecutionException, InterruptedException, IOException {
     final String name = options.getString(nameArg.getDest());
 
-    final int status = client.abortRollingUpdate(name).get();
+    final int status = client.stopDeploymentGroup(name).get();
 
     // TODO(staffam): Support json output
 
     if (status == Response.Status.NO_CONTENT.getStatusCode()) {
-      out.println(format("Aborted rolling-update on deployment-group %s", name));
+      out.println(format("Deployment-group %s stopped", name));
       return 0;
     } else if (status == Response.Status.NOT_FOUND.getStatusCode()) {
       out.println(format("Deployment-group %s not found", name));
       return 1;
     } else {
-      out.println(format("Failed to abort rolling-update on deployment-group %s. Status: %d",
+      out.println(format("Failed to stop deployment-group %s. Status: %d",
                          name, status));
       return 1;
     }


### PR DESCRIPTION
This more accurately reflects what the command actually does - as it
doesn't just abort a rolling-update update, but also stops an ACTIVE
deployment-group, for example.