### PR TITLE
Set kafka metadata fetch timeout to 5 seconds

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/KafkaClientProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/KafkaClientProvider.java
@@ -54,7 +54,8 @@ public class KafkaClientProvider {
         return ImmutableMap.<String, Object>of(
             "bootstrap.servers", Joiner.on(',').join(input),
             "acks", KAFKA_QUORUM_PARAMETER,
-            "client.id", KAFKA_HELIOS_CLIENT_ID);
+            "client.id", KAFKA_HELIOS_CLIENT_ID,
+            "metadata.fetch.timeout.ms", 5000);
       }
     });
   }


### PR DESCRIPTION
instead of the default 1 minute. If kafka is borked,
the minute timeout will make rolling-update timeout.