### PR TITLE
master: allow for hash-less job create

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -71,6 +71,16 @@ public class JobValidator {
 
   public static final List<String> VALID_NETWORK_MODES = ImmutableList.of("bridge", "host");
 
+  private final boolean shouldValidateJobHash;
+
+  public JobValidator() {
+    this(true);
+  }
+
+  public JobValidator(final boolean shouldValidateJobHash) {
+    this.shouldValidateJobHash = shouldValidateJobHash;
+  }
+
   public Set<String> validate(final Job job) {
     final Set<String> errors = Sets.newHashSet();
 
@@ -192,7 +202,10 @@ public class JobValidator {
 
     errors.addAll(validateJobName(jobId, recomputedId));
     errors.addAll(validateJobVersion(jobIdVersion, recomputedId));
-    errors.addAll(validateJobHash(jobIdHash, recomputedId));
+
+    if (this.shouldValidateJobHash) {
+      errors.addAll(validateJobHash(jobIdHash, recomputedId));
+    }
 
     return errors;
   }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -774,6 +774,11 @@ public class Job extends Descriptor implements Comparable<Job> {
       return new Job(id, p);
     }
 
+    public Job buildWithoutHash() {
+      final JobId id = new JobId(p.name, p.version);
+      return new Job(id, p);
+    }
+
     private String hex(final byte[] bytes) {
       return BaseEncoding.base16().lowerCase().encode(bytes);
     }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -532,6 +532,13 @@ public class Job extends Descriptor implements Comparable<Job> {
         this.networkMode = p.networkMode;
         this.metadata = p.metadata;
       }
+
+      private Parameters withoutMetaParameters() {
+        final Parameters clone = new Parameters(this);
+        clone.creatingUser = null;
+
+        return clone;
+      }
     }
 
     public Builder setRegistrationDomain(final String domain) {
@@ -745,7 +752,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     public Job build() {
       final String configHash;
       try {
-        configHash = hex(Json.sha1digest(p));
+        configHash = hex(Json.sha1digest(p.withoutMetaParameters()));
       } catch (IOException e) {
         throw propagate(e);
       }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobId.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobId.java
@@ -80,12 +80,6 @@ public class JobId extends Descriptor implements Comparable<JobId> {
    */
   public JobId(final String name,
                final String version) {
-    checkNotNull(name, "name");
-    checkNotNull(version, "version");
-    checkArgument(!name.isEmpty(), "name is empty");
-    checkArgument(!version.isEmpty(), "version is empty");
-    checkArgument(name.indexOf(':') == -1, "name contains colon");
-    checkArgument(version.indexOf(':') == -1, "version contains colon");
     this.name = name;
     this.version = version;
     this.hash = null;

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobIdTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobIdTest.java
@@ -43,16 +43,6 @@ public class JobIdTest {
     assertEquals("foo:bar", id.toString());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testColonInNameNotAllowed() {
-    JobId.newBuilder().setName("foo:bar").setVersion("17").build();
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testColonInVersionNotAllowed() {
-    JobId.newBuilder().setName("foo").setVersion("release:17").build();
-  }
-
   @Test
   public void testJsonParsing() throws IOException {
     final String json = "\"foo:17:deadbeef\"";

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
@@ -47,6 +47,8 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class JobTest {
@@ -502,5 +504,17 @@ public class JobTest {
     final Job newJob = builder.setRegistration(newRegistration).build();
 
     assertNotEquals(job.getId().getHash(), newJob.getId().getHash());
+  }
+
+  @Test
+  public void testBuildWithoutHash() {
+    final Job.Builder builder = Job.newBuilder()
+        .setCommand(asList("foo", "bar"))
+        .setImage("foobar:4711")
+        .setName("foozbarz")
+        .setVersion("17");
+
+    assertNull(builder.buildWithoutHash().getId().getHash());
+    assertNotNull(builder.build().getId().getHash());
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
@@ -145,12 +145,12 @@ public class JobsResource {
   @ExceptionMetered
   public CreateJobResponse post(@Valid final Job job,
                                 @RequestUser final String username) {
-    final Collection<String> errors = JOB_VALIDATOR.validate(job);
-    final Job actualJob = job.toBuilder()
+    final Job.Builder clone = job.toBuilder()
         .setCreatingUser(username)
-        // if job had an id coming in, preserve it
-        .setHash(job.getId().getHash())
-        .build();
+        // If the job had a hash coming in, preserve it
+        .setHash(job.getId().getHash());
+    final Job actualJob = clone.build();
+    final Collection<String> errors = JOB_VALIDATOR.validate(actualJob);
     final String jobIdString = actualJob.getId().toString();
     if (!errors.isEmpty()) {
       throw badRequest(new CreateJobResponse(INVALID_JOB_DEFINITION, ImmutableList.copyOf(errors),

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/APITest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/APITest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.system;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.protocol.CreateJobResponse;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static com.google.common.io.ByteStreams.toByteArray;
+import static com.spotify.helios.common.protocol.CreateJobResponse.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class APITest extends SystemTestBase {
+
+  /**
+   * Verify that the Helios master generates and returns a hash if the submitted job creation
+   * request does not include one.
+   */
+  @Test
+  public void testHashLessJobCreation() throws Exception {
+    startDefaultMaster();
+
+    final Job job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setCommand(IDLE_COMMAND)
+        .setCreatingUser(TEST_USER)
+        .build();
+
+    // Remove the hash from the id in the json serialized job
+    final ObjectNode json = (ObjectNode) Json.reader().readTree(Json.asString(job));
+    json.set("id", TextNode.valueOf(testJobName + ":" + testJobVersion));
+
+    final HttpURLConnection req = post("/jobs?user=" + TEST_USER,
+                                       Json.asBytes(json));
+
+    assertEquals(req.getResponseCode(), 200);
+
+    final CreateJobResponse res = Json.read(toByteArray(req.getInputStream()),
+                                            CreateJobResponse.class);
+
+    assertEquals(OK, res.getStatus());
+    assertTrue(res.getErrors().isEmpty());
+    assertEquals(job.getId().toString(), res.getId());
+  }
+
+  private HttpURLConnection post(final String path, final byte[] body) throws IOException {
+    final URL url = new URL(masterEndpoint() + path);
+    final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("POST");
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoInput(true);
+    connection.setDoOutput(true);
+    connection.getOutputStream().write(body);
+    return connection;
+  }
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -79,7 +79,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 public class JobCreateCommand extends ControlCommand {
 
-  private static final JobValidator JOB_VALIDATOR = new JobValidator();
+  private static final JobValidator JOB_VALIDATOR = new JobValidator(false);
 
   /**
    * If any of the keys of this map are set as environment variables (i.e. an environment variable
@@ -533,7 +533,10 @@ public class JobCreateCommand extends ControlCommand {
       builder.setToken(token);
     }
 
-    final Job job = builder.build();
+    // We build without a hash here because we want the hash to be calculated server-side.
+    // This allows different CLI versions to be cross-compatible with different master versions
+    // that have either more or fewer job parameters.
+    final Job job = builder.buildWithoutHash();
 
     final Collection<String> errors = JOB_VALIDATOR.validate(job);
     if (!errors.isEmpty()) {
@@ -563,7 +566,7 @@ public class JobCreateCommand extends ControlCommand {
       if (json) {
         out.println(status.toJsonString());
       } else {
-        out.println(job.getId());
+        out.println(status.getId());
       }
       return 0;
     } else {


### PR DESCRIPTION
* Validate job after generating the hash, if not present.
* Add regression test.

Fixes #677, #610.