### PR TITLE
Parallelize execution of rolling updates

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
@@ -305,7 +305,7 @@ public class DeploymentGroupTest extends SystemTestBase {
     final Map<String, MasterMain> masters = startDefaultMasters(3);
 
     final Map<String, AgentMain> agents = Maps.newLinkedHashMap();
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 20; i++) {
       final String name = TEST_HOST + i;
       agents.put(name, startDefaultAgent(name, "--labels", TEST_LABEL));
     }


### PR DESCRIPTION
Have a thread pool of 5 threads which we use to run the rolling update step
for each deployment group. Hopefully this speeds things up a bit.