### PR TITLE
master: Add support for logback config & Kafka

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -221,7 +221,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.8.2.0</version>
+      <version>0.8.2.1</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -242,6 +242,11 @@
       <groupId>net.kencochrane.raven</groupId>
       <artifactId>raven-logback</artifactId>
       <version>4.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.danielwegener</groupId>
+      <artifactId>logback-kafka-appender</artifactId>
+      <version>0.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>


### PR DESCRIPTION
1. If a logback-access.xml exists in the master state directory, use that
   instead of the included logback-access.xml resource.

2. Add a logback-kafka-appender dependency so that access logs can be sent
   directly to Kafka.