### PR TITLE
Use logstash logback encoder instead of Kafka

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -24,8 +24,13 @@
     <!--compile deps-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.5.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -35,7 +40,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>dnsjava</groupId>
@@ -57,7 +62,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/helios-service-registration/pom.xml
+++ b/helios-service-registration/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -137,17 +137,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
@@ -176,8 +176,18 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.5.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.5.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -226,27 +236,27 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-access</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+      <version>4.5.1</version>
     </dependency>
     <dependency>
       <groupId>net.kencochrane.raven</groupId>
       <artifactId>raven-logback</artifactId>
       <version>4.1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.danielwegener</groupId>
-      <artifactId>logback-kafka-appender</artifactId>
-      <version>0.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>
@@ -261,7 +271,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.argparse4j</groupId>

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -31,17 +31,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-guava</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -105,17 +105,17 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.1.2</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-access</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.3</version>
     </dependency>
     <dependency>
       <groupId>net.kencochrane.raven</groupId>
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.argparse4j</groupId>

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -36,11 +36,11 @@
       <artifactId>joda-time</artifactId>
       <version>2.3</version>
     </dependency>
-	<dependency>
+	  <dependency>
 	    <groupId>com.typesafe</groupId>
 	    <artifactId>config</artifactId>
 	    <version>1.2.1</version>
-	</dependency>
+	  </dependency>
 
     <!--test deps-->
     <dependency>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.6</version>
+      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.argparse4j</groupId>

--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -48,6 +48,26 @@ $HELIOS_AGENT_OPTS \
 
 # Start master
 mkdir -p /master
+if [ -n "$LOGSTASH_DESTINATION" ]; then
+	cat > /master/logback-access.xml <<- EOF
+<configuration>
+  <appender name="stash" class="net.logstash.logback.appender.LogstashAccessTcpSocketAppender">
+    <destination>${LOGSTASH_DESTINATION}</destination>
+
+    <!-- encoder is required -->
+    <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder">
+      <fieldNames>
+        <fieldsRequestHeaders>@fields.request_headers</fieldsRequestHeaders>
+        <fieldsResponseHeaders>@fields.response_headers</fieldsResponseHeaders>
+      </fieldNames>
+    </encoder>
+  </appender>
+
+  <appender-ref ref="stash" />
+</configuration>
+EOF
+fi
+
 cd /master
 java -cp '/*' \
 -Xmx128m \


### PR DESCRIPTION
The logstash folks have provided some a helpful logback extension to send
request logs directly to logstash. Use this and bypass Kafka altogether.

This also includes a change to helios-solo to support passing in a logstash
destination (useful for testing).