### PR TITLE
fix crtauth handshake bug; allow system tests to set environment variables

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -28,7 +28,7 @@ case "$1" in
     ;;
 
   dependencies)
-    mvn clean install -T 2 -Dmaven.javadoc.skip=true -DskipTests=true -B -V
+    mvn clean install -T 2 -Dmaven.javadoc.skip=true -DskipTests=true -Dinvoker.skip=true -B -V
 
     ;;
 

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPlugin.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPlugin.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.auth;
 
+import java.util.Map;
+
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 
 /**
@@ -39,7 +41,13 @@ public interface AuthenticationPlugin<C> {
    */
   String schemeName();
 
-  ServerAuthentication<C> serverAuthentication();
+  /**
+   * Create the ServerAuthentication instance to use with this plugin.
+   *
+   * @param environment the environment variables that the Helios Master was started with. Provided
+   *                    as a method parameter rather than System.getenv() for ease of testing.
+   */
+  ServerAuthentication<C> serverAuthentication(Map<String, String> environment);
 
   ClientAuthentication<C> clientAuthentication();
 

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPlugin.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationPlugin.java
@@ -18,6 +18,7 @@
 package com.spotify.helios.auth;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 
@@ -75,6 +76,17 @@ public interface AuthenticationPlugin<C> {
      * for multi-stepped authentication handshakes.
      */
     void registerAdditionalJerseyComponents(JerseyEnvironment env);
+
+    /**
+     * Returns a Set of URI paths (such as <code>auth</code>) that should not require
+     * authentication. Note that the path as presented by Jersey will not have the leading
+     * <code>/</code>.
+     * <p>
+     * If the plugin registers any endpoints for authentication handshakes in {@link
+     * #registerAdditionalJerseyComponents(JerseyEnvironment)} then it must also return the path(s)
+     * to those endpoint(s) in this method.</p>
+     */
+    Set<String> unauthenticatedPaths();
   }
 
   interface ClientAuthentication<C> {

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/SimpleServerAuthentication.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/SimpleServerAuthentication.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.auth;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
+
+import java.util.Set;
+
+import io.dropwizard.jersey.setup.JerseyEnvironment;
+
+/**
+ * A base authentication plugin class that can be used if the plugin does not need to add any
+ * additional Jersey components.
+ */
+public abstract class SimpleServerAuthentication<C> implements ServerAuthentication<C> {
+
+  @Override
+  public final void registerAdditionalJerseyComponents(final JerseyEnvironment env) {
+    // do nothing
+  }
+
+  @Override
+  public Set<String> unauthenticatedPaths() {
+    return ImmutableSet.of();
+  }
+}

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicAuthenticationPlugin.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicAuthenticationPlugin.java
@@ -18,10 +18,19 @@
 package com.spotify.helios.auth.basic;
 
 import com.google.auto.service.AutoService;
+import com.google.common.base.Throwables;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.helios.auth.AuthenticationPlugin;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
 import io.dropwizard.auth.basic.BasicCredentials;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /** Proof of concept for the authentication plugin framework using HTTP Basic Auth. */
 @AutoService(AuthenticationPlugin.class)
@@ -33,8 +42,28 @@ public class BasicAuthenticationPlugin implements AuthenticationPlugin<BasicCred
   }
 
   @Override
