### PR TITLE
DeploymentGroupHistoryWriter: Write actual bytes

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupEvent.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupEvent.java
@@ -45,7 +45,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DeploymentGroupEvent {
+public class DeploymentGroupEvent extends Descriptor {
 
   private final RolloutTask.Action action;
   private final JobId jobId;

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupHistoryWriter.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupHistoryWriter.java
@@ -67,7 +67,7 @@ public class DeploymentGroupHistoryWriter extends QueueingHistoryWriter<Deployme
 
   @Override
   protected byte[] toBytes(final DeploymentGroupEvent deploymentGroupEvent) {
-    return new byte[0];
+    return deploymentGroupEvent.toJsonBytes();
   }
 
   public DeploymentGroupHistoryWriter(final ZooKeeperClient client,


### PR DESCRIPTION
We were erroneously serializing all DeploymentGroupEvent objects to an
empty byte array. Instead, serialize correctly into JSON.