### PR TITLE
Fix total number of deployment group hosts

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
@@ -192,7 +192,7 @@ public class DeploymentGroupResource {
         JobId deployedJobId = null;
         TaskStatus.State state = null;
 
-        if (hostStatus != null) {
+        if (hostStatus != null && hostStatus.getStatus().equals(HostStatus.Status.UP)) {
           for (final Map.Entry<JobId, Deployment> entry : hostStatus.getJobs().entrySet()) {
             if (name.equals(entry.getValue().getDeploymentGroupName())) {
               deployedJobId = entry.getKey();


### PR DESCRIPTION
Only include UP hosts in rolling-update and deployment-group-status
output, i.e. don't include DOWN hosts.

Fixes #620 #599