### PR TITLE
Tweak deployment groups metrics

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -809,7 +809,7 @@ public class ZooKeeperMasterModel implements MasterModel {
       return opFactory.error(e, host, RollingUpdateError.TOKEN_VERIFICATION_ERROR);
     } catch (HostNotFoundException e) {
       return opFactory.error(e, host, RollingUpdateError.HOST_NOT_FOUND);
-    } catch(JobPortAllocationConflictException e) {
+    } catch (JobPortAllocationConflictException e) {
       return opFactory.error(e, host, RollingUpdateError.PORT_CONFLICT);
     } catch (JobAlreadyDeployedException e) {
       // Nothing to do

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -752,8 +752,11 @@ public class ZooKeeperMasterModel implements MasterModel {
       if (isRolloutTimedOut(client, deploymentGroup)) {
         // time exceeding the configured deploy timeout has passed, and this job is still not
         // running
+        final Map<String, Object> metadata = Maps.newHashMap();
+        metadata.put("jobState", taskStatuses.get(deploymentGroup.getJobId()).getState());
         return opFactory.error("timed out waiting for job to reach RUNNING", host,
-                               RollingUpdateError.TIMED_OUT_WAITING_FOR_JOB_TO_REACH_RUNNING);
+                               RollingUpdateError.TIMED_OUT_WAITING_FOR_JOB_TO_REACH_RUNNING,
+                               metadata);
       }
 
       return opFactory.yield();

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupEventFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupEventFactory.java
@@ -97,7 +97,7 @@ public class DeploymentGroupEventFactory {
                                                  final Map<String, Object> failEvent) {
     final Map<String, Object> ev = createEvent("rollingUpdateFinished", deploymentGroup);
     ev.put("success", 0);
-    ev.put("failEvent", failEvent);
+    ev.put("failedTask", failEvent);
     return ev;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupEventFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupEventFactory.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class DeploymentGroupEventFactory {
@@ -55,7 +56,17 @@ public class DeploymentGroupEventFactory {
                                                      final RolloutTask task,
                                                      final String error,
                                                      final RollingUpdateError errorCode) {
+    return rollingUpdateTaskFailed(deploymentGroup, task, error, errorCode,
+                                   Collections.<String, Object>emptyMap());
+  }
+
+  public Map<String, Object> rollingUpdateTaskFailed(final DeploymentGroup deploymentGroup,
+                                                     final RolloutTask task,
+                                                     final String error,
+                                                     final RollingUpdateError errorCode,
+                                                     final Map<String, Object> metadata) {
     final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", deploymentGroup);
+    ev.putAll(metadata);
     ev.put("success", 0);
     ev.put("error", error);
     ev.put("errorCode", errorCode);

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupEventFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/DeploymentGroupEventFactory.java
@@ -24,8 +24,6 @@ package com.spotify.helios.rollingupdate;
 import com.google.common.collect.Maps;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
-import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
-import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
 import java.util.Map;
@@ -37,51 +35,58 @@ public class DeploymentGroupEventFactory {
     HOSTS_CHANGED
   }
 
-  public Map<String, Object> rollingUpdateTaskSucceeded(final DeploymentGroup deploymentGroup,
-                                                        final RolloutTask task) {
+  private Map<String, Object> createEvent(final String eventType,
+                                          final DeploymentGroup deploymentGroup) {
     final Map<String, Object> ev = Maps.newHashMap();
-    ev.put("eventType", "rollingUpdateTaskSucceeded");
+    ev.put("eventType", eventType);
     ev.put("timestamp", System.currentTimeMillis());
-    ev.put("deploymentGroupName", deploymentGroup.getName());
-    ev.put("action", task.getAction());
-    ev.put("target", task.getTarget());
-    ev.put("result", RolloutTask.Status.OK);
+    ev.put("deploymentGroup", deploymentGroup);
     return ev;
   }
 
+  private Map<String, Object> addTaskFields(final Map<String, Object> ev,
+                                            final RolloutTask task) {
+    ev.put("action", task.getAction());
+    ev.put("target", task.getTarget());
+    return ev;
+  }
+
+  public Map<String, Object> rollingUpdateTaskFailed(final DeploymentGroup deploymentGroup,
+                                                     final RolloutTask task,
+                                                     final String error,
+                                                     final RollingUpdateError errorCode) {
+    final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", deploymentGroup);
+    ev.put("success", 0);
+    ev.put("error", error);
+    ev.put("errorCode", errorCode);
+    return addTaskFields(ev, task);
+  }
+
+  public Map<String, Object> rollingUpdateTaskSucceeded(final DeploymentGroup deploymentGroup,
+                                                        final RolloutTask task) {
+    final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", deploymentGroup);
+    ev.put("success", 1);
+    return addTaskFields(ev, task);
+  }
+
   public Map<String, Object> rollingUpdateStarted(final DeploymentGroup deploymentGroup,
-                                                  final RollingUpdateReason reason,
-                                                  final JobId jobId) {
-    final Map<String, Object> ev = Maps.newHashMap();
-    ev.put("eventType", "rollingUpdateStarted");
-    ev.put("timestamp", System.currentTimeMillis());
-    ev.put("deploymentGroupName", deploymentGroup.getName());
+                                                  final RollingUpdateReason reason) {
+    final Map<String, Object> ev = createEvent("rollingUpdateStarted", deploymentGroup);
     ev.put("reason", reason);
-    ev.put("jobId", jobId.toString());
     return ev;
   }
 
   public Map<String, Object> rollingUpdateDone(final DeploymentGroup deploymentGroup) {
-    final Map<String, Object> ev = Maps.newHashMap();
-    ev.put("eventType", "rollingUpdateDone");
-    ev.put("timestamp", System.currentTimeMillis());
-    ev.put("deploymentGroupName", deploymentGroup.getName());
-    ev.put("state", DeploymentGroupStatus.State.DONE);
+    final Map<String, Object> ev = createEvent("rollingUpdateFinished", deploymentGroup);
+    ev.put("success", 1);
     return ev;
   }
 
   public Map<String, Object> rollingUpdateFailed(final DeploymentGroup deploymentGroup,
-                                                 final RolloutTask task,
-                                                 final String error) {
-    final Map<String, Object> ev = Maps.newHashMap();
-    ev.put("eventType", "rollingUpdateFailed");
-    ev.put("timestamp", System.currentTimeMillis());
-    ev.put("deploymentGroupName", deploymentGroup.getName());
-    ev.put("state", DeploymentGroupStatus.State.FAILED);
-    ev.put("action", task.getAction());
-    ev.put("target", task.getTarget());
-    ev.put("result", RolloutTask.Status.FAILED);
-    ev.put("error", error);
+                                                 final Map<String, Object> failEvent) {
+    final Map<String, Object> ev = createEvent("rollingUpdateFinished", deploymentGroup);
+    ev.put("success", 0);
+    ev.put("failEvent", failEvent);
     return ev;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateError.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateError.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.rollingupdate;
+
+public enum RollingUpdateError {
+  PORT_CONFLICT,
+  JOB_UNEXPECTEDLY_UNDEPLOYED,
+  JOB_ALREADY_DEPLOYED,
+  TIMED_OUT_WAITING_FOR_JOB_TO_REACH_RUNNING,
+  TOKEN_VERIFICATION_ERROR,
+  JOB_NOT_FOUND,
+  HOST_NOT_FOUND,
+  TIMED_OUT_RETRIEVING_JOB_STATUS
+}

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactory.java
@@ -104,7 +104,8 @@ public class RollingUpdateOpFactory {
   }
 
   public RollingUpdateOp error(final String msg, final String host,
-                               final RollingUpdateError errorCode) {
+                               final RollingUpdateError errorCode,
+                               final Map<String, Object> metadata) {
     final List<ZooKeeperOperation> operations = Lists.newArrayList();
     final String errMsg = isNullOrEmpty(host) ? msg : host + ": " + msg;
 
@@ -122,12 +123,17 @@ public class RollingUpdateOpFactory {
     // Emit a FAILED event and a failed task event
     final List<Map<String, Object>> events = Lists.newArrayList();
     final Map<String, Object> taskEv = eventFactory.rollingUpdateTaskFailed(
-        deploymentGroup, task, errMsg, errorCode);
+        deploymentGroup, task, errMsg, errorCode, metadata);
     events.add(taskEv);
     events.add(eventFactory.rollingUpdateFailed(deploymentGroup, taskEv));
 
     return new RollingUpdateOp(ImmutableList.copyOf(operations),
                                ImmutableList.copyOf(events));
+  }
+
+  public RollingUpdateOp error(final String msg, final String host,
+                               final RollingUpdateError errorCode) {
+    return error(msg, host, errorCode, Collections.<String, Object>emptyMap());
   }
 
   public RollingUpdateOp error(final Exception e, final String host,

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactoryTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactoryTest.java
@@ -36,6 +36,7 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperOperation;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -190,7 +191,8 @@ public class RollingUpdateOpFactoryTest {
         eq(DEPLOYMENT_GROUP),
         eq(deploymentGroupTasks.getRolloutTasks().get(deploymentGroupTasks.getTaskIndex())),
         anyString(),
-        eq(RollingUpdateError.HOST_NOT_FOUND));
+        eq(RollingUpdateError.HOST_NOT_FOUND),
+        eq(Collections.<String, Object>emptyMap()));
 
     verify(eventFactory).rollingUpdateFailed(
         eq(DEPLOYMENT_GROUP),


### PR DESCRIPTION
 * Always include the full deployment group in all events.
 * For event that either fail or succeed, indicate the result via a
   numeric "success" field.
 * Include a "machine readable" error code for failed tasks.