### PR TITLE
Swallow BadVersionException in rolling update

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -593,8 +593,13 @@ public class ZooKeeperMasterModel implements MasterModel {
           zkOperations.toArray(new ZooKeeperOperation[zkOperations.size()])
       ));
     } catch (final KeeperException e) {
-      throw new HeliosRuntimeException(
-          "rolling-update on deployment-group " + deploymentGroup.getName() + " failed", e);
+      if ((e instanceof KeeperException.BadVersionException) && e.getPath().equals(statusPath)) {
+        // some other master beat us in processing this rolling update step. not exceptional
+      }
+      else {
+        throw new HeliosRuntimeException(
+            "rolling-update on deployment-group " + deploymentGroup.getName() + " failed", e);
+      }
     }
 
     if (deploymentGroupHistoryWriter != null) {


### PR DESCRIPTION
All masters race to process rolling update steps, so some are going to get
a BadVersionException when attempting to save changes to ZooKeeper. This is
by design and not exceptional, so don't throw an exception on it.