### PR TITLE
RFC: Option for deploying rollouts with overlap.

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
@@ -35,13 +35,16 @@ public class RolloutOptions {
   private final long timeout;
   private final int parallelism;
   private final boolean migrate;
+  private final boolean overlap;
 
   public RolloutOptions(@JsonProperty("timeout") final long timeout,
                         @JsonProperty("parallelism") final int parallelism,
-                        @JsonProperty("migrate") final boolean migrate) {
+                        @JsonProperty("migrate") final boolean migrate,
+                        @JsonProperty("overlap") boolean overlap) {
     this.timeout = timeout;
     this.parallelism = parallelism;
     this.migrate = migrate;
+    this.overlap = overlap;
   }
 
   public static Builder newBuilder() {
@@ -67,6 +70,10 @@ public class RolloutOptions {
     return migrate;
   }
 
+  public boolean getOverlap() {
+    return overlap;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -87,6 +94,9 @@ public class RolloutOptions {
     if (timeout != that.timeout) {
       return false;
     }
+    if (overlap != that.overlap) {
+      return false;
+    }
 
     return true;
   }
@@ -96,6 +106,7 @@ public class RolloutOptions {
     int result = (int) (timeout ^ (timeout >>> 32));
     result = 31 * result + parallelism;
     result = 31 * result + (migrate ? 1 : 0);
+    result = 31 * result + (overlap ? 1 : 0);
     return result;
   }
 
@@ -105,6 +116,7 @@ public class RolloutOptions {
            "timeout=" + timeout +
            ", parallelism=" + parallelism +
            ", migrate=" + migrate +
+           ", overlap=" + overlap +
            '}';
   }
 
@@ -113,11 +125,13 @@ public class RolloutOptions {
     private long timeout;
     private int parallelism;
     private boolean migrate;
+    private boolean overlap;
 
     public Builder() {
       this.timeout = DEFAULT_TIMEOUT;
       this.parallelism = DEFAULT_PARALLELISM;
       this.migrate = false;
+      this.overlap = false;
     }
 
 
@@ -136,9 +150,13 @@ public class RolloutOptions {
       return this;
     }
 
+    public Builder setOverlap(final boolean overlap) {
+      this.overlap = overlap;
+      return this;
+    }
 
     public RolloutOptions build() {
-      return new RolloutOptions(timeout, parallelism, migrate);
+      return new RolloutOptions(timeout, parallelism, migrate, overlap);
     }
   }
 }

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/DefaultRolloutPlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/DefaultRolloutPlannerTest.java
@@ -151,4 +151,75 @@ public class DefaultRolloutPlannerTest {
 
     assertEquals(expected, tasks);
   }
+
+  @Test
+  public void testOverlapRollout() {
+    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+        .setRolloutOptions(RolloutOptions.newBuilder().setOverlap(true).build())
+        .build();
+    final HostStatus statusUp = mock(HostStatus.class);
+    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
+    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
+        "agent1", statusUp,
+        "agent2", statusUp,
+        "agent3", statusUp,
+        "agent4", statusUp
+    );
+
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+
+    final List<RolloutTask> expected = Lists.newArrayList(
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent1"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent1"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent1"),
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent2"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent2"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent2"),
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent3"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent3"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent3"),
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent4"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent4"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent4"));
+
+    assertEquals(expected, tasks);
+  }
+
+  @Test
+  public void testOverlapParallelRollout() {
+    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+        .setRolloutOptions(RolloutOptions.newBuilder()
+                               .setOverlap(true)
+                               .setParallelism(2)
+                               .build())
+        .build();
+    final HostStatus statusUp = mock(HostStatus.class);
+    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
+    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
+        "agent1", statusUp,
+        "agent2", statusUp,
+        "agent3", statusUp,
+        "agent4", statusUp
+    );
+
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+
+    final List<RolloutTask> expected = Lists.newArrayList(
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent1"),
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent2"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent1"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent2"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent1"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent2"),
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent3"),
+        RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent4"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent3"),
+        RolloutTask.of(RolloutTask.Action.AWAIT_RUNNING, "agent4"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent3"),
+        RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent4"));
+
+    assertEquals(expected, tasks);
+  }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -63,6 +63,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
   private final Argument asyncArg;
   private final Argument rolloutTimeoutArg;
   private final Argument migrateArg;
+  private final Argument overlapArg;
 
   public RollingUpdateCommand(final Subparser parser) {
     this(parser, new SleepFunction() {
@@ -119,6 +120,13 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         .help("When specified a rolling-update will undeploy not only jobs previously deployed " +
               "by the deployment-group but also jobs with the same job id. Use it ONCE when " +
               "migrating a service to using deployment-groups");
+
+    overlapArg = parser.addArgument("--overlap")
+        .setDefault(false)
+        .action(storeTrue())
+        .help("When specified a rolling-update will, for every host, first deploy the new " +
+              "version of a job before undeploying the old one. Note that the command will fail " +
+              "if the job contains static port assignments.");
   }
 
   @Override
@@ -132,6 +140,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
     final boolean async = options.getBoolean(asyncArg.getDest());
     final long rolloutTimeout = options.getLong(rolloutTimeoutArg.getDest());
     final boolean migrate = options.getBoolean(migrateArg.getDest());
+    final boolean overlap = options.getBoolean(overlapArg.getDest());
 
     checkArgument(timeout > 0, "Timeout must be greater than 0");
     checkArgument(parallelism > 0, "Parallelism must be greater than 0");
@@ -143,6 +152,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         .setTimeout(timeout)
         .setParallelism(parallelism)
         .setMigrate(migrate)
+        .setOverlap(overlap)
         .build();
     final RollingUpdateResponse response = client.rollingUpdate(name, jobId, rolloutOptions).get();
 
@@ -156,15 +166,16 @@ public class RollingUpdateCommand extends WildcardJobCommand {
     }
 
     if (!json) {
-      out.println(format("Rolling update%s started: %s -> %s (parallelism=%d, timeout=%d)%s",
+      out.println(format("Rolling update%s started: %s -> %s (parallelism=%d, timeout=%d, overlap=%b)%s",
                          async ? " (async)" : "",
-                         name, jobId.toShortString(), parallelism, timeout,
+                         name, jobId.toShortString(), parallelism, timeout, overlap,
                          async ? "" : "\n"));
     }
 
     final Map<String, Object> jsonOutput = Maps.newHashMap();
     jsonOutput.put("parallelism", parallelism);
     jsonOutput.put("timeout", timeout);
+    jsonOutput.put("overlap", overlap);
 
     if (async) {
       if (json) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -166,7 +166,8 @@ public class RollingUpdateCommand extends WildcardJobCommand {
     }
 
     if (!json) {
-      out.println(format("Rolling update%s started: %s -> %s (parallelism=%d, timeout=%d, overlap=%b)%s",
+      out.println(format("Rolling update%s started: %s -> %s " +
+                         "(parallelism=%d, timeout=%d, overlap=%b)%s",
                          async ? " (async)" : "",
                          name, jobId.toShortString(), parallelism, timeout, overlap,
                          async ? "" : "\n"));

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -87,6 +87,7 @@ public class RollingUpdateCommandTest {
     when(options.getLong("rollout_timeout")).thenReturn(10L);
     when(options.getBoolean("async")).thenReturn(false);
     when(options.getBoolean("migrate")).thenReturn(false);
+    when(options.getBoolean("overlap")).thenReturn(false);
   }
 
   private static DeploymentGroupStatusResponse.HostStatus makeHostStatus(
@@ -138,11 +139,11 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(0, ret);
 
     final String expected = (
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
         "\n" +
         "host1 -> RUNNING (1/3)\n" +
         "host2 -> RUNNING (2/3)\n" +
@@ -165,11 +166,11 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(0, ret);
 
     final String expected =
-        "Rolling update (async) started: my_group -> foo:2:1212121 (parallelism=1, timeout=300)\n";
+        "Rolling update (async) started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n";
 
     assertEquals(expected, output);
   }
@@ -198,11 +199,11 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(1, ret);
 
     final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
         "\n" +
         "host1 -> RUNNING (1/3)\n" +
         "\n" +
@@ -230,11 +231,11 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(1, ret);
 
     final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
         "\n" +
         "\n" +
         "Timed out! (rolling-update still in progress)\n" +
@@ -261,11 +262,11 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(1, ret);
 
     final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
         "\n" +
         "host1 -> RUNNING (1/2)\n" +
         "\n" +
@@ -293,14 +294,15 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
         "status", "DONE",
         "duration", 0.00,
         "parallelism", PARALLELISM,
-        "timeout", TIMEOUT));
+        "timeout", TIMEOUT,
+        "overlap", false));
   }
 
   @Test
@@ -314,13 +316,14 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
         "status", "OK",
         "parallelism", PARALLELISM,
-        "timeout", TIMEOUT));
+        "timeout", TIMEOUT,
+        "overlap", false));
   }
 
   @Test
@@ -343,15 +346,17 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(1, ret);
 
-    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
-        "status", "FAILED",
-        "error", "Deployment-group job id changed during rolling-update",
-        "duration", 1.00,
-        "parallelism", PARALLELISM,
-        "timeout", TIMEOUT));
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
+        .put("status", "FAILED")
+        .put("error", "Deployment-group job id changed during rolling-update")
+        .put("duration", 1.00)
+        .put("parallelism", PARALLELISM)
+        .put("timeout", TIMEOUT)
+        .put("overlap", false)
+        .build());
   }
 
   @Test
