### PR TITLE
add authentication to helios

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,112 @@
+# Authentication
+
+This document details how to configure your Helios installation to authenticate
+requests between the Helios CLI and the Helios masters/cluster.
+
+# TODOs for this document
+
+- configuration needed to setup master to require authentication
+  - make sure authentication can be enabled based on client version header, to
+    apply to versions >= some value and/or completely
+- add notion of schemes
+- link to how to setup https for helios masters
+
+## Authentication flow
+
+*Note that since all authentication requires clients to send some sort of
+credentials over the wire to the Helios masters, you should first configure
+your Helios clusters to use HTTPS*
+
+When configured to do so, the Helios master(s) will respond to any
+unauthenticated request with a `HTTP 401 Unauthorized` status code in the
+response. The master will set the `WWW-Authenticate` header in the response
+with the configured scheme for the client to use.
+
+When the client receives this response status code, it will look for a plugin
+registered for the given scheme. The Helios CLI will have support for the
+[`crtauth`][] scheme built in, but additional schemes can be added to the CLI
+by doing ... *TODO*.
+
+If the client cannot find a plugin for the scheme, it will be unable to proceed.
+
+After finding the plugin, the client activates it. The plugin is then
+responsible for performing authentication - for example in the crtauth flow (as
+explained below), it is the plugin's role to handle making the multiple HTTP
+requests for the two-step challenge-response flow.
+
+The end result of authenticating is that the Helios server gives the client an
+access token which should be included in the `Authorization` header of any
+subsequent HTTP requests.
+
+Access tokens have an associated expiration time, although the time at which
+the token expires is not communicated to the client. When the client makes a
+request to a protected resource on the service with an expired access token,
+the server will again respond with `401 Unauthorized` to signal that the client
+needs to perform the authentication flow again.
+
+### crtauth flow
+
+To begin the crtauth flow, the client sends a request to `/_auth` on one of the
+masters to request a challenge. The client's request includes the username of
+the current user (`System.getProperty("user.name")` in Java, but this should be
+overridable via the CLI). The server will response with a challenge.
+
+The client signs the challenge using the user's configured SSH key and sends it
+to the server in a second request. 
+
+The server verifies that the signed challenge is valid for the given user. If
+valid, the server sends back an access token that the client is to use in all
+subsequent requests to the server. 
+
+
+## Supported authentication schemes
+
+- [crtauth][]
+
+
+## How to configure the Helios masters to require authentication
+
+*TODO - document CLI args when starting the master, and how to restrict
+authentication to only certain client versions*
+
+## How to add support to Helios for additional schemes
+
+Pieces for implementing support for a new scheme:
+
+server-side:
+```java
+interface Authenticator {
+    /** 
+     * Given a token supplied in the "Authorization" header of the HTTP
+     * request to Helios master, check if the token is valid.
+     * An expired token should be treated like an invalid token by
+     * returning false.
+     */
+    boolean verifyToken(String username, String token)
+
+    /** 
+     * Allows the authentication scheme to register additional HTTP endpoints
+     * in Helios in the form of Jersey resource classes. This allows the scheme
+     * to customize the flow for performing the authentication handshake, for
+     * example to handle the two-step request-response cycle for crtauth.
+     * 
+     * If the scheme requires no custom HTTP endpoints (for instance, if just
+     * validating a pre-shared secret token), return Optional.absent().
+     */
+    Optional<AuthenticationFlowEndpoint> authenticationFlowEndpoint();
+}
+
+interface AuthenticationFlowEndpoint {
+    /** 
+     * Return an Object (i.e. Resource class instance) to be registered with
+     * Jersey at Helios master-startup which provides the HTTP endpoints needed
+     * for this scheme's authentication handshake.
+     */
+    Object createJerseyResource(com.spotify.helios.master.MasterConfig config);
+}
+```
+
+*TODO - what classes to implement*
+
+
+[crtauth]: https://github.com/spotify/crtauth

