### PR TITLE
allow for eager client authentication

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/auth/AuthProvider.java
+++ b/helios-client/src/main/java/com/spotify/helios/auth/AuthProvider.java
@@ -40,12 +40,12 @@ public interface AuthProvider {
    */
   ListenableFuture<String> renewAuthorizationHeader();
 
-  public interface Factory {
+  interface Factory {
 
-    AuthProvider create(String wwwAuthHeader, Context context);
+    AuthProvider create(String scheme, Context context);
   }
 
-  public interface Context {
+  interface Context {
 
     RequestDispatcher dispatcher();
 

--- a/helios-client/src/main/java/com/spotify/helios/auth/AuthProviderSelector.java
+++ b/helios-client/src/main/java/com/spotify/helios/auth/AuthProviderSelector.java
@@ -40,17 +40,14 @@ public class AuthProviderSelector implements AuthProvider.Factory {
   }
 
   @Override
-  public AuthProvider create(final String wwwAuthHeader, final AuthProvider.Context context) {
-    // TODO(staffan): Support multiple comma-separated challenges
-    final String authScheme = wwwAuthHeader.split(" ", 2)[0];
-
+  public AuthProvider create(final String authScheme, final AuthProvider.Context context) {
     final AuthProvider.Factory factory = providerFactories.get(authScheme);
     if (factory == null) {
       log.warn("Unsupported auth-scheme %s", authScheme);
       throw new IllegalArgumentException("Unsupported authentication scheme: " + authScheme);
     }
 
-    final AuthProvider authProvider = factory.create(wwwAuthHeader, context);
+    final AuthProvider authProvider = factory.create(authScheme, context);
     if (authProvider == null) {
       log.warn("AuthProvider.Factory returned null for auth-scheme %s", authScheme);
     } else {

--- a/helios-client/src/main/java/com/spotify/helios/auth/AuthenticatingRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/auth/AuthenticatingRequestDispatcher.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.auth;
 
+import com.google.common.base.Preconditions;
 import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FutureFallback;
@@ -27,40 +28,99 @@ import com.spotify.helios.client.HeliosRequest;
 import com.spotify.helios.client.RequestDispatcher;
 import com.spotify.helios.client.Response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
-import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 public class AuthenticatingRequestDispatcher implements RequestDispatcher {
 
+  private static final Logger log = LoggerFactory.getLogger(AuthenticatingRequestDispatcher.class);
+
   private final RequestDispatcher delegate;
   private final AuthProvider.Factory authProviderFactory;
   private final String user;
+  private final boolean eagerlyAuthenticate;
+  private final String desiredScheme;
   private AuthProvider authProvider;
 
   public AuthenticatingRequestDispatcher(final RequestDispatcher delegate,
                                          final AuthProvider.Factory authProviderFactory,
                                          final String user) {
+    this(delegate, authProviderFactory, user, false, null);
+  }
+
+  public AuthenticatingRequestDispatcher(final RequestDispatcher delegate,
+                                         final AuthProvider.Factory authProviderFactory,
+                                         final String user,
+                                         boolean eagerlyAuthenticate,
+                                         String desiredScheme) {
+
+    Preconditions.checkArgument(!eagerlyAuthenticate || desiredScheme != null,
+        "desiredScheme must be non-null if eagerlyAuthenticate=true");
+
     this.delegate = delegate;
     this.authProviderFactory = authProviderFactory;
     this.user = user;
+    this.eagerlyAuthenticate = eagerlyAuthenticate;
+    this.desiredScheme = desiredScheme;
+
+    if (desiredScheme != null) {
+      loadProvider(desiredScheme);
+    }
+  }
+
+  private void loadProvider(final String scheme) {
+    if (authProvider == null) {
+      try {
+        authProvider = authProviderFactory.create(scheme, new AuthProviderContext(delegate, user));
+
+        if (authProvider == null) {
+          throw new RuntimeException("Failed to instantiate AuthProvider");
+        }
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to instantiate AuthProvider", e);
+      }
+    }
   }
 
   @Override
   public ListenableFuture<Response> request(final HeliosRequest request) {
     // Include an Authorization header if it's currently available
-    final HeliosRequest req;
     final String authHeader = authProvider != null ?
                               authProvider.currentAuthorizationHeader() : null;
+    final HeliosRequest req;
     if (authHeader != null) {
-      req = request.toBuilder().header(HttpHeaders.AUTHORIZATION, authHeader).build();
+      req = addAuthorizationHeader(request, authHeader);
     } else {
       req = request;
     }
 
-    return Futures.transform(delegate.request(req), new AsyncFunction<Response, Response>() {
+    // If we don't have a header and eagerlyAuthenticate is set to true, then fire a future to get
+    // the initial token, and then transform that into a delegate request.
+    // Otherwise the "responseFuture" is the normal request via the delegate.
+
+    final ListenableFuture<Response> responseFuture;
+    if (eagerlyAuthenticate && authHeader == null) {
+      // first fetch a token, then make the request via the delegate
+      final ListenableFuture<String> tokenFuture = authProvider.renewAuthorizationHeader();
+
+      responseFuture = Futures.transform(tokenFuture, new AsyncFunction<String, Response>() {
+        @Override
+        public ListenableFuture<Response> apply(final String token) throws Exception {
+          final HeliosRequest reqWithHeader = addAuthorizationHeader(req, token);
+          return delegate.request(reqWithHeader);
+        }
+      });
+    } else {
+      responseFuture = delegate.request(req);
+    }
+
+    // in either case from above, add a callback to handle 401 Unauthorized responses
+    return Futures.transform(responseFuture, new AsyncFunction<Response, Response>() {
       @Override
       public ListenableFuture<Response> apply(final Response response) throws Exception {
         if (response != null &&
@@ -74,20 +134,19 @@ public class AuthenticatingRequestDispatcher implements RequestDispatcher {
     });
   }
 
+  private static HeliosRequest addAuthorizationHeader(final HeliosRequest request,
+                                               final String authHeader) {
+    return request.toBuilder().header(HttpHeaders.AUTHORIZATION, authHeader).build();
+  }
+
+  private static String parseScheme(Response response) {
+    // TODO(staffan): Support multiple comma-separated challenges
+    return response.header(HttpHeaders.WWW_AUTHENTICATE).split(" ", 2)[0];
+  }
+
   private ListenableFuture<Response> authenticateAndRetry(final HeliosRequest request,
                                                           final Response response) {
-    if (authProvider == null) {
-      try {
-        authProvider = authProviderFactory.create(
-            response.header(HttpHeaders.WWW_AUTHENTICATE), new AuthProviderContext(delegate, user));
-
-        if (authProvider == null) {
-          return immediateFailedFuture(new RuntimeException("Failed to instantiate AuthProvider"));
-        }
-      } catch (Exception e) {
-        return immediateFailedFuture(new RuntimeException("Failed to instantiate AuthProvider", e));
-      }
-    }
+    loadProvider(parseScheme(response));
 
     final ListenableFuture<Response> f = Futures.transform(
         authProvider.renewAuthorizationHeader(),
@@ -95,8 +154,7 @@ public class AuthenticatingRequestDispatcher implements RequestDispatcher {
           @Override
           public ListenableFuture<Response> apply(final String authHeader)
               throws Exception {
-            return delegate.request(
-                request.toBuilder().header(HttpHeaders.AUTHORIZATION, authHeader).build());
+            return delegate.request(addAuthorizationHeader(request, authHeader));
           }
         });
 
@@ -106,7 +164,7 @@ public class AuthenticatingRequestDispatcher implements RequestDispatcher {
     return Futures.withFallback(f, new FutureFallback<Response>() {
       @Override
       public ListenableFuture<Response> create(final Throwable t) throws Exception {
-        // TODO: Log auth failure
+        log.error("Authentication error: {}", t);
         return immediateFuture(response);
       }
     });

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -502,6 +502,8 @@ public class HeliosClient implements AutoCloseable {
     private String user;
     private Supplier<List<URI>> endpointSupplier;
     private AuthProvider.Factory authProviderFactory;
+    private boolean eagerAuthentication;
+    private String eagerAuthScheme;
 
     public Builder setUser(final String user) {
       this.user = user;
@@ -537,8 +539,23 @@ public class HeliosClient implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Sets the Factory to use to retrieve AuthProvider instances. This method enables the
+     * HeliosClient to use authentication when communicating with the masters.
+     */
     public Builder setAuthProviderFactory(final AuthProvider.Factory authProviderFactory) {
       this.authProviderFactory = authProviderFactory;
+      return this;
+    }
+
+    /**
+     * When enabled, the returned HeliosClient will eagerly retrieve authentication tokens from the
+     * AuthProvider, rather than waiting for the Helios master to indicate that requests require
+     * authentication.
+     */
+    public Builder setEagerAuthenticationScheme(String scheme) {
+      this.eagerAuthentication = true;
+      this.eagerAuthScheme = scheme;
       return this;
     }
 
@@ -550,8 +567,11 @@ public class HeliosClient implements AutoCloseable {
 
       final RequestDispatcher dispatcher;
       if (authProviderFactory != null) {
-        dispatcher = new AuthenticatingRequestDispatcher(
-            defaultDispatcher, authProviderFactory, user);
+        dispatcher = new AuthenticatingRequestDispatcher(defaultDispatcher,
+            authProviderFactory,
+            user,
+            eagerAuthentication,
+            eagerAuthScheme);
       } else {
         dispatcher = defaultDispatcher;
       }

--- a/helios-client/src/test/java/com/spotify/helios/auth/AuthProviderSelectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/auth/AuthProviderSelectorTest.java
@@ -62,7 +62,7 @@ public class AuthProviderSelectorTest {
   @Test
   public void testWithParams() {
     final AuthProviderSelector selector = new AuthProviderSelector(factories);
-    assertSame(provider2, selector.create("scheme2 realm='foo.bar'", context));
+    assertSame(provider2, selector.create("scheme2", context));
   }
 
   @Test

--- a/helios-client/src/test/java/com/spotify/helios/auth/BasicAuthProviderTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/auth/BasicAuthProviderTest.java
@@ -40,6 +40,6 @@ public class BasicAuthProviderTest {
   @Test
   public void testColonNotAllowedInUsername() throws Exception {
     exception.expect(IllegalArgumentException.class);
-    final AuthProvider authProvider = new BasicAuthProvider("Aladdin:", "open sesame");
+    new BasicAuthProvider("Aladdin:", "open sesame");
   }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.cli;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -95,6 +96,7 @@ public class CliParser {
   private final List<Target> targets;
   private final String username;
   private boolean json;
+  private final Optional<String> authenticationScheme;
 
   public CliParser(final String... args)
       throws ArgumentParserException, IOException, URISyntaxException {
@@ -146,6 +148,9 @@ public class CliParser {
 
     // TODO (dano): complex, refactor and unit test it
     this.targets = computeTargets(parser, explicitEndpoints, domains, srvName);
+
+    final String scheme = options.getString(globalArgs.authenticationScheme.getDest());
+    this.authenticationScheme = Optional.fromNullable(scheme);
   }
 
   private List<Target> computeTargets(final ArgumentParser parser,
@@ -255,6 +260,10 @@ public class CliParser {
     return json;
   }
 
+  public Optional<String> getForcedAuthenticationScheme() {
+    return this.authenticationScheme;
+  }
+
   private static class GlobalArgs {
 
     private final Argument masterArg;
@@ -264,6 +273,7 @@ public class CliParser {
     private final Argument verbose;
     private final Argument noLogSetup;
     private final Argument jsonArg;
+    private final Argument authenticationScheme;
 
     private final ArgumentGroup globalArgs;
     private final boolean topLevel;
@@ -308,6 +318,9 @@ public class CliParser {
       noLogSetup = addArgument("--no-log-setup")
           .action(storeTrue())
           .help(SUPPRESS);
+
+      authenticationScheme = addArgument("--force-authentication-scheme")
+        .help("Scheme to use with authentication; must be set if --force-authentication is set");
     }
 
     private Argument addArgument(final String... nameOrFlags) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -24,8 +24,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.ListenableFuture;
 
-import com.spotify.helios.auth.AuthProvider;
-import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.HostSelector;
 
 import net.sourceforge.argparse4j.inf.Argument;
@@ -34,8 +32,6 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -51,28 +47,6 @@ public class Utils {
       result.put(e.getKey(), e.getValue().get());
     }
     return result;
-  }
-
-  public static HeliosClient getClient(final Target target, final PrintStream err,
-                                       final String username,
-                                       final AuthProvider.Factory authProviderFactory) {
-
-    List<URI> endpoints = Collections.emptyList();
-    try {
-      endpoints = target.getEndpointSupplier().get();
-    } catch (Exception ignore) {
-      // TODO (dano): Nasty. Refactor target to propagate resolution failure in a checked manner.
-    }
-    if (endpoints.size() == 0) {
-      err.println("Failed to resolve helios master in " + target);
-      return null;
-    }
-
-    return HeliosClient.newBuilder()
-        .setEndpointSupplier(target.getEndpointSupplier())
-        .setUser(username)
-        .setAuthProviderFactory(authProviderFactory)
-        .build();
   }
 
   public static boolean userConfirmed(final PrintStream out, final BufferedReader stdin)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/AbstractCliCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/AbstractCliCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.cli.command;
+
+import com.google.common.base.Optional;
+
+import com.spotify.helios.auth.AuthProvider;
+import com.spotify.helios.cli.Target;
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.client.HeliosClient.Builder;
+
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+abstract class AbstractCliCommand implements CliCommand {
+
+  HeliosClient getClient(final Target target, final PrintStream err,
+                         final String username,
+                         final Optional<String> eagerAuthenticationScheme,
+                         final AuthProvider.Factory authProviderFactory) {
+
+    List<URI> endpoints = Collections.emptyList();
+    try {
+      endpoints = target.getEndpointSupplier().get();
+    } catch (Exception ignore) {
+      // TODO (dano): Nasty. Refactor target to propagate resolution failure in a checked manner.
+    }
+    if (endpoints.size() == 0) {
+      err.println("Failed to resolve helios master in " + target);
+      return null;
+    }
+
+    final Builder builder = HeliosClient.newBuilder()
+        .setEndpointSupplier(target.getEndpointSupplier())
+        .setUser(username)
+        .setAuthProviderFactory(authProviderFactory);
+
+    if (eagerAuthenticationScheme.isPresent()) {
+      builder.setEagerAuthenticationScheme(eagerAuthenticationScheme.get());
+    }
+
+    return builder.build();
+  }
+
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/CliCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/CliCommand.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.cli.command;
 
+import com.google.common.base.Optional;
+
 import com.spotify.helios.auth.AuthProvider;
 import com.spotify.helios.cli.Target;
 
@@ -30,6 +32,7 @@ import java.util.List;
 public interface CliCommand {
   int run(final Namespace options, final List<Target> targets, final PrintStream out,
           final PrintStream err, final String username, final boolean json,
-          final BufferedReader stdin, final AuthProvider.Factory authProviderFactory)
+          final BufferedReader stdin, final Optional<String> eagerAuthenticationScheme,
+          final AuthProvider.Factory authProviderFactory)
               throws IOException, InterruptedException;
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
@@ -17,13 +17,13 @@
 
 package com.spotify.helios.cli.command;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
 import com.spotify.helios.auth.AuthProvider;
 import com.spotify.helios.cli.Target;
-import com.spotify.helios.cli.Utils;
 import com.spotify.helios.client.HeliosClient;
 
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeoutException;
  * This is in contrast to a normal {@link ControlCommand}, which can operate on multiple
  * domains but does so sequentially.
  */
-public abstract class MultiTargetControlCommand implements CliCommand {
+public abstract class MultiTargetControlCommand extends AbstractCliCommand {
   MultiTargetControlCommand(final Subparser parser) {
     parser.setDefault("command", this).defaultHelp(true);
   }
@@ -49,12 +49,15 @@ public abstract class MultiTargetControlCommand implements CliCommand {
   @Override
   public int run(final Namespace options, final List<Target> targets, final PrintStream out,
                  final PrintStream err, final String username, final boolean json,
-                 final BufferedReader stdin, final AuthProvider.Factory authProviderFactory)
+                 final BufferedReader stdin, final Optional<String> eagerAuthenticationScheme,
+                 final AuthProvider.Factory authProviderFactory)
                      throws IOException, InterruptedException {
 
     final Builder<TargetAndClient> clientBuilder = ImmutableList.<TargetAndClient>builder();
     for (final Target target : targets) {
-      final HeliosClient client = Utils.getClient(target, err, username, authProviderFactory);
+      final HeliosClient client =
+          getClient(target, err, username, eagerAuthenticationScheme, authProviderFactory);
+
       if (client == null) {
         return 1;
       }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -2,6 +2,7 @@ package com.spotify.helios.cli;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -148,5 +149,13 @@ public class CliParserTest {
           SRV, ImmutableList.of(DOMAINS[0], DOMAINS[1], DOMAINS[2]));
       assertEquals(expectedTargets, targets);
     }
+  }
+
+  @Test
+  public void testForceAuthentication() throws Exception {
+    final String[] args = {"--force-authentication-scheme", "foo", SUBCOMMAND, SERVICE};
+    final CliParser cliParser = new CliParser(args);
+
+    assertEquals(Optional.of("foo"), cliParser.getForcedAuthenticationScheme());
   }
 }


### PR DESCRIPTION
Change the client authentication behavior so that the flag
`--force-authentication-scheme` will cause the client to immediately 
authenticate using the specified scheme.

If not set, then the previous behavior of waiting until the master
returns a `401 Unauthorized` response is kept.

To enable this, a small refactoring to the `AuthProvider.Factory`
interface: change the first parameter of the `create` method to `scheme`
instead of `authorization header value` - this moves the header parsing
up one layer.