### PR TITLE
add validation of access tokens in http requests to master

### DIFF
--- a/helios-authentication/src/main/java/com/spotify/helios/authentication/HttpAuthenticator.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/authentication/HttpAuthenticator.java
@@ -23,6 +23,9 @@ package com.spotify.helios.authentication;
 
 public interface HttpAuthenticator {
 
+  /** The name of this authentication scheme */
+  String getSchemeName();
+
   String getHttpAuthHeaderKey();
 
   String createChallenge(String request) throws HeliosAuthException;
@@ -33,4 +36,6 @@ public interface HttpAuthenticator {
 
   String badAuthHeaderMsg();
 
+  // TODO (mbrown): correct semantics for this method
+  boolean verifyToken(String username, String accessToken);
 }

--- a/helios-authentication/src/main/java/com/spotify/helios/authentication/NopHttpAuthenticator.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/authentication/NopHttpAuthenticator.java
@@ -24,6 +24,16 @@ package com.spotify.helios.authentication;
 class NopHttpAuthenticator implements HttpAuthenticator {
 
   @Override
+  public String getSchemeName() {
+    return "noop";
+  }
+
+  @Override
+  public boolean verifyToken(String username, String accessToken) {
+    return true;
+  }
+
+  @Override
   public String getHttpAuthHeaderKey() {
     return null;
   }

--- a/helios-client/src/main/java/com/spotify/helios/common/PomVersion.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/PomVersion.java
@@ -22,13 +22,14 @@
 package com.spotify.helios.common;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ComparisonChain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Iterables.size;
 
-public class PomVersion {
+public class PomVersion implements Comparable<PomVersion> {
   private final boolean isSnapshot;
   private final int major;
   private final int minor;
@@ -119,5 +120,15 @@ public class PomVersion {
       return false;
     }
     return patch == other.patch;
+  }
+
+  @Override
+  public int compareTo(PomVersion o) {
+    return ComparisonChain.start()
+        .compare(this.major, o.major)
+        .compare(this.minor, o.minor)
+        .compare(this.patch, o.patch)
+        .compareTrueFirst(this.isSnapshot, o.isSnapshot)
+        .result();
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/common/PomVersionTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/PomVersionTest.java
@@ -71,4 +71,21 @@ public class PomVersionTest {
           e.getMessage().contains("number"));
     }
   }
+
+  @Test
+  public void testComparable() {
+    PomVersion v1 = new PomVersion(false, 1, 0, 5);
+    PomVersion v2 = new PomVersion(false, 2, 1, 0);
+
+    assertTrue(v1.compareTo(v2) < 0);
+    assertTrue(v2.compareTo(v1) > 0);
+  }
+
+  @Test
+  public void testComparable_Equals() {
+    PomVersion v1 = new PomVersion(false, 1, 0, 0);
+    PomVersion v2 = new PomVersion(false, 1, 0, 0);
+    assertEquals(0, v1.compareTo(v2));
+    assertEquals(0, v2.compareTo(v1));
+  }
 }

--- a/helios-crtauth/src/main/java/com/spotify/helios/authentication/crtauth/CrtHttpAuthenticator.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/authentication/crtauth/CrtHttpAuthenticator.java
@@ -39,6 +39,17 @@ public class CrtHttpAuthenticator implements HttpAuthenticator {
   }
 
   @Override
+  public String getSchemeName() {
+    return "crtauth";
+  }
+
+  @Override
+  public boolean verifyToken(String username, String accessToken) {
+    // TODO (mbrown): implement
+    return false;
+  }
+
+  @Override
   public String getHttpAuthHeaderKey() {
     return HEADER;
   }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
@@ -54,6 +54,7 @@ public class MasterConfig extends Configuration {
   private Path stateDirectory;
   private Path authPlugin;
   private String authSecret;
+  private String versionNumberRequiredForAuthentication;
 
   public String getDomain() {
     return domain;
@@ -224,6 +225,15 @@ public class MasterConfig extends Configuration {
 
   public MasterConfig setAuthSecret(final String authSecret) {
     this.authSecret = authSecret;
+    return this;
+  }
+
+  public String getVersionNumberRequiredForAuthentication() {
+    return versionNumberRequiredForAuthentication;
+  }
+
+  public MasterConfig setVersionNumberRequiredForAuthentication(String str) {
+    this.versionNumberRequiredForAuthentication = str;
     return this;
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -21,9 +21,11 @@
 
 package com.spotify.helios.master;
 
+import com.spotify.helios.common.PomVersion;
 import com.spotify.helios.servicescommon.ServiceParser;
 
 import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentChoice;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -44,6 +46,7 @@ public class MasterParser extends ServiceParser {
   private final Namespace options;
   private Argument httpArg;
   private Argument adminArg;
+  private Argument versionsForAuthArg;
   private Argument authPluginArg;
 
   public MasterParser(final String... args) throws ArgumentParserException {
@@ -72,7 +75,8 @@ public class MasterParser extends ServiceParser {
         .setKafkaBrokers(getKafkaBrokers())
         .setStateDirectory(getStateDirectory())
         .setAuthPlugin(getAuthPlugin())
-        .setAuthSecret(System.getenv("HELIOS_AUTH_SECRET"));
+        .setAuthSecret(System.getenv("HELIOS_AUTH_SECRET"))
+        .setVersionNumberRequiredForAuthentication(options.getString(versionsForAuthArg.getDest()));
 
     this.masterConfig = config;
   }
@@ -93,6 +97,13 @@ public class MasterParser extends ServiceParser {
         .setDefault(5802)
         .help("admin http port");
 
+    versionsForAuthArg = parser.addArgument("--auth-required-versions")
+        .help("Set to 'yes' to require authentication for all client versions. Set to a version "
+              + "string to require authentication for versions >= that version. Otherwise, Helios "
+              + "performs no authentication of client requests.")
+        .metavar("VERSION")
+        .choices(new VersionStringForAuthArgumentChoice());
+
     authPluginArg = parser.addArgument("--auth-plugin")
         .type(fileType().verifyExists().verifyCanRead())
         .help("Path to authenticator plugin.");
@@ -100,5 +111,27 @@ public class MasterParser extends ServiceParser {
 
   public MasterConfig getMasterConfig() {
     return masterConfig;
+  }
+
+  private static class VersionStringForAuthArgumentChoice implements ArgumentChoice {
+
+    @Override
+    public boolean contains(Object val) {
+      String value = String.valueOf(val);
+      if ("all".equalsIgnoreCase(value)) {
+        return true;
+      }
+      try {
+        PomVersion.parse(value);
+        return true;
+      } catch (RuntimeException e) {
+        return false;
+      }
+    }
+
+    @Override
+    public String textualFormat() {
+      return "'all' or a version string like 'x.y.z'";
+    }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -29,8 +29,9 @@ import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.codahale.metrics.MetricRegistry;
 import com.spotify.helios.agent.KafkaClientProvider;
-import com.spotify.helios.authentication.ServerAuthProvider;
 import com.spotify.helios.authentication.AuthProviders;
+import com.spotify.helios.authentication.ServerAuthProvider;
+import com.spotify.helios.master.http.AccessTokenFilter;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
 import com.spotify.helios.master.resources.AuthResource;
@@ -200,6 +201,15 @@ public class MasterService extends AbstractIdleService {
     environment.jersey().register(new AuthResource(serverAuthProvider.getHttpAuthenticator()));
 
     // Set up http server
+    if (config.getVersionNumberRequiredForAuthentication() != null) {
+      final AccessTokenFilter filter =
+          new AccessTokenFilter(null, config.getVersionNumberRequiredForAuthentication());
+
+      environment.servlets()
+          .addFilter("CheckForAccessToken", filter)
+          .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
+    }
+
     environment.servlets()
         .addFilter("VersionResponseFilter", VersionResponseFilter.class)
         .addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");

--- a/helios-services/src/main/java/com/spotify/helios/master/http/AccessTokenFilter.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/http/AccessTokenFilter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master.http;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.net.HttpHeaders;
+
+import com.spotify.helios.authentication.HttpAuthenticator;
+import com.spotify.helios.common.PomVersion;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static com.spotify.helios.common.VersionCompatibility.HELIOS_VERSION_HEADER;
+
+public class AccessTokenFilter implements Filter {
+
+  private final HttpAuthenticator authenticator;
+  private final Predicate<PomVersion> clientVersionRequiresAuth;
+
+  public AccessTokenFilter(HttpAuthenticator authenticator, String versionNumberRequiredForAuth) {
+    this.authenticator = authenticator;
+
+    if ("all".equalsIgnoreCase(versionNumberRequiredForAuth)) {
+      this.clientVersionRequiresAuth = Predicates.alwaysTrue();
+    } else {
+      final PomVersion minVersion = PomVersion.parse(versionNumberRequiredForAuth);
+      this.clientVersionRequiresAuth = new Predicate<PomVersion>() {
+        @Override
+        public boolean apply(PomVersion input) {
+          // -1 = minVersion is less than input, 0 = equal versions
+          // any input version above the minVersion requires auth
+          return minVersion.compareTo(input) < 1;
+        }
+      };
+    }
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    final HttpServletRequest httpRequest = (HttpServletRequest) request;
+    final HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+    final String clientVersionHeader = httpRequest.getHeader(HELIOS_VERSION_HEADER);
+    if (clientVersionHeader == null) {
+      httpResponse.sendError(401, "Requests must include '" + HELIOS_VERSION_HEADER + "' header");
+      return;
+    }
+
+    final PomVersion clientVersion = PomVersion.parse(clientVersionHeader);
+    if (clientVersionRequiresAuth.apply(clientVersion)) {
+      final String username = null; // TODO (mbrown): where does this come from?
+      final String accessToken = httpRequest.getHeader(authenticator.getHttpAuthHeaderKey());
+      if (accessToken == null) {
+        httpResponse.addHeader(HttpHeaders.WWW_AUTHENTICATE, authenticator.getSchemeName());
+        httpResponse.sendError(401);
+      } else if (!authenticator.verifyToken(username, accessToken)) {
+        // attach header or response about invalid/expiration?
+        httpResponse.addHeader(HttpHeaders.WWW_AUTHENTICATE, authenticator.getSchemeName());
+        httpResponse.sendError(401);
+      } else {
+        // valid!
+        chain.doFilter(request, response);
+      }
+    } else {
+      chain.doFilter(request, response);
+    }
+  }
+
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override
+  public void destroy() {
+  }
+}


### PR DESCRIPTION
When the master is started with `--auth-required-versions`, `AccessTokenFilter` checks each HTTP request to the master for the presence of an access token in the http headers.

If the http header is not present, a response of 401 Unauthorized is
sent.

If the http header is present, the supplied access token is checked
against the `HttpAuthenticator` that the master is configured to use. If
the authenticator indicates that the token is not valid (or has
expired), a response of 401 Unauthorized is sent.

Otherwise the request is allowed to continue.

Adding this filter requires a few changes in the HttpAuthenticator
interface:

- add a method to expose the name of the auth scheme being used so that
  it can be sent to unauthenticated clients in the WWW-Authenticate
  header
- add a method for validating the supplied access token for the user's
  request

some TODOs:
- Not clear where the `username` to use when validating the token will
  come from in the http request
- Should probably link the new argument controlling whether
  authentication is enabled with the loading of a plugin that actually
  does the authenication - enabling authentication but using the no-op
  implementation seems pointless
- is the signature for `verifyToken(username, token)` legit for the way
  that crtauth works?