@@ -372,14 +377,15 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(1, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
         "status", "TIMEOUT",
         "duration", 601.00,
         "parallelism", PARALLELISM,
-        "timeout", TIMEOUT));
+        "timeout", TIMEOUT,
+        "overlap", false));
   }
 
   @Test
@@ -400,15 +406,17 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
     assertEquals(1, ret);
 
-    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
-        "status", "FAILED",
-        "error", "foobar",
-        "duration", 1.00,
-        "parallelism", PARALLELISM,
-        "timeout", TIMEOUT));
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
+        .put("status", "FAILED")
+        .put("error", "foobar")
+        .put("duration", 1.00)
+        .put("parallelism", PARALLELISM)
+        .put("timeout", TIMEOUT)
+        .put("overlap", false)
+        .build());
   }
 
   @Test
@@ -427,14 +435,42 @@ public class RollingUpdateCommandTest {
 
     // Verify that rollingUpdate() was called with migrate=true
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, true));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, true, false));
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
         "status", "DONE",
         "duration", 0.00,
         "parallelism", PARALLELISM,
-        "timeout", TIMEOUT));
+        "timeout", TIMEOUT,
+        "overlap", false));
+  }
+  
+  @Test
+  public void testRollingUpdateOverlapJson() throws Exception {
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.ACTIVE, null,
+                       makeHostStatus("host1", JOB_ID, TaskStatus.State.RUNNING))
+    ));
+    when(options.getBoolean("overlap")).thenReturn(true);
+
+    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final String output = baos.toString();
+
+    // Verify that rollingUpdate() was called with migrate=true
+    verify(client).rollingUpdate(
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, true));
+    assertEquals(0, ret);
+
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
+        "status", "DONE",
+        "duration", 0.00,
+        "parallelism", PARALLELISM,
+        "timeout", TIMEOUT,
+        "overlap", true));
   }
 
   private static class TimeUtil implements RollingUpdateCommand.SleepFunction, Supplier<Long> {


### PR DESCRIPTION
The new functionality is in `DefaultRolloutPlanner` now since that seemed to be the easiest way to go. Let me know if you'd prefer a separate `RolloutPlanner` implementation instead. I'm also open to better naming suggestions, couldn't come up with anything better than `overlap`.