### PR TITLE
add a 'metadata' field to Jobs

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -355,7 +355,7 @@ public class JobValidator {
     final int firstColon = digest.indexOf(':');
     final int lastColon = digest.lastIndexOf(':');
 
-    if ((firstColon <= 0 ) || (firstColon != lastColon) || (firstColon == digest.length() - 1)) {
+    if ((firstColon <= 0) || (firstColon != lastColon) || (firstColon == digest.length() - 1)) {
       errors.add(format("Illegal digest: \"%s\"", digest));
       return false;
     }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -508,7 +508,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         this.token = EMPTY_TOKEN;
         this.healthCheck = EMPTY_HEALTH_CHECK;
         this.securityOpt = EMPTY_SECURITY_OPT;
-        this.metadata = EMPTY_METADATA;
+        this.metadata = Maps.newHashMap();
       }
 
       private Parameters(final Parameters p) {
@@ -655,7 +655,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     }
 
     public Builder setMetadata(final Map<String, String> metadata) {
-      p.metadata = metadata;
+      p.metadata = Maps.newHashMap(metadata);
       return this;
     }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -68,6 +68,9 @@ import static java.util.Collections.emptyMap;
  *   "id" : "myservice:0.5:3539b7bc2235d53f79e6e8511942bbeaa8816265",
  *   "image" : "myregistry:80/janedoe/myservice:0.5-98c6ff4",
  *   "hostname": "myhost",
+ *   "metadata": {
+ *     "foo": "bar
+ *   },
  *   "networkMode" : "bridge",
  *   "ports" : {
  *     "http" : {
@@ -116,6 +119,7 @@ public class Job extends Descriptor implements Comparable<Job> {
   public static final List<String> EMPTY_SECURITY_OPT = emptyList();
   public static final String DEFAULT_NETWORK_MODE = "bridge";
   public static final String EMPTY_HOSTNAME = null;
+  public static final Map<String, String> EMPTY_METADATA = emptyMap();
 
   private final JobId id;
   private final String image;
@@ -134,6 +138,7 @@ public class Job extends Descriptor implements Comparable<Job> {
   private final HealthCheck healthCheck;
   private final List<String> securityOpt;
   private final String networkMode;
+  private final Map<String, String> metadata;
 
   /**
    * Create a Job.
@@ -181,7 +186,8 @@ public class Job extends Descriptor implements Comparable<Job> {
              @JsonProperty("token") @Nullable String token,
              @JsonProperty("healthCheck") @Nullable HealthCheck healthCheck,
              @JsonProperty("securityOpt") @Nullable final List<String> securityOpt,
-             @JsonProperty("networkMode") @Nullable final String networkMode) {
+             @JsonProperty("networkMode") @Nullable final String networkMode,
+             @JsonProperty("metadata") @Nullable final Map<String, String> metadata) {
     this.id = id;
     this.image = image;
 
@@ -202,6 +208,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     this.healthCheck = Optional.fromNullable(healthCheck).orNull();
     this.securityOpt = Optional.fromNullable(securityOpt).or(EMPTY_SECURITY_OPT);
     this.networkMode = Optional.fromNullable(networkMode).orNull();
+    this.metadata = Optional.fromNullable(metadata).or(EMPTY_METADATA);
   }
 
   private Job(final JobId id, final Builder.Parameters p) {
@@ -224,6 +231,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     this.healthCheck = p.healthCheck;
     this.securityOpt = p.securityOpt;
     this.networkMode = p.networkMode;
+    this.metadata = ImmutableMap.copyOf(p.metadata);
   }
 
   public JobId getId() {
@@ -292,6 +300,10 @@ public class Job extends Descriptor implements Comparable<Job> {
 
   public String getNetworkMode() {
     return networkMode;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
   }
 
   public static Builder newBuilder() {
@@ -367,6 +379,9 @@ public class Job extends Descriptor implements Comparable<Job> {
     if (networkMode != null ? !networkMode.equals(job.networkMode) : job.networkMode != null) {
       return false;
     }
+    if (metadata != null ? !metadata.equals(job.metadata) : job.metadata != null) {
+      return false;
+    }
 
     return true;
   }
@@ -390,6 +405,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     result = 31 * result + (healthCheck != null ? healthCheck.hashCode() : 0);
     result = 31 * result + (securityOpt != null ? securityOpt.hashCode() : 0);
     result = 31 * result + (networkMode != null ? networkMode.hashCode() : 0);
+    result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
     return result;
   }
 
@@ -412,6 +428,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         .add("healthCheck", healthCheck)
         .add("securityOpt", securityOpt)
         .add("networkMode", networkMode)
+        .add("metadata", metadata)
         .toString();
   }
 
@@ -438,7 +455,8 @@ public class Job extends Descriptor implements Comparable<Job> {
         .setToken(token)
         .setHealthCheck(healthCheck)
         .setSecurityOpt(securityOpt)
-        .setNetworkMode(networkMode);
+        .setNetworkMode(networkMode)
+        .setMetadata(metadata);
   }
 
   public static class Builder implements Cloneable {
@@ -475,6 +493,7 @@ public class Job extends Descriptor implements Comparable<Job> {
       public HealthCheck healthCheck;
       public List<String> securityOpt;
       public String networkMode;
+      public Map<String, String> metadata;
 
       private Parameters() {
         this.command = EMPTY_COMMAND;
@@ -489,6 +508,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         this.token = EMPTY_TOKEN;
         this.healthCheck = EMPTY_HEALTH_CHECK;
         this.securityOpt = EMPTY_SECURITY_OPT;
+        this.metadata = EMPTY_METADATA;
       }
 
       private Parameters(final Parameters p) {
@@ -510,6 +530,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         this.healthCheck = p.healthCheck;
         this.securityOpt = p.securityOpt;
         this.networkMode = p.networkMode;
+        this.metadata = p.metadata;
       }
     }
 
@@ -633,6 +654,16 @@ public class Job extends Descriptor implements Comparable<Job> {
       return this;
     }
 
+    public Builder setMetadata(final Map<String, String> metadata) {
+      p.metadata = metadata;
+      return this;
+    }
+
+    public Builder addMetadata(final String name, final String value) {
+      p.metadata.put(name, value);
+      return this;
+    }
+
     public String getName() {
       return p.name;
     }
@@ -699,6 +730,10 @@ public class Job extends Descriptor implements Comparable<Job> {
 
     public String getNetworkMode() {
       return p.networkMode;
+    }
+
+    public Map<String, String> getMetadata() {
+      return ImmutableMap.copyOf(p.metadata);
     }
 
     @SuppressWarnings({"CloneDoesntDeclareCloneNotSupportedException", "CloneDoesntCallSuperClone"})

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -47,6 +47,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_GRACE_PERIOD;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HEALTH_CHECK;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HOSTNAME;
 import static com.spotify.helios.common.descriptors.Job.DEFAULT_NETWORK_MODE;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_METADATA;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
@@ -191,7 +192,8 @@ public class JobValidatorTest {
                             "bar", EMPTY_HOSTNAME, EMPTY_COMMAND, EMPTY_ENV, EMPTY_RESOURCES, EMPTY_PORTS,
                             EMPTY_REGISTRATION, EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                             EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
-                            EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE);
+                            EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
+                            EMPTY_METADATA);
     final JobId recomputedId = job.toBuilder().build().getId();
     assertEquals(ImmutableSet.of("Id hash mismatch: " + job.getId().getHash()
         + " != " + recomputedId.getHash()), validator.validate(job));

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
@@ -370,12 +370,31 @@ public class JobTest {
         .setVersion("17")
         .build();
 
+     removeFieldAndParse(job, "env");
+  }
+
+  @Test
+  public void verifyCanParseJobWithMissingMetadata() throws Exception {
+    final Job job = Job.newBuilder()
+        .setCommand(asList("foo", "bar"))
+        .setImage("foobar:4711")
+        .setName("foozbarz")
+        .setVersion("17")
+        .build();
+
+    removeFieldAndParse(job, "metadata");
+  }
+
+  private static void removeFieldAndParse(final Job job, final String... fieldNames) throws Exception {
     final String jobJson = job.toJsonString();
 
     final ObjectMapper objectMapper = new ObjectMapper();
     final Map<String, Object> fields = objectMapper.readValue(
         jobJson, new TypeReference<Map<String, Object>>() {});
-    fields.remove("env");
+
+    for (String field : fieldNames) {
+      fields.remove(field);
+    }
     final String modifiedJobJson = objectMapper.writeValueAsString(fields);
 
     final Job parsedJob = parse(modifiedJobJson, Job.class);

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,9 +43,11 @@ import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.spotify.helios.common.descriptors.Descriptor.parse;
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 
 public class JobTest {
 
@@ -290,6 +291,25 @@ public class JobTest {
     return b.build();
   }
 
+  /** Verify the Builder allows calling addFoo() before setFoo() for collection types. */
+  @Test
+  public void testBuilderAddBeforeSet() throws Exception {
+    final Job job = Job.newBuilder()
+        .addEnv("env", "var")
+        .addMetadata("meta", "data")
+        .addPort("http", PortMapping.of(80, 8000))
+        .addRegistration(ServiceEndpoint.of("foo", "http"), ServicePorts.of("http"))
+        .addVolume("/foo", "/bar")
+        .build();
+
+    assertThat(job.getEnv(), hasEntry("env","var"));
+    assertThat(job.getMetadata(), hasEntry("meta","data"));
+    assertThat(job.getPorts(), hasEntry("http", PortMapping.of(80, 8000)));
+    assertThat(job.getRegistration(),
+        hasEntry(ServiceEndpoint.of("foo", "http"), ServicePorts.of("http")));
+    assertThat(job.getVolumes(), hasEntry("/foo", "/bar"));
+  }
+
   @Test
   public void verifySha1ID() throws IOException {
     final Map<String, Object> expectedConfig = map("command", asList("foo", "bar"),
@@ -406,6 +426,7 @@ public class JobTest {
   public void verifyJobIsImmutable() {
     final List<String> expectedCommand = ImmutableList.of("foo");
     final Map<String, String> expectedEnv = ImmutableMap.of("e1", "1");
+    final Map<String, String> expectedMetadata = ImmutableMap.of("foo", "bar");
     final Map<String, PortMapping> expectedPorts = ImmutableMap.of("p1", PortMapping.of(1, 2));
     final Map<ServiceEndpoint, ServicePorts> expectedRegistration =
         ImmutableMap.of(ServiceEndpoint.of("foo", "tcp"), ServicePorts.of("p1"));
@@ -413,13 +434,15 @@ public class JobTest {
 
     final List<String> mutableCommand = Lists.newArrayList(expectedCommand);
     final Map<String, String> mutableEnv = Maps.newHashMap(expectedEnv);
+    final Map<String, String> mutableMetadata = Maps.newHashMap(expectedMetadata);
     final Map<String, PortMapping> mutablePorts = Maps.newHashMap(expectedPorts);
-    final HashMap<ServiceEndpoint, ServicePorts> mutableRegistration =
+    final Map<ServiceEndpoint, ServicePorts> mutableRegistration =
         Maps.newHashMap(expectedRegistration);
 
     final Job.Builder builder = Job.newBuilder()
         .setCommand(mutableCommand)
         .setEnv(mutableEnv)
+        .setMetadata(mutableMetadata)
         .setPorts(mutablePorts)
         .setImage("foobar:4711")
         .setName("foozbarz")
@@ -431,17 +454,20 @@ public class JobTest {
 
     mutableCommand.add("bar");
     mutableEnv.put("e2", "2");
+    mutableMetadata.put("some", "thing");
     mutablePorts.put("p2", PortMapping.of(3, 4));
     mutableRegistration.put(ServiceEndpoint.of("bar", "udp"), ServicePorts.of("p2"));
 
-    builder.addPort("added_port", PortMapping.of(4711));
     builder.addEnv("added_env", "FOO");
+    builder.addMetadata("added", "data");
+    builder.addPort("added_port", PortMapping.of(4711));
     builder.addRegistration(ServiceEndpoint.of("added_reg", "added_proto"),
                             ServicePorts.of("added_port"));
     builder.setGracePeriod(480);
 
     assertEquals(expectedCommand, job.getCommand());
     assertEquals(expectedEnv, job.getEnv());
+    assertEquals(expectedMetadata, job.getMetadata());
     assertEquals(expectedPorts, job.getPorts());
     assertEquals(expectedRegistration, job.getRegistration());
     assertEquals(expectedGracePeriod, job.getGracePeriod());

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
@@ -35,6 +35,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_GRACE_PERIOD;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HEALTH_CHECK;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HOSTNAME;
 import static com.spotify.helios.common.descriptors.Job.DEFAULT_NETWORK_MODE;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_METADATA;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
@@ -56,7 +57,9 @@ public class IdMismatchJobCreateTest extends SystemTestBase {
                 EMPTY_ENV, EMPTY_RESOURCES, EMPTY_PORTS, EMPTY_REGISTRATION,
                 EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                 EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
-                EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE)).get();
+                EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
+                EMPTY_METADATA)
+    ).get();
 
     // TODO (dano): Maybe this should be ID_MISMATCH but then JobValidator must become able to
     // TODO (dano): communicate that

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -22,6 +22,8 @@
 package com.spotify.helios.cli.command;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -76,6 +78,20 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 public class JobCreateCommand extends ControlCommand {
 
   private static final JobValidator JOB_VALIDATOR = new JobValidator();
+
+  /**
+   * If any of the keys of this map are set as environment variables (i.e. an environment variable
+   * of GIT_COMMIT_ID=abcdef is set when this command is run), then an entry will be added to the
+   * job's metadata map with with key=this-maps-value, value=environment variable value.
+   *
+   * @see #defaultMetadata()
+   */
+  private static final Map<String, String> DEFAULT_METADATA_ENVVARS = ImmutableMap.of(
+      // GIT_COMMIT is set by the Git plugin in Jenkins, so for jobs created in
+      // Jenkins this will automatically set GIT_COMMIT = the sha1 of the
+      // working tree
+      "GIT_COMMIT", "GIT_COMMIT"
+  );
 
   private final Argument fileArg;
   private final Argument templateArg;
@@ -321,6 +337,7 @@ public class JobCreateCommand extends ControlCommand {
     }
 
     final List<String> envList = options.getList(envArg.getDest());
+    // TODO (mbrown): does this mean that env config is only added when there is a CLI flag too?
     if (!envList.isEmpty()) {
       final Map<String, String> env = Maps.newHashMap();
       // Add environmental variables from helios job configuration file
@@ -332,11 +349,14 @@ public class JobCreateCommand extends ControlCommand {
       builder.setEnv(env);
     }
 
+    Map<String, String> metadata = Maps.newHashMap();
+    metadata.putAll(defaultMetadata());
     final List<String> metadataList = options.getList(metadataArg.getDest());
     if (!metadataList.isEmpty()) {
       // TODO (mbrown): values from job conf file (which maybe involves dereferencing env vars?)
-      builder.setMetadata(parseListOfPairs(metadataList, "metadata"));
+      metadata.putAll(parseListOfPairs(metadataList, "metadata"));
     }
+    builder.setMetadata(metadata);
 
     // Parse port mappings
     final List<String> portSpecs = options.getList(portArg.getDest());
@@ -530,6 +550,27 @@ public class JobCreateCommand extends ControlCommand {
       }
       return 1;
     }
+  }
+
+  /**
+   * Metadata to associate with jobs by default. Currently sets some metadata based upon environment
+   * variables set when the CLI command is run.
+   */
+  private Map<String, String> defaultMetadata() {
+
+    final Builder<String, String> builder = ImmutableMap.builder();
+
+    for (final Map.Entry<String, String> entry : DEFAULT_METADATA_ENVVARS.entrySet()) {
+      final String envKey = entry.getKey();
+      final String metadataKey = entry.getValue();
+
+      final String envValue = System.getenv(envKey);
+      if (envValue != null) {
+        builder.put(metadataKey, envValue);
+      }
+    }
+
+    return builder.build();
   }
 
   private static Map<String, String> parseListOfPairs(final List<String> list,

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
@@ -131,6 +131,7 @@ public class JobInspectCommand extends WildcardJobCommand {
       printMap(out, "Env:   ", QUOTE, job.getEnv());
       out.printf("Health check: %s%n", formatHealthCheck(job.getHealthCheck()));
       out.printf("Grace period (seconds): %s%n", job.getGracePeriod());
+      printMap(out, "Metadata: ", QUOTE, job.getMetadata());
       printMap(out, "Ports: ", FORMAT_PORTMAPPING, job.getPorts());
       printMap(out, "Reg: ", FORMAT_SERVICE_PORTS, job.getRegistration());
       out.printf("Security options: %s%n", job.getSecurityOpt());

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
@@ -22,6 +22,7 @@
 package com.spotify.helios.cli.command;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 
 import com.spotify.helios.client.HeliosClient;
@@ -90,15 +91,20 @@ public class JobCreateCommandTest {
     // For some reason the mocked options.getInt() returns 0 by default.
     // Explicitly return null to check that the value from the JSON file doesn't get overwritten.
     when(options.getInt("grace_period")).thenReturn(null);
+    // TODO (mbrown): this path is weird when running from IntelliJ, should be changed to not
+    // care about CWD
     doReturn(new File("src/main/resources/job_config.json")).when(options).get("file");
     doReturn(SECURITY_OPT).when(options).getList("security_opt");
     when(options.getString("network_mode")).thenReturn(NETWORK_MODE);
+    when(options.getList("metadata")).thenReturn(Lists.<Object>newArrayList("a=1", "b=2"));
+
     final int ret = command.run(options, client, out, false, null);
 
     assertEquals(0, ret);
     final String output = baos.toString();
     assertThat(output, containsString(
         "\"env\":{\"JVM_ARGS\":\"-Ddw.feature.randomFeatureFlagEnabled=true\"}"));
+    assertThat(output, containsString("\"metadata\":{\"a\":\"1\",\"b\":\"2\"},"));
     assertThat(output, containsString("\"gracePeriod\":100"));
     assertThat(output, containsString(
         "\"healthCheck\":{\"type\":\"exec\",\"command\":[\"touch\",\"/this\"],\"type\":\"exec\"},"));


### PR DESCRIPTION
The "metadata" field allows users to optionally store an arbitrary list of
key-value pairs to be associated with the Job.

The Helios master or agent doesn't act on the contents of the Job metadata,
but the field can be used for storing information alongside the Job
definition such as Git Commit ID, etc.

The (optional) list of metadata, as key-value pairs, can be sent in the
JobCreateCommand with the `-m` or `--metadata` switch, like:

```
$ helios create -m a=1 -m b=2 myjob:1 image
```

The format follows the same as the `--env` flag, in that the value is
required to be key-values delimited with `=`.

I don't have very strong opinions on if this is called "metadata" or "labels"
or "tags" or something else, although I do think "metadata" helps imply that
the data is just informational and won't be acted on (unlike "labels"/"tags").