### PR TITLE
WIP: Authentication documentation and plan

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,77 @@
+# Authentication
+
+This document details how to configure your Helios installation to authenticate
+requests between the Helios CLI and the Helios masters/cluster.
+
+# TODOs for this document
+
+- configuration needed to setup master to require authentication
+  - make sure authentication can be enabled based on client version header, to
+    apply to versions >= some value and/or completely
+- add notion of schemes
+- link to how to setup https for helios masters
+
+## Authentication flow
+
+*Note that since all authentication requires clients to send some sort of
+credentials over the wire to the Helios masters, you should first configure
+your Helios clusters to use HTTPS*
+
+When configured to do so, the Helios master(s) will respond to any
+unauthenticated request with a `HTTP 401 Unauthorized` status code in the
+response. The master will set the `WWW-Authenticate` header in the response
+with the configured scheme for the client to use.
+
+When the client receives this response status code, it will look for a plugin
+registered for the given scheme. The Helios CLI will have support for the
+[`crtauth`][] scheme built in, but additional schemes can be added to the CLI
+by doing ... *TODO*.
+
+If the client cannot find a plugin for the scheme, it will be unable to proceed.
+
+After finding the plugin, the client activates it. The plugin is then
+responsible for performing authentication - for example in the crtauth flow (as
+explained below), it is the plugin's role to handle making the multiple HTTP
+requests for the two-step challenge-response flow.
+
+The end result of authenticating is that the Helios server gives the client an
+access token which should be included in the `Authorization` header of any
+subsequent HTTP requests.
+
+Access tokens have an associated expiration time, although the time at which
+the token expires is not communicated to the client. When the client makes a
+request to a protected resource on the service with an expired access token,
+the server will again respond with `401 Unauthorized` to signal that the client
+needs to perform the authentication flow again.
+
+### Crtauth flow
+
+To begin the crtauth flow, the client sends a request to `/_auth` on one of the
+masters to request a challenge. The client's request includes the username of
+the current user (`System.getProperty("user.name")` in Java, but this should be
+overridable via the CLI). The server will response with a challenge.
+
+The client signs the challenge using the user's configured SSH key and sends it
+to the server in a second request. 
+
+The server verifies that the signed challenge is valid for the given user. If
+valid, the server sends back an access token that the client is to use in all
+subsequent requests to the server. 
+
+
+## Supported authentication schemes
+
+- [crtauth][]
+
+
+## How to configure the Helios masters to require authentication
+
+*TODO - document CLI args when starting the master, and how to restrict
+authentication to only certain client versions*
+
+## How to add support to Helios for additional schemes
+
+*TODO - what classes to implement*
+
+
+[crtauth]: https://github.com/spotify/crtauth


### PR DESCRIPTION
**Don't merge**

Adds a doc on the topic of authentication in Helios:
- how to enable it
- how crtauth works
- how to setup different schemes if desired
- document the protocol / flow between client and server

This is very rough and I'm really just sharing it at this point to be able to collaborate and discuss some of the details via Github.

I thought it would be useful to draft how we picture Authentication working, in all it's details, before starting to implement anything.

@rohansingh @davidxia @gimaker 