### PR TITLE
add developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ of running:
 
     $ mvn clean package
 
+For more info on setting up a development environment and an introduction to
+the source code, see the [Developer Guide](docs/developer_guide.md).
+
 How it all fits together
 ------------------------
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,18 @@
+# Building Helios
+
+TODO
+
+Use `bin/helios` and `bin/helios-master` to start the Helios CLI and server
+(respectively) from the locally-built project.
+
+## Running helios-system-tests locally
+
+If you are running helios-system-tests locally and are wondering where the
+slf4j/logback output is when the tests are being run, SystemTestBase will by
+default configure logback to be extra verbose and [to write
+logs][LoggingTestWatcher] to `/tmp/helios-test/log/`.
+
+This behavior can be disabled by disabling the `logToFile` system property when
+maven-surefire-plugin is invoked.
+
+[LoggingTestWatcher]: ../helios-system-tests/src/main/java/com/spotify/helios/system/LoggingTestWatcher.java


### PR DESCRIPTION
Really just a scratchpad really for notes to help get new people
set up quickly based on my experience, for instance to
document the logging setup when running system-tests locally (which is
very smart but just not obvious until you dig into it).