### PR TITLE
kafka: Use an async non-blocking producer

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -30,6 +30,7 @@ import com.spotify.docker.client.DockerCertificates;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
+import com.spotify.helios.servicescommon.KafkaClientProvider;
 import com.spotify.helios.servicescommon.ManagedStatsdReporter;
 import com.spotify.helios.servicescommon.PersistentAtomicReference;
 import com.spotify.helios.servicescommon.ReactorFactory;

--- a/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
@@ -26,6 +26,7 @@ import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.Task;
 import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.common.descriptors.TaskStatusEvent;
+import com.spotify.helios.servicescommon.KafkaClientProvider;
 import com.spotify.helios.servicescommon.KafkaRecord;
 import com.spotify.helios.servicescommon.KafkaSender;
 import com.spotify.helios.servicescommon.coordination.Paths;

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -24,7 +24,7 @@ import com.google.common.io.Resources;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.codahale.metrics.MetricRegistry;
-import com.spotify.helios.agent.KafkaClientProvider;
+import com.spotify.helios.servicescommon.KafkaClientProvider;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
 import com.spotify.helios.master.resources.DeploymentGroupResource;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
@@ -23,21 +23,23 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-
-import java.util.List;
 
 public class KafkaClientProvider {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaClientProvider.class);
 
   private static final String KAFKA_HELIOS_CLIENT_ID = "Helios";
-  private static final String KAFKA_QUORUM_PARAMETER = "1";
+  private static final int KAFKA_QUORUM_PARAMETER = 1;
+  public static final int MAX_BLOCK_TIMEOUT = 5000;
 
   private final Optional<ImmutableMap<String, Object>> partialConfigs;
 
@@ -47,11 +49,38 @@ public class KafkaClientProvider {
       @Nullable
       @Override
       public ImmutableMap<String, Object> apply(List<String> input) {
-        return ImmutableMap.<String, Object>of(
-            "bootstrap.servers", Joiner.on(',').join(input),
-            "acks", KAFKA_QUORUM_PARAMETER,
-            "client.id", KAFKA_HELIOS_CLIENT_ID,
-            "metadata.fetch.timeout.ms", 5000);
+        return ImmutableMap.<String, Object>builder()
+            .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Joiner.on(',').join(input))
+            .put(ProducerConfig.CLIENT_ID_CONFIG, KAFKA_HELIOS_CLIENT_ID)
+
+            // how many acknowledgments from the leader does the producer need to consider the
+            // request complete?
+            //
+            // 1 = the leader will write the record to its local log but will respond without
+            // awaiting full acknowledgement from all followers. In this case should the leader fail
+            // immediately after acknowledging the record but before the followers have replicated
+            // it then the record will be lost.
+            //
+            // 0 = the producer will not wait for any acknowledgment from the server at all. The
+            // record will be immediately added to the socket buffer and considered sent. No
+            // guarantee can be made that the server has received the record in this case, and the
+            // retries configuration will not take effect (as the client won't generally know of any
+            // failures). The offset given back for each record will always be set to -1.
+            .put(ProducerConfig.ACKS_CONFIG, KAFKA_QUORUM_PARAMETER)
+
+            // The first time data is sent to a topic we must fetch metadata about that topic to
+            // know which servers host the topic's partitions. This fetch to succeed before throwing
+            // an exception back to the client.
+            .put(ProducerConfig.METADATA_FETCH_TIMEOUT_CONFIG, MAX_BLOCK_TIMEOUT)
+
+            // the KafkaProducer maintains an in-memory buffer of a certain size (setting is
+            // buffer.memory, default is 32MB) of records that have not yet been transmitted to the
+            // brokers. When this buffer is full, additional calls to KafkaProducer.send(record)
+            // will block. We don't want blocking. Note that with this set to false, instead the
+            // call to KafkaProducer.send() will throw a BufferExhaustedException exception.
+            .put(ProducerConfig.BLOCK_ON_BUFFER_FULL_CONFIG, false)
+
+            .build();
       }
     });
   }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-package com.spotify.helios.agent;
+package com.spotify.helios.servicescommon;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;


### PR DESCRIPTION
This will let messages be batched for better throughput, but also ensures
we never block on sending to Kafka.