### PR TITLE
fix failure in CliConfigTest if HELIOS_MASTER is set on host

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -21,6 +21,7 @@
 
 package com.spotify.helios.cli;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -53,6 +54,7 @@ public class CliConfig {
   private static final String CONFIG_PATH = CONFIG_DIR + File.separator + CONFIG_FILE;
   public static final List<String> EMPTY_STRING_LIST = Collections.emptyList();
 
+  @VisibleForTesting
   static Map<String, String> environment = System.getenv();
 
   private final String username;

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.ConfigException;
 
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,6 +33,14 @@ public class CliConfigTest {
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Rule public final ExpectedException expectedEx = ExpectedException.none();
+
+  @Before
+   public void setUp() {
+    // ignore any environment variables that happen to be set on the JVM running these tests,
+    // for the random case where someone already has HELIOS_MASTER set but a test expects it to
+    // not be set.
+    CliConfig.environment = ImmutableMap.of();
+  }
 
   @Test
   public void testSite() throws Exception {

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.ConfigException;
 
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +40,15 @@ public class CliConfigTest {
     // ignore any environment variables that happen to be set on the JVM running these tests,
     // for the random case where someone already has HELIOS_MASTER set but a test expects it to
     // not be set.
+    resetEnvironmentVariables();
+  }
+
+  @After
+  public void tearDown() {
+    resetEnvironmentVariables();
+  }
+
+  private static void resetEnvironmentVariables() {
     CliConfig.environment = ImmutableMap.of();
   }
 


### PR DESCRIPTION
If you happen to run CliConfigTest#testConfigFromFile() on a host that
has the environment variable `HELIOS_MASTER` set, the test will fail as
it implicitly assumes no environment variables are set. To be safe when
running the test, always wipe out whatever env vars are inherited by the
process.