### PR TITLE
Perform rolling-update even if deployment group hasn't changed

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -488,11 +488,6 @@ public class ZooKeeperMasterModel implements MasterModel {
         .setRolloutOptions(options)
         .build();
 
-    if (updated.equals(deploymentGroup)) {
-      // the current and desired deployment group are identical, nothing to do.
-      return;
-    }
-
     if (getJob(jobId) == null) {
       throw new JobDoesNotExistException(jobId);
     }


### PR DESCRIPTION
When rolling-update is called, the server logic was to perform the operation
only if the job ID or rollout options had changed. This would cause a problem
if a rollout failed, and the operation needed to be performed again. The code
would detect that the desired state had not changed and do nothing. We now
perform the rollout every time to ensure the actual state matches the desired
state.