### PR TITLE
Support for creating/deploying jobs with image digests

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -287,9 +287,16 @@ public class JobValidator {
 
     final String repo;
     final String tag;
+    final String digest;
 
+    final int lastAtSign = imageRef.lastIndexOf('@');
     final int lastColon = imageRef.lastIndexOf(':');
-    if (lastColon != -1 && !(tag = imageRef.substring(lastColon + 1)).contains("/")) {
+
+    if (lastAtSign != -1) {
+      repo = imageRef.substring(0, lastAtSign);
+      digest = imageRef.substring(lastAtSign + 1);
+      valid &= validateDigest(digest, errors);
+    } else if (lastColon != -1 && !(tag = imageRef.substring(lastColon + 1)).contains("/")) {
       repo = imageRef.substring(0, lastColon);
       valid &= validateTag(tag, errors);
     } else {
@@ -337,6 +344,23 @@ public class JobValidator {
       valid = false;
     }
     return valid;
+  }
+
+  private boolean validateDigest(final String digest, final Collection<String> errors) {
+    if (digest.isEmpty()) {
+      errors.add("Digest cannot be empty");
+      return false;
+    }
+
+    final int firstColon = digest.indexOf(':');
+    final int lastColon = digest.lastIndexOf(':');
+
+    if ((firstColon <= 0 ) || (firstColon != lastColon) || (firstColon == digest.length() - 1)) {
+      errors.add(format("Illegal digest: \"%s\"", digest));
+      return false;
+    }
+
+    return true;
   }
 
   private boolean validateEndpoint(final String endpoint, final Collection<String> errors) {

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -117,6 +117,18 @@ public class JobValidatorTest {
                is(empty()));
     assertThat(validator.validate(b.setImage("registry.test.net.:80/fooo/bar").build()),
                is(empty()));
+    assertThat(
+        validator.validate(b.setImage(
+            "namespace/foo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+                               .build()), is(empty()));
+    assertThat(
+        validator.validate(b.setImage(
+            "foo.net/bar@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+                               .build()), is(empty()));
+    assertThat(
+        validator.validate(b.setImage(
+            "foo@tarsum.v1+sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b")
+                               .build()), is(empty()));
   }
 
   @Test
@@ -220,6 +232,15 @@ public class JobValidatorTest {
 
     assertEquals(newHashSet("Tag cannot be empty"),
                  validator.validate(b.setImage("repo:").build()));
+
+    assertEquals(newHashSet("Digest cannot be empty"),
+                 validator.validate(b.setImage("foo@").build()));
+
+    assertEquals(newHashSet("Illegal digest: \":123\""),
+                 validator.validate(b.setImage("foo@:123").build()));
+
+    assertEquals(newHashSet("Illegal digest: \"sha256:\""),
+                 validator.validate(b.setImage("foo@sha256:").build()));
 
     assertFalse(validator.validate(b.setImage("repo:/").build()).isEmpty());
 

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -146,6 +146,8 @@ public abstract class SystemTestBase {
   public static final int LONG_WAIT_SECONDS = 400;
 
   public static final String BUSYBOX = "busybox:latest";
+  public static final String BUSYBOX_WITH_DIGEST =
+      "busybox@sha256:16a2a52884c2a9481ed267c2d46483eac7693b813a63132368ab098a71303f8a";
   public static final String NGINX = "rohan/nginx-alpine:latest";
   public static final String UHTTPD = "fnichol/docker-uhttpd:latest";
   public static final String ALPINE = "onescience/alpine:latest";


### PR DESCRIPTION
This updates the JobValidator to accept image names that have digests, and
adds some unit tests and an integration test to make sure it all works.