### PR TITLE
build api-docs module after helios-testing

### DIFF
--- a/helios-api-documentation/pom.xml
+++ b/helios-api-documentation/pom.xml
@@ -24,6 +24,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>helios-testing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>2.0.3</version>


### PR DESCRIPTION
The Jacoco setup in the api-docs module requires helios-testing to have
been build first (as it refers to it's `target/classes` directory).

Adding a `<dependency>` on helios-testing moves the API Documentation to
the last module to be built by Maven.

But in reality we are probably abusing Maven and the setup of this thing
is totally fragile.