### PR TITLE
refactor CliConfig to remove static reference to System.getenv()

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -21,7 +21,6 @@
 
 package com.spotify.helios.cli;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -53,9 +52,6 @@ public class CliConfig {
   private static final String CONFIG_FILE = "config";
   private static final String CONFIG_PATH = CONFIG_DIR + File.separator + CONFIG_FILE;
   public static final List<String> EMPTY_STRING_LIST = Collections.emptyList();
-
-  @VisibleForTesting
-  static Map<String, String> environment = System.getenv();
 
   private final String username;
   private final List<String> domains;
@@ -109,11 +105,12 @@ public class CliConfig {
    * @throws IOException        If the file exists but could not be read
    * @throws URISyntaxException If a HELIOS_MASTER env var is present and doesn't parse as a URI
    */
-  public static CliConfig fromUserConfig() throws IOException, URISyntaxException {
+  public static CliConfig fromUserConfig(final Map<String, String> environmentVariables)
+      throws IOException, URISyntaxException {
     final String userHome = System.getProperty("user.home");
     final String defaults = userHome + File.separator + CONFIG_PATH;
     final File defaultsFile = new File(defaults);
-    return fromFile(defaultsFile);
+    return fromFile(defaultsFile, environmentVariables);
   }
 
   /**
@@ -126,18 +123,24 @@ public class CliConfig {
    * @throws IOException        If the file exists but could not be read
    * @throws URISyntaxException If a HELIOS_MASTER env var is present and doesn't parse as a URI
    */
-  public static CliConfig fromFile(final File defaultsFile) throws IOException, URISyntaxException {
+  public static CliConfig fromFile(final File defaultsFile,
+                                   final Map<String, String> environmentVariables)
+      throws IOException, URISyntaxException {
+
     final Config config;
     if (defaultsFile.exists() && defaultsFile.canRead()) {
       config = ConfigFactory.parseFile(defaultsFile);
     } else {
       config = ConfigFactory.empty();
     }
-    return fromEnvVar(config);
+    return fromEnvVar(config, environmentVariables);
   }
 
-  public static CliConfig fromEnvVar(final Config config) throws URISyntaxException {
-    final String master = environment.get("HELIOS_MASTER");
+  public static CliConfig fromEnvVar(final Config config,
+                                     final Map<String, String> environmentVariables)
+      throws URISyntaxException {
+
+    final String master = environmentVariables.get("HELIOS_MASTER");
     if (master == null) {
       return fromConfig(config);
     }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -108,7 +108,7 @@ public class CliParser {
         .version(format("%s%nTested on Docker %s", NAME_AND_VERSION, TESTED_DOCKER_VERSION))
         .description(format("%s%n%n%s%n%s", NAME_AND_VERSION, HELP_ISSUES, HELP_WIKI));
 
-    cliConfig = CliConfig.fromUserConfig();
+    cliConfig = CliConfig.fromUserConfig(System.getenv());
 
     final GlobalArgs globalArgs = addGlobalArgs(parser, cliConfig, true);
 

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -3,10 +3,8 @@ package com.spotify.helios.cli;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -33,14 +31,6 @@ public class CliParserTest {
   private static final String[] DOMAINS = {"foo", "bar", "baz"};
   private static final String SERVICE = "foo-service";
   private static final String SRV = "helios";
-
-  @Before
-  public void init() {
-    // TODO (dxia) For some reason CliConfig.java:59 never gets called here, but it's called when
-    // running CliConfigTest. If I don't clear the environment attribute, there's a stray key -> val
-    // of "HELIOS_MASTER" -> "domain://foo" left behind from somewhere that screws up the tests.
-    CliConfig.environment = ImmutableMap.of();
-  }
 
   @Test
   public void testComputeTargetsSingleEndpoint() throws Exception {


### PR DESCRIPTION
Storing the result of `System.getenv()` in a non-private static
reference causes the tests that touch `CliConfig` to need to worry about
setting or resetting this reference for the environment variables it
wants to simulate as being present for it's test case.

Refactoring `CliConfig.fromUserConfig()` to require the caller to pass
along what it thinks it's environment variables are (which is only
called from one place in non-test code) removes this need for the tests
worry about cleanup and state.