--- a/helios-authentication/pom.xml
+++ b/helios-authentication/pom.xml
@@ -49,6 +49,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/helios-authentication/pom.xml
+++ b/helios-authentication/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>helios-parent</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Helios Authentication</name>
+  <artifactId>helios-authentication</artifactId>
+  <packaging>jar</packaging>
+
+  <description>
+    SPI for authentication in Helios. Defines the framework for authentication using
+    plugins, and an example implementation providing HTTP Basic Authentication.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.6</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>17.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-jersey</artifactId>
+      <version>0.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-auth</artifactId>
+      <version>0.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.0-rc2</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPlugin.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPlugin.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth;
+
+import com.sun.jersey.api.model.Parameter;
+import com.sun.jersey.spi.inject.InjectableProvider;
+
+import io.dropwizard.auth.Auth;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+
+/**
+ * @param <C> the type of Credentials used
+ */
+public interface AuthenticationPlugin<C> {
+
+  /**
+   * The name of the scheme that this plugin provides.
+   * <p>
+   * When the Helios master starts up and attempts to load all configured authentication plugins,
+   * it will compare the return value of this method against the <code>--auth-scheme</code>
+   * argument that it was started with.
+   * </p>
+   */
+  String schemeName();
+
+  ServerAuthentication<C> serverAuthentication();
+
+  ClientAuthentication<C> clientAuthentication();
+
+  interface ServerAuthentication<C> {
+
+    /**
+     * The server-side authentication plugin needs to supply an InjectableProvider to Jersey to
+     * allow
+     * it to authenticate HTTP requests whenever the resource has an {@link Auth} annotation.
+     * <p>
+     * Plugin implementations will have to return an InjectableProvider whose
+     * <pre>getInjectable</pre> method examines the current HTTP request to extract the
+     * Authorization header (or other headers), constructs a "credentials" object out of them, and
+     * runs that through an instance of {@link io.dropwizard.auth.Authenticator} to get the
+     * HeliosUser instance.
+     *
+     * @see io.dropwizard.auth.basic.BasicAuthProvider Dropwizard's BasicAuthProvider as an example
+     */
+    // TODO (mbrown): change this signature to be just the Authenticator and do the common work of
+    // the InjectableProvider in this package, as it is mostly boilerplate
+    InjectableProvider<Auth, Parameter> authProvider();
+
+    /**
+     * A hook for implementations to register additional Jersey components, such as Resource
+     * classes
+     * for multi-stepped authentication handshakes.
+     */
+    void registerAdditionalJerseyComponents(JerseyEnvironment env);
+  }
+
+  interface ClientAuthentication<C> {
+    // TODO (mbrown): have an interface!
+  }
+}

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPluginLoader.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPluginLoader.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.ServiceLoader;
 
