### PR TITLE
Remove Kafka functionality from QueuingHistoryWriter

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
@@ -39,7 +39,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class TaskStatusEvent {
+public class TaskStatusEvent extends Descriptor {
+
+  public static final String KAFKA_TOPIC = "HeliosTaskStatusEvents";
+
   private final TaskStatus status;
   private final long timestamp;
   private final String host;


### PR DESCRIPTION
Have the caller handle sending events to Kafka to make
QueuingHistoryWriter only be responsible for sending to
ZooKeeper. Simplifies things.