### PR TITLE
additional fixes for job metadata / GIT_COMMIT

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliDeploymentTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliDeploymentTest.java
@@ -121,7 +121,7 @@ public class CliDeploymentTest extends SystemTestBase {
             testJobName + ":" + testJobVersion + "-cloned")));
     final String clonedInspectOutput = cli("inspect", "--json", clonedJobId.toString());
     final Job clonedParsed = Json.read(clonedInspectOutput, Job.class);
-    assertEquals(expectedCloned, clonedParsed);
+    assertJobEquals(expectedCloned, clonedParsed);
 
     // Verify that port mapping and environment variables are correct
     final String statusString = cli("status", "--job", jobId.toString(), "--json");

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -88,7 +88,7 @@ public class JobCreateCommand extends ControlCommand {
    *
    * @see #defaultMetadata()
    */
-  private static final Map<String, String> DEFAULT_METADATA_ENVVARS = ImmutableMap.of(
+  public static final Map<String, String> DEFAULT_METADATA_ENVVARS = ImmutableMap.of(
       // GIT_COMMIT is set by the Git plugin in Jenkins, so for jobs created in
       // Jenkins this will automatically set GIT_COMMIT = the sha1 of the
       // working tree


### PR DESCRIPTION
This fixes failures in the system tests when run under Jenkins (or any
agent with the `GIT_COMMIT` environment variable set) that are caused by
the job being created with the environment variable automatically
included but the test does a deep-equality assertion against an expected
Job value.

The hacky fix here is to modify `assertJobEquals()` to remove any
automatically-included-metadata from being compared in the assertion.

This is a continuation of #671