### PR TITLE
Fix bug in the logic for determining if a rolling-update is timed out

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -799,7 +799,7 @@ public class ZooKeeperMasterModel implements MasterModel {
   private boolean isRolloutTimedOut(final ZooKeeperClient client,
                                     final DeploymentGroup deploymentGroup) {
     try {
-      final String statusPath = Paths.statusDeploymentGroup(deploymentGroup.getName());
+      final String statusPath = Paths.statusDeploymentGroupTasks(deploymentGroup.getName());
       final long secondsSinceDeploy = MILLISECONDS.toSeconds(
           System.currentTimeMillis() - client.getNode(statusPath).getStat().getMtime());
       return secondsSinceDeploy > deploymentGroup.getRolloutOptions().getTimeout();


### PR DESCRIPTION
Previously, we'd update the deployment-group status on every task and
as a consequence we looked at the mtime of the deployment-group status
node to determine how long ago a task started. With the recent changes
to how deployment-groups work, i.e. introducing the separate tasks node,
this is no longer the case.

So, instead look at the mtime of the deployment-group tasks path --
which we write to whenever we proceeded to a new task.