### PR TITLE
Don't overwrite job config file settings

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliJobCreationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliJobCreationTest.java
@@ -22,6 +22,7 @@
 package com.spotify.helios.system;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -84,7 +85,10 @@ public class CliJobCreationTest extends SystemTestBase {
         .setPorts(ports)
         .setRegistration(registration)
         .setVolumes(volumes)
-        .setCreatingUser(TEST_USER);
+        .setCreatingUser(TEST_USER)
+        .setToken("foo-token")
+        .setNetworkMode("host")
+        .setSecurityOpt(ImmutableList.of("label:user:dxia", "apparmor:foo"));
     final Job job = builder.build();
     final String jobConfigJsonString = job.toJsonString();
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -229,7 +229,7 @@ public class JobCreateCommand extends ControlCommand {
     // TODO (dano): look for e.g. Heliosfile in cwd by default?
 
     final String templateJobId = options.getString(templateArg.getDest());
-    final File file = (File) options.get(fileArg.getDest());
+    final File file = options.get(fileArg.getDest());
 
     if (file != null && templateJobId != null) {
       throw new IllegalArgumentException("Please use only one of -t/--template and -f/--file");
@@ -398,7 +398,7 @@ public class JobCreateCommand extends ControlCommand {
     builder.setRegistration(registration);
 
     // Get grace period interval
-    Integer gracePeriod = options.getInt(gracePeriodArg.getDest());
+    final Integer gracePeriod = options.getInt(gracePeriodArg.getDest());
     if (gracePeriod != null) {
       builder.setGracePeriod(gracePeriod);
     }
@@ -464,11 +464,20 @@ public class JobCreateCommand extends ControlCommand {
       builder.setHealthCheck(TcpHealthCheck.of(tcpHealthCheck));
     }
 
-    builder.setSecurityOpt(options.<String>getList(securityOptArg.getDest()));
+    final List<String> securityOpt = options.getList(securityOptArg.getDest());
+    if (securityOpt != null && !securityOpt.isEmpty()) {
+      builder.setSecurityOpt(securityOpt);
+    }
 
-    builder.setNetworkMode(options.getString(networkModeArg.getDest()));
+    final String networkMode = options.getString(networkModeArg.getDest());
+    if (!isNullOrEmpty(networkMode)) {
+      builder.setNetworkMode(networkMode);
+    }
 
-    builder.setToken(options.getString(tokenArg.getDest()));
+    final String token = options.getString(tokenArg.getDest());
+    if (!isNullOrEmpty(token)) {
+      builder.setToken(token);
+    }
 
     final Job job = builder.build();
 

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
@@ -22,7 +22,6 @@
 package com.spotify.helios.cli.command;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 
 import com.spotify.helios.client.HeliosClient;
@@ -58,7 +57,7 @@ public class JobCreateCommandTest {
   private static final String JOB_ID = JOB_NAME + ":123";
   private static final String EXEC_HEALTH_CHECK = "touch /this";
   private static final List<String> SECURITY_OPT =
-      Lists.newArrayList("label:user:dxia", "apparmor:foo");
+      ImmutableList.of("label:user:dxia", "apparmor:foo");
   private static final String NETWORK_MODE = "host";
 
   private final Namespace options = mock(Namespace.class);


### PR DESCRIPTION
Don't overwrite job config file's settings if CLI args aren't present.

* network mode
* security option
* token