### PR TITLE
Make deployment groups support insecure access tokens

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
@@ -56,7 +56,9 @@ import static java.util.Collections.emptyList;
  *   "rolloutOptions":{
  *     "migrate":false,
  *     "parallelism":2,
- *     "timeout":1000
+ *     "timeout":1000,
+ *     "overlap":true,
+ *     "token": "insecure-access-token"
  *   }
  * }
  * </pre>

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
@@ -26,6 +26,38 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
+
+/**
+ * Represents a deployment group's rollout options.
+ *
+ * An sample expression of it in JSON might be:
+ * <pre>
+ * {
+ *   "name": "foo-group",
+ *   "job": "foo:0.1.0",
+ *   "hostSelectors": [
+ *     {
+ *       "label": "foo",
+ *       "operator": "EQUALS"
+ *       "operand": "bar",
+ *     },
+ *     {
+ *       "label": "baz",
+ *       "operator": "EQUALS"
+ *       "operand": "qux",
+ *     }
+ *   ],
+ *   "rolloutOptions": {
+ *     "migrate": false,
+ *     "parallelism": 2,
+ *     "timeout": 1000,
+ *     "overlap": true,
+ *     "token": "insecure-access-token"
+ *   }
+ * }
+ * </pre>
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RolloutOptions {
 
@@ -36,15 +68,18 @@ public class RolloutOptions {
   private final int parallelism;
   private final boolean migrate;
   private final boolean overlap;
+  private final String token;
 
   public RolloutOptions(@JsonProperty("timeout") final long timeout,
                         @JsonProperty("parallelism") final int parallelism,
                         @JsonProperty("migrate") final boolean migrate,
-                        @JsonProperty("overlap") boolean overlap) {
+                        @JsonProperty("overlap") boolean overlap,
+                        @JsonProperty("token") String token) {
     this.timeout = timeout;
     this.parallelism = parallelism;
     this.migrate = migrate;
     this.overlap = overlap;
+    this.token = token;
   }
 
   public static Builder newBuilder() {
@@ -55,7 +90,8 @@ public class RolloutOptions {
     return new Builder()
         .setTimeout(timeout)
         .setParallelism(parallelism)
-        .setMigrate(migrate);
+        .setMigrate(migrate)
+        .setToken(token);
   }
 
   public long getTimeout() {
@@ -72,6 +108,10 @@ public class RolloutOptions {
 
   public boolean getOverlap() {
     return overlap;
+  }
+
+  public String getToken() {
+    return token;
   }
 
   @Override
@@ -97,6 +137,9 @@ public class RolloutOptions {
     if (overlap != that.overlap) {
       return false;
     }
+    if (token != null ? !token.equals(that.token) : that.token != null) {
+      return false;
+    }
 
     return true;
   }
@@ -107,6 +150,7 @@ public class RolloutOptions {
     result = 31 * result + parallelism;
     result = 31 * result + (migrate ? 1 : 0);
     result = 31 * result + (overlap ? 1 : 0);
+    result = 31 * result + (token != null ? token.hashCode() : 0);
     return result;
   }
 
@@ -117,6 +161,7 @@ public class RolloutOptions {
            ", parallelism=" + parallelism +
            ", migrate=" + migrate +
            ", overlap=" + overlap +
+           ", token=" + token +
            '}';
   }
 
@@ -126,12 +171,14 @@ public class RolloutOptions {
     private int parallelism;
     private boolean migrate;
     private boolean overlap;
+    private String token;
 
     public Builder() {
       this.timeout = DEFAULT_TIMEOUT;
       this.parallelism = DEFAULT_PARALLELISM;
       this.migrate = false;
       this.overlap = false;
+      this.token = EMPTY_TOKEN;
     }
 
 
@@ -155,8 +202,13 @@ public class RolloutOptions {
       return this;
     }
 
+    public Builder setToken(final String token) {
+      this.token = token;
+      return this;
+    }
+
     public RolloutOptions build() {
-      return new RolloutOptions(timeout, parallelism, migrate, overlap);
+      return new RolloutOptions(timeout, parallelism, migrate, overlap, token);
     }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -63,6 +63,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.FORBIDDEN;
 import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.HOST_NOT_FOUND;
 import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.INVALID_ID;
@@ -208,14 +209,14 @@ public class HostsResource {
   @Produces(APPLICATION_JSON)
   @Timed
   @ExceptionMetered
-  public JobDeployResponse jobPut(@PathParam("host") final String host,
-                                  @PathParam("job") final JobId jobId,
-                                  @Valid final Deployment deployment,
-                                  @RequestUser final String username,
-                                  @QueryParam("token") @DefaultValue("") final String token) {
+  public JobDeployResponse jobPut(
+      @PathParam("host") final String host,
+      @PathParam("job") final JobId jobId,
+      @Valid final Deployment deployment,
+      @RequestUser final String username,
+      @QueryParam("token") @DefaultValue(EMPTY_TOKEN) final String token) {
     if (!jobId.isFullyQualified()) {
-      throw badRequest(new JobDeployResponse(JobDeployResponse.Status.INVALID_ID, host,
-                                             jobId));
+      throw badRequest(new JobDeployResponse(JobDeployResponse.Status.INVALID_ID, host, jobId));
     }
     try {
       final Deployment actualDeployment = deployment.toBuilder().setDeployerUser(username).build();

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
@@ -37,6 +37,7 @@ import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
 import com.spotify.helios.common.descriptors.Goal;
 import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -70,6 +71,7 @@ public class DeploymentGroupTest extends SystemTestBase {
 
   private static final String TEST_GROUP = "my_group";
   private static final String TEST_LABEL = "foo=bar";
+  private static final String TOKEN = "foo-token";
 
   private MasterMain master;
 
@@ -233,8 +235,55 @@ public class DeploymentGroupTest extends SystemTestBase {
     assertEquals(TEST_GROUP, jobDeploymentGroup);
 
     // rolling-update should succeed & job should be running
-    awaitDeploymentGroupStatus(defaultClient(), TEST_GROUP,
-                               DeploymentGroupStatus.State.DONE);
+    awaitDeploymentGroupStatus(defaultClient(), TEST_GROUP, DeploymentGroupStatus.State.DONE);
+    awaitTaskState(jobId, host, TaskStatus.State.RUNNING);
+  }
+
+  @Test
+  public void testRollingUpdateMigrateWithToken() throws Exception {
+    final String host = testHost();
+    startDefaultAgent(host, "--labels", TEST_LABEL);
+
+    // Wait for agent to come up
+    final HeliosClient client = defaultClient();
+    awaitHostStatus(client, testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+    // Manually deploy a job with a token on the host (i.e. a job not part of the deployment group)
+    final Job job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(IDLE_COMMAND)
+        .setToken(TOKEN)
+        .build();
+    final JobId jobId = createJob(job);
+    deployJob(jobId, host, TOKEN);
+    awaitTaskState(jobId, host, TaskStatus.State.RUNNING);
+
+    // Create a deployment-group and trigger a migration rolling-update
+    cli("create-deployment-group", "--json", TEST_GROUP, TEST_LABEL);
+    cli("rolling-update", "--async", "--migrate", "--token", TOKEN, testJobNameAndVersion,
+        TEST_GROUP);
+
+    // Check that the deployment's deployment-group name eventually changes to TEST_GROUP
+    // (should be null or empty before)
+    final String jobDeploymentGroup = Polling.await(
+        LONG_WAIT_SECONDS, SECONDS, new Callable<String>() {
+          @Override
+          public String call() throws Exception {
+            final Deployment deployment =
+                defaultClient().hostStatus(host).get().getJobs().get(jobId);
+            if (deployment != null && !isNullOrEmpty(deployment.getDeploymentGroupName())) {
+              return deployment.getDeploymentGroupName();
+            } else {
+              return null;
+            }
+          }
+        });
+    assertEquals(TEST_GROUP, jobDeploymentGroup);
+
+    // rolling-update should succeed & job should be running
+    awaitDeploymentGroupStatus(defaultClient(), TEST_GROUP, DeploymentGroupStatus.State.DONE);
     awaitTaskState(jobId, host, TaskStatus.State.RUNNING);
   }
 
@@ -503,7 +552,6 @@ public class DeploymentGroupTest extends SystemTestBase {
                       (System.currentTimeMillis() - t0) / 1000.0);
   }
 
-
   @Test
   public void testRollingUpdateWithOverlapAndParallelism() throws Exception {
     // create and start agents
@@ -540,5 +588,39 @@ public class DeploymentGroupTest extends SystemTestBase {
       awaitTaskState(secondJobId, host, TaskStatus.State.RUNNING);
     }
     awaitDeploymentGroupStatus(defaultClient(), TEST_GROUP, DeploymentGroupStatus.State.DONE);
+  }
+
+  @Test
+  public void testRollingUpdateWithToken() throws Exception {
+    final String host = testHost();
+    startDefaultAgent(host, "--labels", TEST_LABEL);
+
+    // Wait for agent to come up
+    final HeliosClient client = defaultClient();
+    awaitHostStatus(client, testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+    // Manually deploy a job with a token on the host (i.e. a job not part of the deployment group)
+    final Job job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(IDLE_COMMAND)
+        .setToken(TOKEN)
+        .build();
+    final JobId jobId = createJob(job);
+
+    // Create a deployment-group and trigger a migration rolling-update
+    cli("create-deployment-group", "--json", TEST_GROUP, TEST_LABEL);
+    cli("rolling-update", "--async", "--token", TOKEN, testJobNameAndVersion, TEST_GROUP);
+
+    // rolling-update should succeed & job should be running
+    awaitDeploymentGroupStatus(defaultClient(), TEST_GROUP, DeploymentGroupStatus.State.DONE);
+    awaitTaskState(jobId, host, TaskStatus.State.RUNNING);
+
+    // Check that we cannot manually undeploy the job with a token
+    final String output = cli("undeploy", jobId.toString(), host);
+    assertThat(output, containsString("FORBIDDEN"));
+    awaitDeploymentGroupStatus(defaultClient(), TEST_GROUP, DeploymentGroupStatus.State.DONE);
+    awaitTaskState(jobId, host, TaskStatus.State.RUNNING);
   }
 }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -756,9 +756,19 @@ public abstract class SystemTestBase {
     return cli("create", args);
   }
 
-  protected void deployJob(final JobId jobId, final String host)
+  protected void deployJob(final JobId jobId, final String host) throws Exception {
+    deployJob(jobId, host, null);
+  }
+
+  protected void deployJob(final JobId jobId, final String host, final String token)
       throws Exception {
-    final String deployOutput = cli("deploy", jobId.toString(), host);
+    final List<String> deployArgs = Lists.newArrayList(jobId.toString(), host);
+
+    if (token != null) {
+      deployArgs.addAll(ImmutableList.of("--token", token));
+    }
+
+    final String deployOutput = cli("deploy", deployArgs);
     assertThat(deployOutput, containsString(host + ": done"));
 
     final String output = cli("status", "--host", host, "--json");
@@ -777,8 +787,7 @@ public abstract class SystemTestBase {
         Json.readUnchecked(output, new TypeReference<Map<JobId, JobStatus>>() {
         });
     final JobStatus status = statuses.get(jobId);
-    assertTrue(status == null ||
-               status.getDeployments().get(host) == null);
+    assertTrue(status == null || status.getDeployments().get(host) == null);
   }
 
   protected String startJob(final JobId jobId, final String host) throws Exception {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -62,6 +62,7 @@ import java.util.regex.Pattern;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static com.spotify.helios.common.descriptors.PortMapping.TCP;
 import static com.spotify.helios.common.descriptors.ServiceEndpoint.HTTP;
 import static java.util.Arrays.asList;
@@ -127,7 +128,7 @@ public class JobCreateCommand extends ControlCommand {
 
     tokenArg = parser.addArgument("--token")
          .nargs("?")
-         .setDefault("")
+         .setDefault(EMPTY_TOKEN)
          .help("Insecure access token meant to prevent accidental changes to your job " +
                "(e.g. undeploys).");
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static java.lang.String.format;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
@@ -64,6 +65,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
   private final Argument rolloutTimeoutArg;
   private final Argument migrateArg;
   private final Argument overlapArg;
+  private final Argument tokenArg;
 
   public RollingUpdateCommand(final Subparser parser) {
     this(parser, new SleepFunction() {
@@ -127,6 +129,12 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         .help("When specified a rolling-update will, for every host, first deploy the new " +
               "version of a job before undeploying the old one. Note that the command will fail " +
               "if the job contains static port assignments.");
+
+    tokenArg = parser.addArgument("--token")
+        .nargs("?")
+        .setDefault(EMPTY_TOKEN)
+        .help("Insecure access token meant to prevent accidental changes to your job " +
+              "(e.g. undeploys).");
   }
 
   @Override
@@ -141,6 +149,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
     final long rolloutTimeout = options.getLong(rolloutTimeoutArg.getDest());
     final boolean migrate = options.getBoolean(migrateArg.getDest());
     final boolean overlap = options.getBoolean(overlapArg.getDest());
+    final String token = options.getString(tokenArg.getDest());
 
     checkArgument(timeout > 0, "Timeout must be greater than 0");
     checkArgument(parallelism > 0, "Parallelism must be greater than 0");
@@ -153,6 +162,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         .setParallelism(parallelism)
         .setMigrate(migrate)
         .setOverlap(overlap)
+        .setToken(token)
         .build();
     final RollingUpdateResponse response = client.rollingUpdate(name, jobId, rolloutOptions).get();
 
@@ -167,9 +177,9 @@ public class RollingUpdateCommand extends WildcardJobCommand {
 
     if (!json) {
       out.println(format("Rolling update%s started: %s -> %s " +
-                         "(parallelism=%d, timeout=%d, overlap=%b)%s",
+                         "(parallelism=%d, timeout=%d, overlap=%b, token=%s)%s",
                          async ? " (async)" : "",
-                         name, jobId.toShortString(), parallelism, timeout, overlap,
+                         name, jobId.toShortString(), parallelism, timeout, overlap, token,
                          async ? "" : "\n"));
     }
 
@@ -177,6 +187,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
     jsonOutput.put("parallelism", parallelism);
     jsonOutput.put("timeout", timeout);
     jsonOutput.put("overlap", overlap);
+    jsonOutput.put("token", token);
 
     if (async) {
       if (json) {

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -68,6 +68,7 @@ public class RollingUpdateCommandTest {
   private static final JobId NEW_JOB_ID = new JobId("foo", "3", "4242424242424242424");
   private static final int PARALLELISM = 1;
   private static final long TIMEOUT = 300;
+  private static final String TOKEN = "my_token";
 
   private final Namespace options = mock(Namespace.class);
   private final HeliosClient client = mock(HeliosClient.class);
@@ -88,6 +89,7 @@ public class RollingUpdateCommandTest {
     when(options.getBoolean("async")).thenReturn(false);
     when(options.getBoolean("migrate")).thenReturn(false);
     when(options.getBoolean("overlap")).thenReturn(false);
+    when(options.getString("token")).thenReturn(TOKEN);
   }
 
   private static DeploymentGroupStatusResponse.HostStatus makeHostStatus(
@@ -139,11 +141,12 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(0, ret);
 
     final String expected = (
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
+        + "overlap=false, token=" + TOKEN + ")\n" +
         "\n" +
         "host1 -> RUNNING (1/3)\n" +
         "host2 -> RUNNING (2/3)\n" +
@@ -166,11 +169,12 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(0, ret);
 
     final String expected =
-        "Rolling update (async) started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n";
+        "Rolling update (async) started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
+        + "overlap=false, token=" + TOKEN + ")\n";
 
     assertEquals(expected, output);
   }
@@ -199,11 +203,12 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(1, ret);
 
     final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
+        + "overlap=false, token=" + TOKEN + ")\n" +
         "\n" +
         "host1 -> RUNNING (1/3)\n" +
         "\n" +
@@ -231,11 +236,12 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(1, ret);
 
     final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
+        + "overlap=false, token=" + TOKEN + ")\n" +
         "\n" +
         "\n" +
         "Timed out! (rolling-update still in progress)\n" +
@@ -262,11 +268,12 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(1, ret);
 
     final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, overlap=false)\n" +
+        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
+        + "overlap=false, token=" + TOKEN + ")\n" +
         "\n" +
         "host1 -> RUNNING (1/2)\n" +
         "\n" +
@@ -294,15 +301,17 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(0, ret);
 
-    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
-        "status", "DONE",
-        "duration", 0.00,
-        "parallelism", PARALLELISM,
-        "timeout", TIMEOUT,
-        "overlap", false));
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
+        .put("status", "DONE")
+        .put("duration", 0.00)
+        .put("parallelism", PARALLELISM)
+        .put("timeout", TIMEOUT)
+        .put("overlap", false)
+        .put("token", TOKEN)
+        .build());
   }
 
   @Test
@@ -316,14 +325,15 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
         "status", "OK",
         "parallelism", PARALLELISM,
         "timeout", TIMEOUT,
-        "overlap", false));
+        "overlap", false,
+        "token", TOKEN));
   }
 
   @Test
@@ -346,7 +356,7 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(1, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -356,6 +366,7 @@ public class RollingUpdateCommandTest {
         .put("parallelism", PARALLELISM)
         .put("timeout", TIMEOUT)
         .put("overlap", false)
+        .put("token", TOKEN)
         .build());
   }
 
@@ -377,15 +388,17 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(1, ret);
 
-    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
-        "status", "TIMEOUT",
-        "duration", 601.00,
-        "parallelism", PARALLELISM,
-        "timeout", TIMEOUT,
-        "overlap", false));
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
+        .put("status", "TIMEOUT")
+        .put("duration", 601.00)
+        .put("parallelism", PARALLELISM)
+        .put("timeout", TIMEOUT)
+        .put("overlap", false)
+        .put("token", TOKEN)
+        .build());
   }
 
   @Test
@@ -406,7 +419,7 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
     assertEquals(1, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -416,6 +429,7 @@ public class RollingUpdateCommandTest {
         .put("parallelism", PARALLELISM)
         .put("timeout", TIMEOUT)
         .put("overlap", false)
+        .put("token", TOKEN)
         .build());
   }
 
@@ -435,15 +449,17 @@ public class RollingUpdateCommandTest {
 
     // Verify that rollingUpdate() was called with migrate=true
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, true, false));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, true, false, TOKEN));
     assertEquals(0, ret);
 
-    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
-        "status", "DONE",
-        "duration", 0.00,
-        "parallelism", PARALLELISM,
-        "timeout", TIMEOUT,
-        "overlap", false));
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
+        .put("status", "DONE")
+        .put("duration", 0.00)
+        .put("parallelism", PARALLELISM)
+        .put("timeout", TIMEOUT)
+        .put("overlap", false)
+        .put("token", TOKEN)
+        .build());
   }
   
   @Test
@@ -462,15 +478,17 @@ public class RollingUpdateCommandTest {
 
     // Verify that rollingUpdate() was called with migrate=true
     verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, true));
+        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, true, TOKEN));
     assertEquals(0, ret);
 
-    assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
-        "status", "DONE",
-        "duration", 0.00,
-        "parallelism", PARALLELISM,
-        "timeout", TIMEOUT,
-        "overlap", true));
+    assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
+        .put("status", "DONE")
+        .put("duration", 0.00)
+        .put("parallelism", PARALLELISM)
+        .put("timeout", TIMEOUT)
+        .put("overlap", true)
+        .put("token", TOKEN)
+        .build());
   }
 
   private static class TimeUtil implements RollingUpdateCommand.SleepFunction, Supplier<Long> {


### PR DESCRIPTION
`helios rolling-update` now takes a `--token` switch which allows it to
undeploy and deploy jobs with tokens.