### PR TITLE
Include ThrottleState in deployment group metrics

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -661,6 +661,7 @@ public class ZooKeeperMasterModel implements MasterModel {
         final Map<String, Object> metadata = Maps.newHashMap();
         metadata.put("jobState", taskStatus.getState());
         metadata.put("previousJobStates", previousJobStates);
+        metadata.put("throttleState", taskStatus.getThrottled());
         return opFactory.error("timed out waiting for job to reach RUNNING", host,
                                RollingUpdateError.TIMED_OUT_WAITING_FOR_JOB_TO_REACH_RUNNING,
                                metadata);


### PR DESCRIPTION
... when a deplyoment group fails because the job failed to reach
RUNNING before the configured time out. This is useful to distinguish
between likely infrastructural issues (e.g. IMAGE_MISSING) and likely
"user errors" (e.g. FLAPPING).