### PR TITLE
test that users can proactively authenticate

### DIFF
--- a/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationRequestFilter.java
+++ b/helios-authentication/src/main/java/com/spotify/helios/auth/AuthenticationRequestFilter.java
@@ -61,6 +61,8 @@ public class AuthenticationRequestFilter implements ContainerRequestFilter {
 
         if (result.isPresent()) {
           // authenticated!
+          // store user in request attributes for any possible downstream uses
+          request.getProperties().put("helios.user.principal", result.get());
           return request;
         }
       } catch (AuthenticationException e) {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -36,6 +36,7 @@ import com.spotify.helios.common.PomVersion;
 import com.spotify.helios.common.VersionCompatibility;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
+import com.spotify.helios.master.resources.AuthenticationResponseFilter;
 import com.spotify.helios.master.resources.DeploymentGroupResource;
 import com.spotify.helios.master.resources.HistoryResource;
 import com.spotify.helios.master.resources.HostsResource;
@@ -65,6 +66,7 @@ import com.spotify.helios.servicescommon.statistics.Metrics;
 import com.spotify.helios.servicescommon.statistics.MetricsImpl;
 import com.spotify.helios.servicescommon.statistics.NoopMetrics;
 import com.sun.jersey.api.core.HttpRequestContext;
+import com.sun.jersey.api.core.ResourceConfig;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
@@ -271,7 +273,9 @@ public class MasterService extends AbstractIdleService {
         authenticationRequired(authentication, authConfig));
 
     // setting up filters in Jersey 1.x is convoluted:
-    environment.jersey().getResourceConfig().getContainerRequestFilters().add(filter);
+    final ResourceConfig resourceConfig = environment.jersey().getResourceConfig();
+    resourceConfig.getContainerRequestFilters().add(filter);
+    resourceConfig.getContainerResponseFilters().add(new AuthenticationResponseFilter());
 
     // register any additional resources needed by the plugin
     authentication.registerAdditionalJerseyComponents(environment.jersey());

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/AuthenticationResponseFilter.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/AuthenticationResponseFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master.resources;
+
+import com.spotify.helios.auth.HeliosUser;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+
+/**
+ * If user is authenticated, add a response header containing the username.
+ * <p>
+ * Possibly only useful for debugging/troubleshooting the authentication module.</p>
+ */
+public class AuthenticationResponseFilter implements ContainerResponseFilter {
+
+  public static final String USER_PROPERTY_KEY = "helios.user.principal";
+
+  @Override
+  public ContainerResponse filter(final ContainerRequest request,
+                                  final ContainerResponse response) {
+
+    if (request.getProperties().containsKey(USER_PROPERTY_KEY)) {
+      final HeliosUser user = (HeliosUser) request.getProperties().get(USER_PROPERTY_KEY);
+      response.getHttpHeaders().putSingle("Authentication-Principal", user.getUsername());
+    }
+
+    return response;
+  }
+}

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/MasterAuthenticationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/MasterAuthenticationTest.java
@@ -27,12 +27,16 @@ import com.spotify.helios.auth.AuthenticationPlugin;
 import com.spotify.helios.auth.Authenticator;
 import com.spotify.helios.auth.HeliosUser;
 import com.spotify.helios.auth.SimpleServerAuthentication;
+import com.spotify.helios.common.Version;
+import com.spotify.helios.common.VersionCompatibility;
 import com.sun.jersey.api.core.HttpRequestContext;
 
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.io.File;
@@ -122,7 +126,40 @@ public class MasterAuthenticationTest extends SystemTestBase {
     public ClientAuthentication<String> clientAuthentication() {
       return null;
     }
+  }
 
+  /**
+   * Test that a client can authenticate if it really wants to when it's client version header is
+   * less than the minimum-required-version. Reuse FixedPasswordAuthentication from above for
+   * simplicity.
+   */
+  @Test
+  public void clientCanAuthenticateIfBelowMinimumRequiredVersion() throws Exception {
+    startDefaultMaster("--auth-scheme", "fixed-password", "--auth-minimum-version", "99.9.9");
+
+    // ensure request with no token is ok
+    final HttpGet initialGet = new HttpGet(masterEndpoint() + "/masters");
+    initialGet.addHeader(VersionCompatibility.HELIOS_VERSION_HEADER, Version.POM_VERSION);
+    try (CloseableHttpResponse response = httpClient.execute(initialGet)) {
+      assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.SC_OK));
+    }
+
+    // add a good auth header
+    initialGet.addHeader("Authorization", "secret123");
+    try (CloseableHttpResponse response = httpClient.execute(initialGet)) {
+      assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.SC_OK));
+
+      assertThat(response.getFirstHeader("Authentication-Principal"), hasValue("the-user"));
+    }
+  }
+
+  private static Matcher<Header> hasValue(final String value) {
+    return new CustomTypeSafeMatcher<Header>("Header with value: " + value) {
+      @Override
+      protected boolean matchesSafely(final Header item) {
+        return item.getValue().equals(value);
+      }
+    };
   }
 
   @Test


### PR DESCRIPTION
Adds a system test that enables authentication with
`--auth-minimum-version` set to a really high version (99.9.9) and
verifies that a client can supply `Authorization` headers when their 
version is less than this value and be authenticated if they really want to.

To verify this behavior, add a Jersey response filter that sets a header
`Authentication-Principal` (too enterprise-y??) containing the username of the
authenticated user. 

Since having someone else's authorization token gives you power to do anything
that user could do, finding out the username that corresponds to that token
seems like it would give no benefit to an attacker (who has already won).