### PR TITLE
KafkaSender: Change failures from ERROR to WARN

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaSender.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaSender.java
@@ -57,7 +57,7 @@ public class KafkaSender {
         final RecordMetadata metadata = future.get(KAFKA_SEND_TIMEOUT, TimeUnit.SECONDS);
         log.debug("Sent an event to Kafka, meta: {}", metadata);
       } catch (ExecutionException | InterruptedException | TimeoutException e) {
-        log.error("Unable to send an event to Kafka", e);
+        log.warn("Unable to send an event to Kafka", e);
       }
     } else {
       log.debug("KafkaProducer isn't set. Not sending anything.");


### PR DESCRIPTION
It's not really an exceptional error if there's an occasional issue sending
an event to Kafka. Avoid causing alerts based on this.