### PR TITLE
client: Treat 502 Bad Gateway as connection error

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
@@ -64,6 +64,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
 
 import static java.lang.System.currentTimeMillis;
+import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 class DefaultRequestDispatcher implements RequestDispatcher {
@@ -266,7 +267,11 @@ class DefaultRequestDispatcher implements RequestDispatcher {
     } else {
       setRequestMethod(connection, method, false);
     }
-    connection.getResponseCode();
+
+    if (connection.getResponseCode() == HTTP_BAD_GATEWAY) {
+      throw new ConnectException("502 Bad Gateway");
+    }
+
     return connection;
   }
 


### PR DESCRIPTION
If we get a 502 Bad Gateway, we should treat it as a connection error and
retry the response with the next server (just like we do for a TCP error).
This lets retries work even when Helios is behind something like nginx.