### PR TITLE
CircleCI - Support free plan by default

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -3,7 +3,7 @@
 case "$1" in
   pre_machine)
     # ensure correct level of parallelism
-    expected_nodes=5
+    expected_nodes=4
     if [ "$CIRCLE_NODE_TOTAL" -ne "$expected_nodes" ]
     then
         echo "Parallelism is set to ${CIRCLE_NODE_TOTAL}x, but we need ${expected_nodes}x."


### PR DESCRIPTION
Default parallelism is set to *5*, don't know if this is by intention. *4* is the maximum of the free plan and would make it easier to contribute.