### PR TITLE
Get rid of ZK paths for deployment group history

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/MasterZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterZooKeeperRegistrar.java
@@ -76,7 +76,6 @@ public class MasterZooKeeperRegistrar implements ZooKeeperRegistrarEventListener
     client.ensurePath(Paths.statusHosts());
     client.ensurePath(Paths.statusMasters());
     client.ensurePath(Paths.historyJobs());
-    client.ensurePath(Paths.historyDeploymentGroups());
     client.ensurePath(Paths.configDeploymentGroups());
     client.ensurePath(Paths.statusDeploymentGroups());
 

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -593,8 +593,7 @@ public class ZooKeeperMasterModel implements MasterModel {
         // ideally we would check the path in the exception, but curator doesn't provide a path
         // for exceptions thrown as part of a transaction.
         log.debug("error saving rolling-update operations: {}", e);
-      }
-      else {
+      } else {
         throw new HeliosRuntimeException(
             "rolling-update on deployment-group " + deploymentGroup.getName() + " failed", e);
       }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.servicescommon.coordination;
 
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.JobId;
 
 import java.util.UUID;
@@ -58,8 +57,6 @@ public class Paths {
       "/", STATUS, DEPLOYMENT_GROUPS);
 
   private static final PathFactory HISTORY_JOBS = new PathFactory("/", HISTORY, JOBS);
-  private static final PathFactory HISTORY_DEPLOYMENT_GROUPS =
-      new PathFactory("/", HISTORY, DEPLOYMENT_GROUPS);
   private static final String CREATION_PREFIX = "creation-";
 
   public static String configHosts() {
@@ -233,13 +230,5 @@ public class Paths {
 
   public static String historyJobs() {
     return HISTORY_JOBS.path();
-  }
-
-  public static String historyDeploymentGroups() {
-    return HISTORY_DEPLOYMENT_GROUPS.path();
-  }
-
-  public static String historyDeploymentGroup(final DeploymentGroup group) {
-    return HISTORY_DEPLOYMENT_GROUPS.path(group.getName());
   }
 }


### PR DESCRIPTION
We're no longer writing deployment group history to ZooKeeper, just sending
it to Kafka.