-  public ServerAuthentication<BasicCredentials> serverAuthentication() {
-    return new BasicServerAuthentication();
+  public ServerAuthentication<BasicCredentials> serverAuthentication(
+      Map<String, String> environment) {
+
+    final String path = environment.get("AUTH_BASIC_USERDB");
+    checkNotNull(path,
+        "Environment variable AUTH_BASIC_USERDB not defined, required for "
+        + BasicAuthenticationPlugin.class.getSimpleName());
+
+    return new BasicServerAuthentication(readFileOfUsers(path));
+  }
+
+  private Map<String, String> readFileOfUsers(final String path) {
+    final File file = new File(path);
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final TypeReference<Map<String, String>> typeToken = new TypeReference<Map<String, String>>() {
+    };
+
+    try {
+      return  objectMapper.readValue(file, typeToken);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   @Override

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicServerAuthentication.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicServerAuthentication.java
@@ -17,20 +17,10 @@
 
 package com.spotify.helios.auth.basic;
 
-import com.google.common.base.Throwables;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
-
-import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 
 import io.dropwizard.auth.basic.BasicCredentials;
-import io.dropwizard.jersey.setup.JerseyEnvironment;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A very simple implementation of ServerAuthentication to demonstrate how to implement an
@@ -41,23 +31,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class BasicServerAuthentication implements ServerAuthentication<BasicCredentials> {
 
   private final Map<String, String> users;
-
-  public BasicServerAuthentication() {
-    final String path = System.getenv("AUTH_BASIC_USERDB");
-    checkNotNull(path,
-        "Environment variable AUTH_BASIC_USERDB not defined, required for "
-        + BasicAuthenticationPlugin.class.getSimpleName());
-
-    File file = new File(path);
-    final ObjectMapper objectMapper = new ObjectMapper();
-
-    try {
-      this.users = objectMapper.readValue(file, new TypeReference<Map<String, String>>() {
-      });
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
-  }
 
   public BasicServerAuthentication(Map<String, String> users) {
     this.users = users;

--- a/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicServerAuthentication.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/basic/BasicServerAuthentication.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.auth.basic;
 
+import com.spotify.helios.auth.SimpleServerAuthentication;
 
 import java.util.Map;
 
@@ -28,7 +29,7 @@ import io.dropwizard.auth.basic.BasicCredentials;
  * configured by an environment variable, making it likely far too simple to be used for anything
  * but demonstrations.
  */
-public class BasicServerAuthentication implements ServerAuthentication<BasicCredentials> {
+public class BasicServerAuthentication extends SimpleServerAuthentication<BasicCredentials> {
 
   private final Map<String, String> users;
 
@@ -41,8 +42,4 @@ public class BasicServerAuthentication implements ServerAuthentication<BasicCred
     return new BasicAuthenticator(users);
   }
 
-  @Override
-  public void registerAdditionalJerseyComponents(JerseyEnvironment env) {
-    // nothing to add
-  }
 }

--- a/helios-authentication/src/test/java/com/spotify/helios/auth/AuthenticationPluginLoaderTest.java
+++ b/helios-authentication/src/test/java/com/spotify/helios/auth/AuthenticationPluginLoaderTest.java
@@ -23,6 +23,8 @@ package com.spotify.helios.auth;
 
 import org.junit.Test;
 
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
@@ -53,7 +55,7 @@ public class AuthenticationPluginLoaderTest {
     }
 
     @Override
-    public ServerAuthentication<String> serverAuthentication() {
+    public ServerAuthentication<String> serverAuthentication(Map<String, String> environment) {
       return null;
     }
 

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtHandshakeResource.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtHandshakeResource.java
@@ -31,9 +31,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-@Path("/_auth")
+@Path(CrtHandshakeResource.PATH)
 public class CrtHandshakeResource {
 
+  public static final String PATH = "_auth";
   private static final Logger log = LoggerFactory.getLogger(CrtHandshakeResource.class);
 
   private final CrtAuthServer authServer;

--- a/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtServerAuthentication.java
+++ b/helios-crtauth/src/main/java/com/spotify/helios/auth/crt/CrtServerAuthentication.java
@@ -17,9 +17,13 @@
 
 package com.spotify.helios.auth.crt;
 
+import com.google.common.collect.ImmutableSet;
+
 import com.spotify.crtauth.CrtAuthServer;
 import com.spotify.helios.auth.AuthenticationPlugin.ServerAuthentication;
 import com.spotify.helios.auth.Authenticator;
+
+import java.util.Set;
 
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 
@@ -43,4 +47,8 @@ public class CrtServerAuthentication implements ServerAuthentication<CrtAccessTo
     env.register(new CrtHandshakeResource(this.authServer));
   }
 
+  @Override
+  public Set<String> unauthenticatedPaths() {
+    return ImmutableSet.of(CrtHandshakeResource.PATH);
+  }
 }

--- a/helios-crtauth/src/test/java/com/spotify/helios/auth/crt/CrtAuthenticationPluginTest.java
+++ b/helios-crtauth/src/test/java/com/spotify/helios/auth/crt/CrtAuthenticationPluginTest.java
@@ -49,14 +49,14 @@ public class CrtAuthenticationPluginTest {
 
     final Map<String, String> env = ImmutableMap.of();
 
-    final CrtAuthenticationPlugin plugin = new CrtAuthenticationPlugin(env);
-    plugin.serverAuthentication();
+    final CrtAuthenticationPlugin plugin = new CrtAuthenticationPlugin();
+    plugin.serverAuthentication(env);
   }
 
   @Test
   public void serverAuthentication_AllRequiredArgs() {
-    final CrtAuthenticationPlugin plugin = new CrtAuthenticationPlugin(requiredEnvArgs);
-    plugin.serverAuthentication();
+    final CrtAuthenticationPlugin plugin = new CrtAuthenticationPlugin();
+    plugin.serverAuthentication(requiredEnvArgs);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class CrtAuthenticationPluginTest {
     final Map<String, String> env = new HashMap<>(requiredEnvArgs);
     env.put("CRTAUTH_TOKEN_LIFETIME_SECS", "asdf");
 
-    final CrtAuthenticationPlugin plugin = new CrtAuthenticationPlugin(env);
-    plugin.serverAuthentication();
+    final CrtAuthenticationPlugin plugin = new CrtAuthenticationPlugin();
+    plugin.serverAuthentication(env);
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -83,6 +83,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.DispatcherType;
@@ -116,6 +117,7 @@ public class MasterService extends AbstractIdleService {
   private final ExpiredJobReaper expiredJobReaper;
   private final CuratorClientFactory curatorClientFactory;
   private final RollingUpdateService rollingUpdateService;
+  private final Map<String, String> environmentVariables;
 
   private ZooKeeperRegistrarService zkRegistrar;
 
@@ -127,11 +129,14 @@ public class MasterService extends AbstractIdleService {
    * @param curatorClientFactory The zookeeper curator factory.
    * @throws ConfigurationException If there is a problem with the DropWizard configuration.
    */
-  public MasterService(final MasterConfig config, final Environment environment,
-                       final CuratorClientFactory curatorClientFactory)
+  public MasterService(final MasterConfig config,
+                       final Environment environment,
+                       final CuratorClientFactory curatorClientFactory,
+                       final Map<String, String> environmentVariables)
       throws ConfigurationException, IOException, InterruptedException {
     this.config = config;
     this.curatorClientFactory = curatorClientFactory;
+    this.environmentVariables = environmentVariables;
 
     // Configure metrics
     // TODO (dano): do something with the riemann facade
@@ -256,12 +261,14 @@ public class MasterService extends AbstractIdleService {
         authPlugin.getClass().getName(),
         authConfig.getEnabledScheme());
 
-    final ServerAuthentication<?> authentication = authPlugin.serverAuthentication();
-    final Authenticator authenticator = authPlugin.serverAuthentication().authenticator();
-    final Predicate<HttpRequestContext> isRequired = authenticationRequired(authConfig);
+    final ServerAuthentication<?> authentication =
+        authPlugin.serverAuthentication(this.environmentVariables);
 
-    final AuthenticationRequestFilter filter =
-        new AuthenticationRequestFilter(authenticator, authPlugin.schemeName(), isRequired);
+    final Authenticator authenticator = authentication.authenticator();
+
+    final AuthenticationRequestFilter filter = new AuthenticationRequestFilter(authenticator,
+        authPlugin.schemeName(),
+        authenticationRequired(authentication, authConfig));
 
     // setting up filters in Jersey 1.x is convoluted:
     environment.jersey().getResourceConfig().getContainerRequestFilters().add(filter);
@@ -270,7 +277,8 @@ public class MasterService extends AbstractIdleService {
     authentication.registerAdditionalJerseyComponents(environment.jersey());
   }
 
-  private Predicate<HttpRequestContext> authenticationRequired(ServerAuthenticationConfig config) {
+  private Predicate<HttpRequestContext> authenticationRequired(
+      final ServerAuthentication<?> authentication, final ServerAuthenticationConfig config) {
     if (config.isEnabledForAllVersions()) {
       return Predicates.alwaysTrue();
     }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/MasterAuthenticationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/MasterAuthenticationTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.spotify.helios.auth.AuthenticationPlugin;
 import com.spotify.helios.auth.Authenticator;
 import com.spotify.helios.auth.HeliosUser;
+import com.spotify.helios.auth.SimpleServerAuthentication;
 import com.sun.jersey.api.core.HttpRequestContext;
 
 import org.apache.http.Header;
@@ -38,7 +39,6 @@ import java.util.Map;
 import javax.ws.rs.core.HttpHeaders;
 
 import io.dropwizard.auth.AuthenticationException;
-import io.dropwizard.jersey.setup.JerseyEnvironment;
 
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.is;
@@ -111,10 +111,6 @@ public class MasterAuthenticationTest extends SystemTestBase {
               return Optional.absent();
             }
           };
-        }
-
-        @Override
-        public void registerAdditionalJerseyComponents(final JerseyEnvironment env) {
         }
       };
     }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -569,14 +569,27 @@ public abstract class SystemTestBase {
     return startDefaultMaster(0, args);
   }
 
+  protected MasterMain startDefaultMaster(Map<String, String> environmentVariables, String... args)
+      throws Exception {
+    return startDefaultMaster(0, environmentVariables, args);
+  }
+
   protected MasterMain startDefaultMaster(final int offset, String... args) throws Exception {
+    return startDefaultMaster(offset, ImmutableMap.<String, String>of(), args);
+  }
+
+  protected MasterMain startDefaultMaster(final int offset,
+                                          final Map<String, String> environmentVariables,
+                                          final String... args) throws Exception {
     final List<String> argsList = setupDefaultMaster(offset, args);
 
     if (argsList == null) {
       return null;
     }
 
-    final MasterMain master = startMaster(argsList.toArray(new String[argsList.size()]));
+    final MasterMain master =
+        startMaster(environmentVariables, argsList.toArray(new String[argsList.size()]));
+
     waitForMasterToBeFullyUp();
 
     return master;
@@ -658,8 +671,9 @@ public abstract class SystemTestBase {
     return startAgent(argsList.toArray(new String[argsList.size()]));
   }
 
-  protected MasterMain startMaster(final String... args) throws Exception {
-    final MasterMain main = new MasterMain(args);
+  protected MasterMain startMaster(final Map<String, String> environmentVariables,
+                                   final String... args) throws Exception {
+    final MasterMain main = new MasterMain(environmentVariables, args);
     main.startAsync().awaitRunning();
     services.add(main);
     return main;


### PR DESCRIPTION
### easier system tests

Refactor MasterService so that it is possible to pass custom environment
variables (represented as a `Map<String, String>`).

This makes it possible for system tests to start the master with custom defined
environment - previously not possible since the MasterMain is started in the
same process.

Also pass the Master's view of environment variables down to the
AuthenticationPlugin framework to simplify their loading logic.  

### allow plugins to set paths that don't require auth

This fixes a bug where the CrtHandshakeResource (at `/_auth`) requires a
token in order to get a token, which will probably never work.