-public class AuthenticatorLoader {
+public class AuthenticationPluginLoader {
 
   public static AuthenticationPlugin<?> load(ServerAuthenticationConfig config) {
     return load(config, ImmutableList.<Path>of());

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticatorLoader.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticatorLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth;
+
+import com.google.common.collect.ImmutableList;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.ServiceLoader;
+
+public class AuthenticatorLoader {
+
+  public static AuthenticationPlugin<?> load(ServerAuthenticationConfig config) {
+    return load(config, ImmutableList.<Path>of());
+  }
+
+  public static AuthenticationPlugin<?> load(ServerAuthenticationConfig config,
+                                             List<Path> pluginPaths) {
+
+    final String scheme = config.getEnabledScheme();
+
+    // TODO (mbrown): extra classloader magic for plugin paths
+    final ServiceLoader<AuthenticationPlugin> loader =
+        ServiceLoader.load(AuthenticationPlugin.class);
+
+    for (AuthenticationPlugin plugin : loader) {
+      if (scheme.equals(plugin.schemeName())) {
+        return plugin;
+      }
+    }
+
+    throw new IllegalStateException("No AuthenticationPlugin found for scheme " + scheme
+                                    + ". Check classpath and plugin path settings");
+  }
+}

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/HeliosUser.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/HeliosUser.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth;
+
+/** Represents an authenticated user accessing resources within the Helios master service. */
+public class HeliosUser {
+
+  private final String username;
+
+  public HeliosUser(String username) {
+    this.username = username;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+}

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/ServerAuthenticationConfig.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/ServerAuthenticationConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth;
+
+import java.nio.file.Path;
+
+public class ServerAuthenticationConfig {
+
+  private String enabledScheme;
+  private String minimumEnabledVersion;
+  private Path pluginsPath;
+
+  public String getEnabledScheme() {
+    return enabledScheme;
+  }
+
+  public ServerAuthenticationConfig setEnabledScheme(String enabledScheme) {
+    this.enabledScheme = enabledScheme;
+    return this;
+  }
+
+  public String getMinimumEnabledVersion() {
+    return minimumEnabledVersion;
+  }
+
+  public ServerAuthenticationConfig setMinimumEnabledVersion(String minimumEnabledVersion) {
+    this.minimumEnabledVersion = minimumEnabledVersion;
+    return this;
+  }
+
+  public boolean isEnabledForAllVersions() {
+    return this.minimumEnabledVersion == null;
+  }
+
+  public Path getPluginsPath() {
+    return pluginsPath;
+  }
+
+  public ServerAuthenticationConfig setPluginsPath(Path pluginsPath) {
+    this.pluginsPath = pluginsPath;
+    return this;
+  }
+}

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicAuthenticationPlugin.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicAuthenticationPlugin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.basic;
+
+import com.google.auto.service.AutoService;
+
+import com.spotify.helios.auth.AuthenticationPlugin;
+
+import io.dropwizard.auth.basic.BasicCredentials;
+
+/** Proof of concept for the authentication plugin framework using HTTP Basic Auth. */
+@AutoService(AuthenticationPlugin.class)
+public class BasicAuthenticationPlugin implements AuthenticationPlugin<BasicCredentials> {
+
+  @Override
+  public String schemeName() {
+    return "http-basic";
+  }
+
+  @Override
+  public ServerAuthentication<BasicCredentials> serverAuthentication() {
+    return new BasicServerAuthentication();
+  }
+
+  @Override
+  public ClientAuthentication<BasicCredentials> clientAuthentication() {
+    return null;
+  }
+}

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicServerAuthentication.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicServerAuthentication.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.basic;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
+import com.spotify.helios.auth.HeliosUser;
+import com.sun.jersey.api.model.Parameter;
+import com.sun.jersey.spi.inject.InjectableProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import io.dropwizard.auth.Auth;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import io.dropwizard.auth.basic.BasicAuthProvider;
+import io.dropwizard.auth.basic.BasicCredentials;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A very simple implementation of ServerAuthentication to demonstrate how to implement an
+ * authentication plugin. This version reads in a user "database" from a JSON file store at a path
+ * configured by an environment variable, making it likely far too simple to be used for anything
+ * but demonstrations.
+ */
+public class BasicServerAuthentication implements ServerAuthentication<BasicCredentials> {
+
+
+  private final Map<String, String> users;
+
+  public BasicServerAuthentication() {
+    final String path = System.getenv("AUTH_BASIC_USERDB");
+    checkNotNull(path, "Environment variable AUTH_BASIC_USERDB not defined");
+
+    File file = new File(path);
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    try {
+      this.users = objectMapper.readValue(file, new TypeReference<Map<String, String>>() {
+      });
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  public BasicServerAuthentication(Map<String, String> users) {
+    this.users = users;
+  }
+
+  @Override
+  public InjectableProvider<Auth, Parameter> authProvider() {
+    Authenticator<BasicCredentials, HeliosUser> authenticator =
+        new Authenticator<BasicCredentials, HeliosUser>() {
+          @Override
+          public Optional<HeliosUser> authenticate(BasicCredentials credentials)
+              throws AuthenticationException {
+            final String username = credentials.getUsername();
+            final String password = credentials.getPassword();
+            if (users.containsKey(username) && users.get(username).equals(password)) {
+              Optional.of(new HeliosUser(username));
+            }
+            return Optional.absent();
+          }
+        };
+
+    // dropwizard provides an InjectableProvider for basic auth
+    return new BasicAuthProvider<>(authenticator, "helios");
+  }
+
+  @Override
+  public void registerAdditionalJerseyComponents(JerseyEnvironment env) {
+  }
+}

--- a/helios-authentication/src/test/java/com/spotify/helios/auth/AuthenticationPluginLoaderTest.java
+++ b/helios-authentication/src/test/java/com/spotify/helios/auth/AuthenticationPluginLoaderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class AuthenticationPluginLoaderTest {
+
+  private final ServerAuthenticationConfig config = new ServerAuthenticationConfig();
+
+  @Test
+  public void canLoadPlugin() {
+    System.out.println(TestPlugin.class.getCanonicalName());
+    config.setEnabledScheme("test-plugin");
+    final AuthenticationPlugin<?> plugin = AuthenticationPluginLoader.load(config);
+
+    assertThat(plugin, instanceOf(TestPlugin.class));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void pluginNotFound() {
+    config.setEnabledScheme("something-that-does-not-exist");
+    AuthenticationPluginLoader.load(config);
+  }
+
+  /** Plugin implementation used by tests above */
+  public static class TestPlugin implements AuthenticationPlugin<String> {
+
+    @Override
+    public String schemeName() {
+      return "test-plugin";
+    }
+
+    @Override
+    public ServerAuthentication<String> serverAuthentication() {
+      return null;
+    }
+
+    @Override
+    public ClientAuthentication<String> clientAuthentication() {
+      return null;
+    }
+  }
+}

--- a/helios-authentication/src/test/resources/META-INF/services/com.spotify.helios.auth.AuthenticationPlugin
+++ b/helios-authentication/src/test/resources/META-INF/services/com.spotify.helios.auth.AuthenticationPlugin
@@ -1,0 +1,1 @@
+com.spotify.helios.auth.AuthenticationPluginLoaderTest$TestPlugin

--- a/helios-client/src/main/java/com/spotify/helios/common/PomVersion.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/PomVersion.java
@@ -22,13 +22,14 @@
 package com.spotify.helios.common;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ComparisonChain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.collect.Iterables.get;
 import static com.google.common.collect.Iterables.size;
 
-public class PomVersion {
+public class PomVersion implements Comparable<PomVersion> {
   private final boolean isSnapshot;
   private final int major;
   private final int minor;
@@ -119,5 +120,15 @@ public class PomVersion {
       return false;
     }
     return patch == other.patch;
+  }
+
+  @Override
+  public int compareTo(PomVersion o) {
+    return ComparisonChain.start()
+        .compare(this.major, o.major)
+        .compare(this.minor, o.minor)
+        .compare(this.patch, o.patch)
+        .compareTrueFirst(this.isSnapshot, o.isSnapshot)
+        .result();
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/common/PomVersionTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/PomVersionTest.java
@@ -71,4 +71,21 @@ public class PomVersionTest {
           e.getMessage().contains("number"));
     }
   }
+
+  @Test
+  public void testComparable() {
+    PomVersion v1 = new PomVersion(false, 1, 0, 5);
+    PomVersion v2 = new PomVersion(false, 2, 1, 0);
+
+    assertTrue(v1.compareTo(v2) < 0);
+    assertTrue(v2.compareTo(v1) > 0);
+  }
+
+  @Test
+  public void testComparable_Equals() {
+    PomVersion v1 = new PomVersion(false, 1, 0, 0);
+    PomVersion v2 = new PomVersion(false, 1, 0, 0);
+    assertEquals(0, v1.compareTo(v2));
+    assertEquals(0, v2.compareTo(v1));
+  }
 }

--- a/helios-crtauth/pom.xml
+++ b/helios-crtauth/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>helios-parent</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Helios CRTauth plugin</name>
+  <artifactId>helios-crtauth</artifactId>
+  <packaging>jar</packaging>
+
+  <description>A CRTauth and LDAP authentication provider for Helios.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>helios-authentication</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.0-rc2</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>crtauth</artifactId>
+      <version>0.2.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>crtauth-agent-signer</artifactId>
+      <version>0.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.ldap</groupId>
+      <artifactId>spring-ldap-core</artifactId>
+      <version>2.0.2.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.4.1</version>
+    </dependency>
+
+    <!-- test deps -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtAccessToken.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtAccessToken.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+/** Represents the credentials sent in HTTP requests for CRT */
+public class CrtAccessToken {
+
+  private final String token;
+
+  public CrtAccessToken(String token) {
+    this.token = token;
+  }
+
+  public String getToken() {
+    return token;
+  }
+}

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtAuthProvider.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtAuthProvider.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+import com.google.common.base.Optional;
+
+import com.spotify.helios.auth.HeliosUser;
+import com.sun.jersey.api.core.HttpContext;
+import com.sun.jersey.api.model.Parameter;
+import com.sun.jersey.core.spi.component.ComponentContext;
+import com.sun.jersey.core.spi.component.ComponentScope;
+import com.sun.jersey.server.impl.inject.AbstractHttpContextInjectable;
+import com.sun.jersey.spi.inject.Injectable;
+import com.sun.jersey.spi.inject.InjectableProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import io.dropwizard.auth.Auth;
+import io.dropwizard.auth.AuthenticationException;
+
+/**
+ * This class sets up Jersey to be able to call our Authenticator instance whenever a constructor or
+ * method parameter is annotated with {@link Auth}.
+ */
+public class CrtAuthProvider implements InjectableProvider<Auth, Parameter> {
+
+  private final CrtTokenAuthenticator tokenAuthenticator;
+
+  public CrtAuthProvider(CrtTokenAuthenticator tokenAuthenticator) {
+    this.tokenAuthenticator = tokenAuthenticator;
+  }
+
+  @Override
+  public ComponentScope getScope() {
+    return ComponentScope.PerRequest;
+  }
+
+  @Override
+  public Injectable getInjectable(ComponentContext ic, Auth auth, Parameter parameter) {
+    return new CrtAuthInjectable(tokenAuthenticator, auth.required());
+  }
+
+  private static class CrtAuthInjectable extends AbstractHttpContextInjectable<HeliosUser> {
+
+    private static final Logger log = LoggerFactory.getLogger(CrtAuthInjectable.class);
+
+    private final CrtTokenAuthenticator authenticator;
+    private final boolean required;
+
+    public CrtAuthInjectable(CrtTokenAuthenticator authenticator, boolean required) {
+      this.authenticator = authenticator;
+      this.required = required;
+    }
+
+    /**
+     * The role of this method is to examine the HttpContext for the Authorization header,  turn
+     * it into a CrtAccessToken instance if present, and run it through the Authenticator.
+     */
+    @Override
+    public HeliosUser getValue(HttpContext c) {
+      final String authHeader = c.getRequest().getHeaderValue(HttpHeaders.AUTHORIZATION);
+
+      if (authHeader != null) {
+        final String[] tokenParts = authHeader.split(":");
+        if (tokenParts.length == 2) {
+          final String prefix = tokenParts[0];
+
+          if (prefix.equals("chap")) {
+            final String token = tokenParts[1];
+            try {
+              final Optional<HeliosUser> result =
+                  authenticator.authenticate(new CrtAccessToken(token));
+
+              if (result.isPresent()) {
+                return result.get();
+              }
+            } catch (AuthenticationException e) {
+              log.warn("Error authenticating credentials", e);
+              throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+            }
+          }
+        }
+      }
+
+      // if we have fallen through here, because the header is not present or is not in the
+      // expected structure, return 401 if the auth token is required.
+      if (required) {
+        throw new WebApplicationException(
+            Response.status(Status.UNAUTHORIZED)
+                // TODO (mbrown): check if this header value is correct
+                .header(HttpHeaders.WWW_AUTHENTICATE, "crtauth")
+                .type(MediaType.TEXT_PLAIN_TYPE)
+                .entity("Credentials are required to access this resource.")
+                .build());
+      }
+
+      return null;
+    }
+  }
+
+}

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtAuthenticationPlugin.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtAuthenticationPlugin.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+import com.google.auto.service.AutoService;
+
+import com.spotify.crtauth.CrtAuthServer;
+import com.spotify.crtauth.keyprovider.KeyProvider;
+import com.spotify.helios.auth.AuthenticationPlugin;
+
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+
+import java.util.concurrent.TimeUnit;
+
+@AutoService(AuthenticationPlugin.class)
+public class CrtAuthenticationPlugin implements AuthenticationPlugin<CrtAccessToken> {
+
+  @Override
+  public String schemeName() {
+    return "crtauth";
+  }
+
+  @Override
+  public ServerAuthentication<CrtAccessToken> serverAuthentication() {
+    // TODO (mbrown): check for null
+    final String ldapUrl = System.getenv("CRTAUTH_LDAP_URL");
+    final String ldapSearchPath = System.getenv("CRTAUTH_LDAP_SEARCH_PATH");
+    final String serverName = System.getenv("CRTAUTH_SERVERNAME");
+    final String secret = System.getenv("CRTAUTH_SECRET");
+    final String ldapFieldNameOfKey = System.getenv("CRTAUTH_LDAP_KEY_FIELDNAME");
+
+    final LdapContextSource contextSource = new LdapContextSource();
+    contextSource.setUrl(ldapUrl);
+    contextSource.setAnonymousReadOnly(true);
+    contextSource.setCacheEnvironmentProperties(false);
+
+    final LdapTemplate ldapTemplate = new LdapTemplate(contextSource);
+
+    // TODO (mbrown): this should be general, support reading from flat files etc
+    final KeyProvider keyProvider =
+        new LdapKeyProvider(ldapTemplate, ldapSearchPath, ldapFieldNameOfKey);
+
+    CrtAuthServer authServer = new CrtAuthServer.Builder()
+        .setServerName(serverName)
+        .setKeyProvider(keyProvider)
+        .setSecret(secret.getBytes())
+        .setTokenLifetimeInS((int) TimeUnit.MINUTES.toSeconds(9))
+        .build();
+
+    return new CrtServerAuthentication(new CrtTokenAuthenticator(authServer), authServer);
+  }
+
+  @Override
+  public ClientAuthentication<CrtAccessToken> clientAuthentication() {
+    return null;
+  }
+}

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtHandshakeResource.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtHandshakeResource.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+import com.spotify.crtauth.CrtAuthServer;
+import com.spotify.crtauth.exceptions.ProtocolVersionException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+@Path("/_auth")
+public class CrtHandshakeResource {
+
+  private final CrtAuthServer authServer;
+
+  public CrtHandshakeResource(CrtAuthServer authServer) {
+    this.authServer = authServer;
+  }
+
+  @GET
+  public Response handshake(@Context HttpHeaders headers) {
+    // initial request should have X-CHAP: request:<blob>
+    final String chap = headers.getRequestHeaders().getFirst("X-CHAP");
+    if (chap != null) {
+      if (chap.startsWith("request:")) {
+        return sendChallenge(chap);
+      } else if (chap.startsWith("response:")) {
+        return sendResponse(chap);
+      }
+    }
+
+    return Response.status(Status.BAD_REQUEST)
+        .header(HttpHeaders.CONTENT_TYPE, "text/plain")
+        .entity("Bad handshake")
+        .build();
+
+  }
+
+  private Response sendChallenge(String chap) {
+    final String requestPayload = chap.substring(chap.indexOf(":") + 1);
+    try {
+      final String challenge = authServer.createChallenge(requestPayload);
+      return Response.ok()
+          .header("X-CHAP", "challenge:" + challenge)
+          .build();
+    } catch (ProtocolVersionException e) {
+      // TODO (mbrown): proper response
+      return Response.status(Status.BAD_REQUEST)
+          .build();
+    }
+  }
+
+  private Response sendResponse(String chap) {
+    final String responsePayload = chap.substring(chap.indexOf(":") + 1);
+    final String token;
+    try {
+      token = authServer.createToken(responsePayload);
+      return Response.ok()
+          .header("X-CHAP", "token:" + token)
+          .build();
+    } catch (ProtocolVersionException e) {
+      // TODO (mbrown): proper response
+      return Response.status(Status.BAD_REQUEST)
+          .build();
+    }
+  }
+
+
+}

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtServerAuthentication.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtServerAuthentication.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+import com.spotify.crtauth.CrtAuthServer;
+import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
+import com.sun.jersey.api.model.Parameter;
+import com.sun.jersey.spi.inject.InjectableProvider;
+
+import io.dropwizard.auth.Auth;
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+
+public class CrtServerAuthentication implements ServerAuthentication<CrtAccessToken> {
+
+  private final CrtTokenAuthenticator authenticator;
+  private final CrtAuthServer authServer;
+
+  public CrtServerAuthentication(CrtTokenAuthenticator authenticator, CrtAuthServer authServer) {
+    this.authenticator = authenticator;
+    this.authServer = authServer;
+  }
+
+  @Override
+  public InjectableProvider<Auth, Parameter> authProvider() {
+    // register the jersey injectable that run whenever a resource with @Auth is requested
+    return new CrtAuthProvider(authenticator);
+  }
+
+  @Override
+  public void registerAdditionalJerseyComponents(JerseyEnvironment env) {
+    env.register(new CrtHandshakeResource(this.authServer));
+  }
+
+}

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtTokenAuthenticator.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtTokenAuthenticator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+import com.google.common.base.Optional;
+
+import com.spotify.crtauth.CrtAuthServer;
+import com.spotify.crtauth.exceptions.ProtocolVersionException;
+import com.spotify.crtauth.exceptions.TokenExpiredException;
+import com.spotify.helios.auth.HeliosUser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+
+class CrtTokenAuthenticator implements Authenticator<CrtAccessToken, HeliosUser> {
+
+  private static final Logger log = LoggerFactory.getLogger(CrtTokenAuthenticator.class);
+
+  private final CrtAuthServer crtAuthServer;
+
+  public CrtTokenAuthenticator(CrtAuthServer crtAuthServer) {
+    this.crtAuthServer = crtAuthServer;
+  }
+
+  @Override
+  public Optional<HeliosUser> authenticate(CrtAccessToken credentials)
+      throws AuthenticationException {
+
+    final String token = credentials.getToken();
+    final String encodedUsername;
+    try {
+      encodedUsername = crtAuthServer.validateToken(token);
+    } catch (TokenExpiredException | ProtocolVersionException e) {
+      log.warn("error validating CRT token", e);
+      return Optional.absent();
+    }
+
+    return Optional.of(new HeliosUser(encodedUsername));
+  }
+}

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/LdapKeyProvider.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/LdapKeyProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth.crt;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+
+import com.spotify.crtauth.exceptions.KeyNotFoundException;
+import com.spotify.crtauth.keyprovider.KeyProvider;
+import com.spotify.crtauth.utils.TraditionalKeyParser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.LdapTemplate;
+
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.List;
+
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
+/**
+ * Returns user data from an LDAP directory.
+ */
+// TODO (mbrown): generalize this
+public class LdapKeyProvider implements KeyProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(LdapKeyProvider.class);
+
+  private final LdapTemplate ldapTemplate;
+  private final String baseSearchPath;
+  /** name of the ldap attribute holding the key */
+  private final String fieldName;
+
+  public LdapKeyProvider(final LdapTemplate ldapTemplate,
+                         final String baseSearchPath,
+                         final String fieldName) {
+    this.fieldName = fieldName;
+    this.ldapTemplate = Preconditions.checkNotNull(ldapTemplate);
+    this.baseSearchPath = Preconditions.checkNotNull(baseSearchPath);
+  }
+
+  @Override
+  public RSAPublicKey getKey(final String username) throws KeyNotFoundException {
+    final List<String> result = ldapTemplate.search(
+        query()
+            .base(baseSearchPath)
+            .where("uid").is(username),
+        new AttributesMapper<String>() {
+          // TODO (mbrown): how spotify specific is this field.lowercase stuff?
+          @Override
+          public String mapFromAttributes(final Attributes attributes) throws NamingException {
+            log.debug("got ldap stuff for uid {}", username);
+            return attributes.get(fieldName.toLowerCase()).toString();
+          }
+        });
+
+    if (result.isEmpty()) {
+      throw new KeyNotFoundException();
+    } else if (result.size() == 1) {
+      final String r = result.get(0);
+      RSAPublicKeySpec publicKeySpec;
+      try {
+        final String sshPublicKey = r.replace(fieldName + ": ", "").trim();
+        publicKeySpec = TraditionalKeyParser.parsePemPublicKey(sshPublicKey);
+        final KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
+      } catch (InvalidKeyException | InvalidKeySpecException | NoSuchAlgorithmException e) {
+        throw Throwables.propagate(e);
+      }
+
+    }
+
+    throw new IllegalStateException("Found more than one LDAP user for name: " + username);
+  }
+}

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -151,6 +151,16 @@
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
+      <artifactId>helios-authentication</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>helios-crtauth</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
       <artifactId>helios-service-registration</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -162,7 +172,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.8</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -345,6 +355,12 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>2.5.0</version>
+    </dependency>
+    <!-- TODO: (dxia) This won't be needed once we upgrade this dependency in docker-client and upgrade docker-client here. -->
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-unixsocket</artifactId>
+      <version>0.8</version>
     </dependency>
   </dependencies>
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
@@ -21,6 +21,8 @@
 
 package com.spotify.helios.master;
 
+import com.spotify.helios.auth.ServerAuthenticationConfig;
+
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.List;
@@ -52,6 +54,7 @@ public class MasterConfig extends Configuration {
   private InetSocketAddress httpEndpoint;
   private List<String> kafkaBrokers;
   private Path stateDirectory;
+  private ServerAuthenticationConfig authenticationConfig;
 
   public String getDomain() {
     return domain;
@@ -214,4 +217,17 @@ public class MasterConfig extends Configuration {
   public InetSocketAddress getHttpEndpoint() {
     return httpEndpoint;
   }
+
+  public ServerAuthenticationConfig getAuthenticationConfig() {
+    return this.authenticationConfig;
+  }
+
+  public void setAuthenticationConfig(ServerAuthenticationConfig authenticationConfig) {
+    this.authenticationConfig = authenticationConfig;
+  }
+
+  public boolean isAuthenticationEnabled() {
+    return this.authenticationConfig != null;
+  }
+
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -21,14 +21,21 @@
 
 package com.spotify.helios.master;
 
+import com.spotify.helios.auth.ServerAuthenticationConfig;
+import com.spotify.helios.common.PomVersion;
 import com.spotify.helios.servicescommon.ServiceParser;
 
+import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentChoice;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
+import java.io.File;
 import java.net.InetSocketAddress;
+
+import static net.sourceforge.argparse4j.impl.Arguments.fileType;
 
 /**
  * Parses command-line arguments to produce the {@link MasterConfig}.
@@ -39,6 +46,12 @@ public class MasterParser extends ServiceParser {
 
   private Argument httpArg;
   private Argument adminArg;
+
+  // authentication-related arguments:
+  private Argument authenticationEnabled;
+  private Argument authenticationScheme;
+  private Argument authenticationMinimumVersion;
+  private Argument authenticationPluginsPathArg;
 
   public MasterParser(final String... args) throws ArgumentParserException {
     super("helios-master", "Spotify Helios Master", args);
@@ -66,6 +79,23 @@ public class MasterParser extends ServiceParser {
         .setKafkaBrokers(getKafkaBrokers())
         .setStateDirectory(getStateDirectory());
 
+    // TODO (mbrown): argparse way for require some arguments if others are set?
+    if (options.getBoolean(authenticationEnabled.getDest())) {
+      ServerAuthenticationConfig authConfig = new ServerAuthenticationConfig();
+      authConfig.setEnabledScheme(options.getString(authenticationScheme.getDest()));
+
+      final File pluginPath = options.get(authenticationPluginsPathArg.getDest());
+      if (pluginPath != null) {
+        authConfig.setPluginsPath(pluginPath.toPath());
+      }
+
+      final String minVersion = options.getString(authenticationMinimumVersion.getDest());
+      if (minVersion != null) {
+        authConfig.setMinimumEnabledVersion(minVersion);
+      }
+
+      config.setAuthenticationConfig(authConfig);
+    }
     this.masterConfig = config;
   }
 
@@ -79,9 +109,50 @@ public class MasterParser extends ServiceParser {
         .type(Integer.class)
         .setDefault(5802)
         .help("admin http port");
+
+    authenticationEnabled = parser.addArgument("--auth-enabled")
+        .type(Boolean.class)
+        .setDefault(false)
+        .action(Arguments.storeTrue())
+        .help("Enable authentication. Requires setting of --auth-scheme as well.");
+
+    authenticationScheme = parser.addArgument("--auth-scheme")
+        .metavar("SCHEMENAME")
+        .help("Name of authentication scheme to use. 'crtauth' support is built into Helios. "
+              + "For other values, --auth-plugin must also be set.");
+
+    authenticationMinimumVersion = parser.addArgument("--auth-minimum-version")
+        .help("Set to a version string to only require authentication for versions >= that version."
+              + " Otherwise all requests require authentication. Only valid when --auth-enabled"
+              + " is set.")
+        .metavar("VERSION-STRING")
+        .choices(new VersionStringChoice());
+
+    authenticationPluginsPathArg = parser.addArgument("--auth-plugin")
+        .type(fileType().verifyExists().verifyCanRead())
+        .help("Path to authenticator plugin.");
   }
 
   public MasterConfig getMasterConfig() {
     return masterConfig;
+  }
+
+  private static class VersionStringChoice implements ArgumentChoice {
+
+    @Override
+    public boolean contains(Object val) {
+      final String value = String.valueOf(val);
+      try {
+        PomVersion.parse(value);
+        return true;
+      } catch (RuntimeException e) {
+        return false;
+      }
+    }
+
+    @Override
+    public String textualFormat() {
+      return "a version string like 'x.y.z'";
+    }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -34,6 +34,7 @@ import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
 import com.spotify.helios.auth.ServerAuthenticationConfig;
 import com.spotify.helios.auth.AuthenticatorLoader;
 import com.spotify.helios.master.http.VersionResponseFilter;
+import com.spotify.helios.master.jersey.DisabledAuthInjectableProvider;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
 import com.spotify.helios.master.resources.DeploymentGroupResource;
 import com.spotify.helios.master.resources.HistoryResource;
@@ -221,6 +222,10 @@ public class MasterService extends AbstractIdleService {
 
       // register any additional resources needed by the plugin
       authentication.registerAdditionalJerseyComponents(environment.jersey());
+    } else {
+      // when authentication is disabled, we need to register an InjectableProvider with jersey to
+      // tell it what to do with all the @Auth annotations in our resources
+      environment.jersey().register(new DisabledAuthInjectableProvider());
     }
 
     final DefaultServerFactory serverFactory = ServiceUtil.createServerFactory(

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -32,7 +32,7 @@ import com.spotify.helios.agent.KafkaClientProvider;
 import com.spotify.helios.auth.AuthenticationPlugin;
 import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
 import com.spotify.helios.auth.ServerAuthenticationConfig;
-import com.spotify.helios.auth.AuthenticatorLoader;
+import com.spotify.helios.auth.AuthenticationPluginLoader;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.jersey.DisabledAuthInjectableProvider;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
@@ -215,7 +215,7 @@ public class MasterService extends AbstractIdleService {
     if (config.isAuthenticationEnabled()) {
       // Set up authentication
       final ServerAuthenticationConfig authConfig = config.getAuthenticationConfig();
-      final AuthenticationPlugin<?> authPlugin = AuthenticatorLoader.load(authConfig);
+      final AuthenticationPlugin<?> authPlugin = AuthenticationPluginLoader.load(authConfig);
       final ServerAuthentication<?> authentication = authPlugin.serverAuthentication();
 
       environment.jersey().register(authentication.authProvider());

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -29,6 +29,10 @@ import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.codahale.metrics.MetricRegistry;
 import com.spotify.helios.agent.KafkaClientProvider;
+import com.spotify.helios.auth.AuthenticationPlugin;
+import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
+import com.spotify.helios.auth.ServerAuthenticationConfig;
+import com.spotify.helios.auth.AuthenticatorLoader;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
 import com.spotify.helios.master.resources.DeploymentGroupResource;
@@ -206,6 +210,18 @@ public class MasterService extends AbstractIdleService {
     environment.jersey().register(new VersionResource());
     environment.jersey().register(new UserProvider());
     environment.jersey().register(new DeploymentGroupResource(model));
+
+    if (config.isAuthenticationEnabled()) {
+      // Set up authentication
+      final ServerAuthenticationConfig authConfig = config.getAuthenticationConfig();
+      final AuthenticationPlugin<?> authPlugin = AuthenticatorLoader.load(authConfig);
+      final ServerAuthentication<?> authentication = authPlugin.serverAuthentication();
+
+      environment.jersey().register(authentication.authProvider());
+
+      // register any additional resources needed by the plugin
+      authentication.registerAdditionalJerseyComponents(environment.jersey());
+    }
 
     final DefaultServerFactory serverFactory = ServiceUtil.createServerFactory(
         config.getHttpEndpoint(), config.getAdminPort(), false);

--- a/helios-services/src/main/java/com/spotify/helios/master/jersey/DisabledAuthInjectableProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/jersey/DisabledAuthInjectableProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master.jersey;
+
+import com.sun.jersey.api.core.HttpContext;
+import com.sun.jersey.api.model.Parameter;
+import com.sun.jersey.core.spi.component.ComponentContext;
+import com.sun.jersey.core.spi.component.ComponentScope;
+import com.sun.jersey.server.impl.inject.AbstractHttpContextInjectable;
+import com.sun.jersey.spi.inject.Injectable;
+import com.sun.jersey.spi.inject.InjectableProvider;
+
+import io.dropwizard.auth.Auth;
+
+/**
+ * InjectableProvider for {@link io.dropwizard.auth.Auth} annotated parameters that simply returns
+ * null. Used when authentication is disabled. Otherwise Jersey tries to parse the request body into
+ * the annotated parameter which will fail 100% of the time.
+ */
+public class DisabledAuthInjectableProvider implements InjectableProvider<Auth, Parameter> {
+
+  @Override
+  public ComponentScope getScope() {
+    return ComponentScope.PerRequest;
+  }
+
+  @Override
+  public Injectable getInjectable(ComponentContext ic, Auth auth, Parameter parameter) {
+    return new AbstractHttpContextInjectable() {
+      @Override
+      public Object getValue(HttpContext context) {
+        return null;
+      }
+    };
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/MastersResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/MastersResource.java
@@ -21,15 +21,18 @@
 
 package com.spotify.helios.master.resources;
 
-import com.spotify.helios.master.MasterModel;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.spotify.helios.auth.HeliosUser;
+import com.spotify.helios.master.MasterModel;
 
 import java.util.List;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+
+import io.dropwizard.auth.Auth;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -50,7 +53,7 @@ public class MastersResource {
   @Produces(APPLICATION_JSON)
   @Timed
   @ExceptionMetered
-  public List<String> list() {
+  public List<String> list(@Auth(required = false) HeliosUser user) {
     return model.getRunningMasters();
   }
 }

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.8</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,15 +113,17 @@
   </properties>
 
   <modules>
+    <module>helios-api-documentation</module>
+    <module>helios-authentication</module>
     <module>helios-client</module>
-    <module>helios-service-registration</module>
+    <module>helios-crtauth</module>
+    <module>helios-integration-tests</module>
     <module>helios-tools</module>
     <module>helios-testing</module>
     <module>helios-testing-common</module>
+    <module>helios-service-registration</module>
     <module>helios-services</module>
     <module>helios-system-tests</module>
-    <module>helios-integration-tests</module>
-    <module>helios-api-documentation</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
WIP. @davidxia and I worked on this together.

Opening now for feedback and to share, will probably close and re-open again when properly tested (and the tests don't fail...)

This adds an (optional) authentication module to helios master, along with an (example) HTTP Basic implementation as well as one for crtauth.

There are some detailed notes in the commits and in [docs/authentication.md](https://github.com/mattnworb/helios/blob/authentication-new/docs/authentication.md) on how it all works so I won't repeat myself here.