### PR TITLE
Minor docs fix/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ Build & Test
 ------------
 
 First, make sure you have Docker installed locally. If you're using OS X, we
-recommend using [Boot2Docker](http://boot2docker.io/) or
-[docker-machine](https://docs.docker.com/machine/).
+recommend using [docker-machine](https://docs.docker.com/machine/).
 
 Actually building Helios and running its tests should be a simple matter
 of running:

--- a/docs/helios_solo.md
+++ b/docs/helios_solo.md
@@ -79,7 +79,7 @@ $ helios-solo deploy test:1 solo
 $ helios-solo status
 
 # Undeploy job
-$ helios-solo undeploy -a -f test:1
+$ helios-solo undeploy -a --yes test:1
 
 # Remove job
 $ helios-solo remove test:1

--- a/docs/helios_solo.md
+++ b/docs/helios_solo.md
@@ -11,7 +11,7 @@ Install & Run
 
 ### OS X
 
-Install Docker using [Boot2Docker](http://boot2docker.io/) or
+Install [docker-machine](https://docs.docker.com/machine/) or
 another similar solution. Configure it correctly and **start the service** so that commands like
 `docker info` and `docker ps` work. Then run the below.
 


### PR DESCRIPTION
boot2docker-cli deprecation:
https://github.com/boot2docker/boot2docker-cli