### PR TITLE
client: Use ssh-agent identity for TLS client auth

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,66 @@
+# Authentication with Helios
+
+When using HTTPS, Helios client can present an X.509 client certificate to verify
+the user's identity. By presenting a digital signature to the Helios master, the
+client proves that it is who it claims to be.
+
+Generally this type of mutual TLS authentication requires the user to have their
+own SSL certificate issued by some certificate authority (CA). Often, this
+will be your company or organization's CA. However, for users who do not have a
+CA or digital certificates but do have OpenSSH keys, the Helios client can
+generate certificates on-the-fly based on the user's SSH key.
+
+## Mutual TLS authentication
+
+To enable mutual TLS authentication, you must use HTTPS endpoints for the Helios
+master. To do this:
+
+1. Place the Helios master behind nginx or another web application server.
+
+2. Ensure that your server is requesting client certificates. For example, with
+   nginx, set the [`ssl_verify_client` option](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_verify_client)
+   to any value other than `off`.
+
+3. Use the options for your web server to validate the certificates in your
+   preferred way. For example, at Spotify, we have nginx pass the SSL certificate
+   to a microservice that ensures that the UID and public key match a known user
+   in our LDAP database.
+
+## Client certificates
+
+The Helios client will now need to present a client certificate to authenticate.
+This can be either a pre-issued X.509 certificate file and associated private
+key, or a certificate generated based on your SSH key.
+
+### Existing X.509 certificate
+
+This is actually not yet implemented.
+
+### On-the-fly certificates with ssh-agent
+
+If you have an OpenSSH key and use [ssh-agent](http://linux.die.net/man/1/ssh-agent)
+(you probably do if you use `ssh`), Helios can generate an X509 certificate for
+you on the fly. Here's how it works:
+
+1. The Helios client checks for a running SSH agent, and if one is found, asks
+   for a list of your public SSH keys. Private keys are never exposed by
+   ssh-agent.
+
+2. The Helios client generates a self-signed X.509 certificate containing your
+   SSH public key and username, which it sends to the HTTPS server.
+
+3. To prove that you own the corresponding private key, the Helios client asks
+   ssh-agent to cryptographically hash and sign part of the TLS handshake with
+   the server.
+
+The hashing and signing in the final step is a standard part of the TLS handshake
+and how the client proves to the server that it has possession of the private key.
+The only difference in our implementation is that we ask ssh-agent to do the
+signing, since Helios doesn't have access to your private key.
+
+**It is important to note that the generated certificate is a self-signed
+certificate**, and all it proves is that you have the private key corresponding
+to your SSH public key. The web server must still decide whether or not to accept
+your certificate. At Spotify, we've configured nginx to pass the certificate to
+another tiny service which extracts the public key from the certificate and
+verifies that it matches the public SSH key of one of our employees.

--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -57,6 +57,31 @@
       <artifactId>httpclient</artifactId>
       <version>4.5</version>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+      <version>1.53</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.53</version>
+    </dependency>
+    <dependency>
+      <groupId>com.eaio.uuid</groupId>
+      <artifactId>uuid</artifactId>
+      <version>3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>ssh-agent-proxy</artifactId>
+      <version>0.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+    </dependency>
 
     <!-- test deps -->
     <dependency>

--- a/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
@@ -23,12 +23,17 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.spotify.helios.client.tls.SshAgentSSLSocketFactory;
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.Json;
+import com.spotify.sshagentproxy.AgentProxies;
+import com.spotify.sshagentproxy.AgentProxy;
+import com.spotify.sshagentproxy.Identity;
 
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.slf4j.Logger;
@@ -48,6 +53,7 @@ import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -58,9 +64,13 @@ import java.util.zip.GZIPInputStream;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.System.currentTimeMillis;
 import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 class DefaultRequestDispatcher implements RequestDispatcher {
@@ -75,11 +85,14 @@ class DefaultRequestDispatcher implements RequestDispatcher {
 
   private final Supplier<List<URI>> endpointSupplier;
   private final ListeningExecutorService executorService;
+  private final String user;
 
   public DefaultRequestDispatcher(final Supplier<List<URI>> endpointSupplier,
+                                  final String user,
                                   final ListeningExecutorService executorService) {
     this.endpointSupplier = endpointSupplier;
     this.executorService = executorService;
+    this.user = user;
   }
 
   @Override
@@ -92,11 +105,13 @@ class DefaultRequestDispatcher implements RequestDispatcher {
         final HttpURLConnection connection = connect(uri, method, entityBytes, headers);
         final int status = connection.getResponseCode();
         final InputStream rawStream;
+
         if (status / 100 != 2) {
           rawStream = connection.getErrorStream();
         } else {
           rawStream = connection.getInputStream();
         }
+
         final boolean gzip = isGzipCompressed(connection);
         final InputStream stream = gzip ? new GZIPInputStream(rawStream) : rawStream;
         final ByteArrayOutputStream payload = new ByteArrayOutputStream();
@@ -107,6 +122,7 @@ class DefaultRequestDispatcher implements RequestDispatcher {
             payload.write(buffer, 0, n);
           }
         }
+
         URI realUri = connection.getURL().toURI();
         if (log.isTraceEnabled()) {
           log.trace("rep: {} {} {} {} {} gzip:{}",
@@ -155,6 +171,7 @@ class DefaultRequestDispatcher implements RequestDispatcher {
              HeliosException {
     final long deadline = currentTimeMillis() + RETRY_TIMEOUT_MILLIS;
     final int offset = ThreadLocalRandom.current().nextInt();
+
     while (currentTimeMillis() < deadline) {
       final List<URI> endpoints = endpointSupplier.get();
       if (endpoints.isEmpty()) {
@@ -196,17 +213,48 @@ class DefaultRequestDispatcher implements RequestDispatcher {
         }
 
         final URI realUri = new URI(scheme, host + ":" + port, fullpath, uri.getQuery(), null);
+
+        AgentProxy agentProxy = null;
+        Deque<Identity> identities = null;
         try {
-          log.debug("connecting to {}", realUri);
-          return connect0(realUri, method, entity, headers,
-                          ipToHostnameUris.get(ipEndpoint).getHost());
-        } catch (ConnectException | SocketTimeoutException | UnknownHostException e) {
-          // UnknownHostException happens if we can't resolve hostname into IP address.
-          // UnknownHostException's getMessage method returns just the hostname which is a useless
-          // message, so log the exception class name to provide more info.
-          log.debug(e.toString());
-          // Connecting failed, sleep a bit to avoid hammering and then try another endpoint
-          Thread.sleep(200);
+          if (scheme.equals("https")) {
+            agentProxy = AgentProxies.newInstance();
+            identities = Queues.newArrayDeque(agentProxy.list());
+          }
+        } catch (Exception e) {
+          log.warn("Couldn't get identities from ssh-agent", e);
+        }
+
+        try {
+          boolean tryNextIdentity = false;
+          do {
+            final Identity identity = (identities != null) ?
+                                      identities.poll() :
+                                      null;
+            try {
+              log.debug("connecting to {}", realUri);
+              return connect0(realUri, method, entity, headers,
+                              ipToHostnameUris.get(ipEndpoint).getHost(),
+                              agentProxy, identity);
+            } catch (SecurityException e) {
+              // there was some sort of security error. if we have any more SSH identities to try,
+              // retry with the next available identity
+              log.debug(e.toString());
+              tryNextIdentity = (identities != null) && !identities.isEmpty();
+            } catch (ConnectException | SocketTimeoutException | UnknownHostException e) {
+              // UnknownHostException happens if we can't resolve hostname into IP address.
+              // UnknownHostException's getMessage method returns just the hostname which is a
+              // useless message, so log the exception class name to provide more info.
+              log.debug(e.toString());
+              // Connecting failed, sleep a bit to avoid hammering and then try another endpoint
+              Thread.sleep(200);
+            }
+          } while (tryNextIdentity);
+        } finally {
+          if (agentProxy != null) {
+            agentProxy.close();
+            agentProxy = null;
+          }
         }
       }
       log.warn("Failed to connect, retrying in 5 seconds.");
@@ -217,7 +265,8 @@ class DefaultRequestDispatcher implements RequestDispatcher {
 
   private HttpURLConnection connect0(final URI ipUri, final String method, final byte[] entity,
                                      final Map<String, List<String>> headers,
-                                     final String hostname)
+                                     final String hostname, final AgentProxy agentProxy,
+                                     final Identity identity)
       throws IOException {
     if (log.isTraceEnabled()) {
       log.trace("req: {} {} {} {} {} {}", method, ipUri, headers.size(),
@@ -235,7 +284,9 @@ class DefaultRequestDispatcher implements RequestDispatcher {
     if (urlConnection instanceof HttpsURLConnection) {
       System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
       connection.setRequestProperty("Host", hostname);
-      ((HttpsURLConnection) connection).setHostnameVerifier(new HostnameVerifier() {
+
+      final HttpsURLConnection httpsConnection = (HttpsURLConnection) urlConnection;
+      httpsConnection.setHostnameVerifier(new HostnameVerifier() {
         @Override
         public boolean verify(String ip, SSLSession sslSession) {
           final String tHostname = hostname.endsWith(".") ?
@@ -243,6 +294,11 @@ class DefaultRequestDispatcher implements RequestDispatcher {
           return new DefaultHostnameVerifier().verify(tHostname, sslSession);
         }
       });
+
+      if (!isNullOrEmpty(user) && (agentProxy != null) && (identity != null)) {
+        final SSLSocketFactory factory = new SshAgentSSLSocketFactory(agentProxy, identity, user);
+        httpsConnection.setSSLSocketFactory(factory);
+      }
     }
 
     connection.setRequestProperty("Accept-Encoding", "gzip");
@@ -264,8 +320,11 @@ class DefaultRequestDispatcher implements RequestDispatcher {
       setRequestMethod(connection, method, false);
     }
 
-    if (connection.getResponseCode() == HTTP_BAD_GATEWAY) {
+    final int responseCode = connection.getResponseCode();
+    if (responseCode == HTTP_BAD_GATEWAY) {
       throw new ConnectException("502 Bad Gateway");
+    } else if ((responseCode == HTTP_FORBIDDEN) || (responseCode == HTTP_UNAUTHORIZED)) {
+      throw new SecurityException("Response code: " + responseCode);
     }
 
     return connection;

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -535,7 +535,7 @@ public class HeliosClient implements AutoCloseable {
 
     public HeliosClient build() {
       return new HeliosClient(user, new DefaultRequestDispatcher(
-          endpointSupplier,
+          endpointSupplier, user,
           MoreExecutors.listeningDecorator(getExitingExecutorService(
               (ThreadPoolExecutor) newFixedThreadPool(4), 0, SECONDS))));
     }

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/RecordingTlsClientProtocol.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/RecordingTlsClientProtocol.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import org.bouncycastle.crypto.tls.ByteQueue;
+import org.bouncycastle.crypto.tls.ContentType;
+import org.bouncycastle.crypto.tls.HandshakeType;
+import org.bouncycastle.crypto.tls.TlsClientProtocol;
+import org.bouncycastle.crypto.tls.TlsUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.SecureRandom;
+
+/**
+ * A {@link org.bouncycastle.crypto.tls.TlsClientProtocol} that keeps a complete record of all
+ * handshake messages (for later hashing and signing by ssh-agent).
+ */
+class RecordingTlsClientProtocol extends TlsClientProtocol {
+
+  private ByteArrayOutputStream record = new ByteArrayOutputStream();
+  private ByteQueue handshakeQueue = new ByteQueue();
+
+  private boolean recording = true;
+
+  public RecordingTlsClientProtocol(InputStream input, OutputStream output,
+                                    SecureRandom secureRandom) {
+    super(input, output, secureRandom);
+  }
+
+  public byte[] getRecord() {
+    return record.toByteArray();
+  }
+
+  @Override
+  protected void sendClientKeyExchangeMessage() throws IOException {
+    super.sendClientKeyExchangeMessage();
+    recording = false;
+  }
+
+  @Override
+  protected void safeWriteRecord(short type, byte[] buf, int offset, int len) throws IOException {
+    if (recording && (type == ContentType.handshake)) {
+      record.write(buf, offset, len);
+    }
+
+    super.safeWriteRecord(type, buf, offset, len);
+  }
+
+  @Override
+  protected void processRecord(short protocol, byte[] buf, int offset, int len) throws IOException {
+    if (recording && (protocol == ContentType.handshake)) {
+      handshakeQueue.addData(buf, offset, len);
+      processHandshakeQueue();
+    }
+
+    super.processRecord(protocol, buf, offset, len);
+  }
+
+  private void processHandshakeQueue() {
+    boolean read;
+    do {
+      read = false;
+
+      // we need at least 4 bytes to tell what the message type is, otherwise we
+      // can't make the decision on whether it goes into the record
+      if (handshakeQueue.available() >= 4) {
+        // read the header that tells us the message type and content length
+        byte[] beginning = new byte[4];
+        handshakeQueue.read(beginning, 0, 4, 0);
+        short type = TlsUtils.readUint8(beginning, 0);
+        int len = TlsUtils.readUint24(beginning, 1);
+
+        // based on the content length we just read, only proceed if we've received
+        // all the content for the message
+        if (handshakeQueue.available() >= (len + 4)) {
+          byte[] buffer = handshakeQueue.removeData(len, 4);
+
+          switch (type) {
+            case HandshakeType.hello_request:
+              break;
+            case HandshakeType.finished:
+              break;
+            default:
+              // this is a type of data that we do indeed want to record
+              record.write(beginning, 0, 4);
+              record.write(buffer, 0, len);
+              break;
+          }
+
+          read = true; // we read some data, so there might be some more. loop again.
+        }
+      }
+    } while (read);
+  }
+
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentContentSigner.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentContentSigner.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Returns a signed SHA1 hash of any arbitrary data by sending it to the local SSH agent.
+ * Returns a signed hash of any arbitrary data by sending it to the local SSH agent.
  */
 class SshAgentContentSigner implements ContentSigner {
 

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentContentSigner.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentContentSigner.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import com.google.common.base.Throwables;
+
+import com.spotify.sshagentproxy.AgentProxy;
+import com.spotify.sshagentproxy.Identity;
+
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Returns a signed SHA1 hash of any arbitrary data by sending it to the local SSH agent.
+ */
+class SshAgentContentSigner implements ContentSigner {
+
+  private static final AlgorithmIdentifier IDENTIFIER =
+      new DefaultSignatureAlgorithmIdentifierFinder().find("SHA1withRSA");
+
+  private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+  private final AgentProxy agentProxy;
+  private final Identity identity;
+
+  public SshAgentContentSigner(final AgentProxy agentProxy, final Identity identity) {
+    this.agentProxy = agentProxy;
+    this.identity = identity;
+  }
+
+  @Override
+  public AlgorithmIdentifier getAlgorithmIdentifier() {
+    return IDENTIFIER;
+  }
+
+  @Override
+  public OutputStream getOutputStream() {
+    return stream;
+  }
+
+  @Override
+  public byte[] getSignature() {
+    try {
+      return agentProxy.sign(identity, stream.toByteArray());
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentSSLSocketFactory.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentSSLSocketFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import com.spotify.sshagentproxy.AgentProxy;
+import com.spotify.sshagentproxy.Identity;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.SecureRandom;
+
+import javax.net.ssl.SSLSocketFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Wraps our custom TLS functionality in a {@link javax.net.ssl.SSLSocketFactory}, specifically for
+ * use with {@link javax.net.ssl.HttpsURLConnection#setSSLSocketFactory(SSLSocketFactory)}. Only
+ * operations that are actually used by HttpsURLConnection are implemented.
+ */
+public class SshAgentSSLSocketFactory extends SSLSocketFactory {
+
+  private final AgentProxy agentProxy;
+  private final Identity identity;
+  private final String username;
+
+  /**
+   * @param username The username to set in the UID field of generated X509 certificates.
+   * @throws IOException Should never be thrown.
+   */
+  public SshAgentSSLSocketFactory(final AgentProxy agentProxy, final Identity identity,
+                                  final String username)
+      throws IOException {
+    checkNotNull(agentProxy, "agentProxy");
+    checkNotNull(identity, "identity");
+    checkNotNull(username, "username");
+
+    this.agentProxy = agentProxy;
+    this.identity = identity;
+    this.username = username;
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(Socket s, String host, int port, boolean autoClose)
+      throws IOException {
+    final RecordingTlsClientProtocol protocol = new RecordingTlsClientProtocol(
+        s.getInputStream(), s.getOutputStream(), new SecureRandom());
+    final SshAgentTlsClient tlsClient = new SshAgentTlsClient(agentProxy, identity, username,
+                                                              protocol);
+
+    protocol.connect(tlsClient);
+    return new SshAgentTlsSocket(tlsClient, s);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localAddress, int localPort)
+      throws IOException, UnknownHostException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+                             int localPort)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentTlsClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentTlsClient.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import com.google.common.collect.Lists;
+
+import com.spotify.sshagentproxy.AgentProxy;
+import com.spotify.sshagentproxy.Identity;
+
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.crypto.tls.Certificate;
+import org.bouncycastle.crypto.tls.CertificateRequest;
+import org.bouncycastle.crypto.tls.DefaultTlsClient;
+import org.bouncycastle.crypto.tls.HashAlgorithm;
+import org.bouncycastle.crypto.tls.SignatureAlgorithm;
+import org.bouncycastle.crypto.tls.SignatureAndHashAlgorithm;
+import org.bouncycastle.crypto.tls.TlsAuthentication;
+import org.bouncycastle.crypto.tls.TlsCredentials;
+import org.bouncycastle.crypto.tls.TlsSignerCredentials;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * A {@link org.bouncycastle.crypto.tls.TlsClient} that uses an SSH agent identity for client
+ * authentication. An X509 certificate is generated based on the SSH agent identity, and the
+ * handshake record is sent to the local SSH agent to be signed.
+ */
+class SshAgentTlsClient extends DefaultTlsClient {
+
+  private static final SignatureAndHashAlgorithm ALGO = new SignatureAndHashAlgorithm(
+      HashAlgorithm.sha1, SignatureAlgorithm.rsa);
+
+  private final AgentProxy agentProxy;
+  private final Identity identity;
+  private final String username;
+  private final RecordingTlsClientProtocol protocol;
+
+  private X509Certificate[] serverCertificates;
+
+  public SshAgentTlsClient(final AgentProxy agentProxy,
+                           final Identity identity,
+                           final String username,
+                           final RecordingTlsClientProtocol protocol) {
+    super();
+    this.agentProxy = agentProxy;
+    this.username = username;
+    this.identity = identity;
+    this.protocol = protocol;
+  }
+
+  public RecordingTlsClientProtocol getProtocol() {
+    return protocol;
+  }
+
+  public X509Certificate[] getServerCertificates() {
+    return serverCertificates;
+  }
+
+  @Override
+  public TlsAuthentication getAuthentication() throws IOException {
+    return new SshAgentTlsAuthentication();
+  }
+
+  private class SshAgentTlsAuthentication implements TlsAuthentication {
+
+    private final Certificate certificate;
+
+    public SshAgentTlsAuthentication() {
+      certificate = X509CertificateFactory.get(agentProxy, identity, username);
+    }
+
+    @Override
+    public void notifyServerCertificate(final Certificate serverCertificate)
+        throws IOException {
+      final JcaX509CertificateConverter converter =
+          new JcaX509CertificateConverter().setProvider("BC");
+
+      final List<X509Certificate> x509Certs = Lists.newArrayList();
+      try {
+        for (final org.bouncycastle.asn1.x509.Certificate cert :
+            serverCertificate.getCertificateList()) {
+          x509Certs.add(converter.getCertificate(new X509CertificateHolder(cert)));
+        }
+      } catch (CertificateException e) {
+        throw new IOException("couldn't convert the server certificate", e);
+      }
+
+      serverCertificates = x509Certs.toArray(new X509Certificate[0]);
+    }
+
+    @Override
+    public TlsCredentials getClientCredentials(final CertificateRequest certificateRequest)
+        throws IOException {
+      return new TlsSignerCredentials() {
+
+        @Override
+        public byte[] generateCertificateSignature(final byte[] hash) throws IOException {
+          final SshAgentContentSigner signer = new SshAgentContentSigner(agentProxy, identity);
+          signer.getOutputStream().write(protocol.getRecord());
+          return signer.getSignature();
+        }
+
+        @Override
+        public SignatureAndHashAlgorithm getSignatureAndHashAlgorithm() {
+          return ALGO;
+        }
+
+        @Override
+        public Certificate getCertificate() {
+          return certificate;
+        }
+      };
+    }
+  }
+
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentTlsSocket.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/SshAgentTlsSocket.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import com.google.common.base.Throwables;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocket;
+import javax.security.cert.CertificateException;
+import javax.security.cert.X509Certificate;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Presents our custom TLS connection as a {@link javax.net.ssl.SSLSocket} that can be easily used
+ * by {@link javax.net.ssl.HttpsURLConnection}. Only operations that are actually used by
+ * HttpsURLConnection are implemented.
+ */
+class SshAgentTlsSocket extends SSLSocket {
+
+  private final SshAgentTlsClient client;
+  private final RecordingTlsClientProtocol protocol;
+  private final Socket underlying;
+
+  public SshAgentTlsSocket(final SshAgentTlsClient client, final Socket underlying) {
+    checkNotNull(client);
+    checkNotNull(underlying);
+
+    this.client = client;
+    this.protocol = client.getProtocol();
+    this.underlying = underlying;
+  }
+
+  @Override
+  public OutputStream getOutputStream() throws IOException {
+    return protocol.getOutputStream();
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return protocol.getInputStream();
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    protocol.close();
+  }
+
+  @Override
+  public void connect(SocketAddress endpoint) throws IOException {
+    underlying.connect(endpoint);
+  }
+
+  @Override
+  public void connect(SocketAddress endpoint, int timeout) throws IOException {
+    underlying.connect(endpoint, timeout);
+  }
+
+  @Override
+  public void bind(SocketAddress bindpoint) throws IOException {
+    underlying.bind(bindpoint);
+  }
+
+  @Override
+  public InetAddress getInetAddress() {
+    return underlying.getInetAddress();
+  }
+
+  @Override
+  public InetAddress getLocalAddress() {
+    return underlying.getLocalAddress();
+  }
+
+  @Override
+  public int getPort() {
+    return underlying.getPort();
+  }
+
+  @Override
+  public int getLocalPort() {
+    return underlying.getLocalPort();
+  }
+
+  @Override
+  public SocketAddress getRemoteSocketAddress() {
+    return underlying.getRemoteSocketAddress();
+  }
+
+  @Override
+  public SocketAddress getLocalSocketAddress() {
+    return underlying.getLocalSocketAddress();
+  }
+
+  @Override
+  public SocketChannel getChannel() {
+    return underlying.getChannel();
+  }
+
+  @Override
+  public void setTcpNoDelay(boolean on) throws SocketException {
+    underlying.setTcpNoDelay(on);
+  }
+
+  @Override
+  public boolean getTcpNoDelay() throws SocketException {
+    return underlying.getTcpNoDelay();
+  }
+
+  @Override
+  public void setSoLinger(boolean on, int linger) throws SocketException {
+    underlying.setSoLinger(on, linger);
+  }
+
+  @Override
+  public int getSoLinger() throws SocketException {
+    return underlying.getSoLinger();
+  }
+
+  @Override
+  public void sendUrgentData(int data) throws IOException {
+    underlying.sendUrgentData(data);
+  }
+
+  @Override
+  public void setOOBInline(boolean on) throws SocketException {
+    underlying.setOOBInline(on);
+  }
+
+  @Override
+  public boolean getOOBInline() throws SocketException {
+    return underlying.getOOBInline();
+  }
+
+  @Override
+  public void setSoTimeout(int timeout) throws SocketException {
+    underlying.setSoTimeout(timeout);
+  }
+
+  @Override
+  public int getSoTimeout() throws SocketException {
+    return underlying.getSoTimeout();
+  }
+
+  @Override
+  public void setSendBufferSize(int size) throws SocketException {
+    underlying.setSendBufferSize(size);
+  }
+
+  @Override
+  public int getSendBufferSize() throws SocketException {
+    return underlying.getSendBufferSize();
+  }
+
+  @Override
+  public void setReceiveBufferSize(int size) throws SocketException {
+    underlying.setReceiveBufferSize(size);
+  }
+
+  @Override
+  public int getReceiveBufferSize() throws SocketException {
+    return underlying.getReceiveBufferSize();
+  }
+
+  @Override
+  public void setKeepAlive(boolean on) throws SocketException {
+    underlying.setKeepAlive(on);
+  }
+
+  @Override
+  public boolean getKeepAlive() throws SocketException {
+    return underlying.getKeepAlive();
+  }
+
+  @Override
+  public void setTrafficClass(int tc) throws SocketException {
+    underlying.setTrafficClass(tc);
+  }
+
+  @Override
+  public int getTrafficClass() throws SocketException {
+    return underlying.getTrafficClass();
+  }
+
+  @Override
+  public void setReuseAddress(boolean on) throws SocketException {
+    underlying.setReuseAddress(on);
+  }
+
+  @Override
+  public boolean getReuseAddress() throws SocketException {
+    return underlying.getReuseAddress();
+  }
+
+  @Override
+  public void shutdownInput() throws IOException {
+    underlying.shutdownInput();
+  }
+
+  @Override
+  public void shutdownOutput() throws IOException {
+    underlying.shutdownOutput();
+  }
+
+  @Override
+  public boolean isConnected() {
+    return underlying.isConnected();
+  }
+
+  @Override
+  public boolean isBound() {
+    return underlying.isBound();
+  }
+
+  @Override
+  public boolean isClosed() {
+    return underlying.isClosed();
+  }
+
+  @Override
+  public boolean isInputShutdown() {
+    return underlying.isInputShutdown();
+  }
+
+  @Override
+  public boolean isOutputShutdown() {
+    return underlying.isOutputShutdown();
+  }
+
+  @Override
+  public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+    underlying.setPerformancePreferences(connectionTime, latency, bandwidth);
+  }
+
+  @Override
+  public SSLSession getSession() {
+    return new SSLSession() {
+      @Override
+      public byte[] getId() {
+        return new byte[0];
+      }
+
+      @Override
+      public SSLSessionContext getSessionContext() {
+        return null;
+      }
+
+      @Override
+      public long getCreationTime() {
+        return 0;
+      }
+
+      @Override
+      public long getLastAccessedTime() {
+        return 0;
+      }
+
+      @Override
+      public void invalidate() {
+
+      }
+
+      @Override
+      public boolean isValid() {
+        return false;
+      }
+
+      @Override
+      public void putValue(String s, Object o) {
+
+      }
+
+      @Override
+      public Object getValue(String s) {
+        return null;
+      }
+
+      @Override
+      public void removeValue(String s) {
+
+      }
+
+      @Override
+      public String[] getValueNames() {
+        return new String[0];
+      }
+
+      @Override
+      public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
+        return client.getServerCertificates();
+      }
+
+      @Override
+      public Certificate[] getLocalCertificates() {
+        return new Certificate[0];
+      }
+
+      @Override
+      public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
+        final Certificate[] certificates = client.getServerCertificates();
+        final X509Certificate[] x509Certificates = new X509Certificate[certificates.length];
+
+        for (int i = 0; i < certificates.length; i++) {
+          try {
+            x509Certificates[i] = X509Certificate.getInstance(certificates[i].getEncoded());
+          } catch (CertificateException | CertificateEncodingException e) {
+            throw Throwables.propagate(e);
+          }
+        }
+
+        return x509Certificates;
+      }
+
+      @Override
+      public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
+        final X509Certificate[] x509Certificates = getPeerCertificateChain();
+        if ((x509Certificates != null) && (x509Certificates.length > 0)) {
+          return x509Certificates[0].getSubjectDN();
+        } else {
+          return null;
+        }
+      }
+
+      @Override
+      public Principal getLocalPrincipal() {
+        return null;
+      }
+
+      @Override
+      public String getCipherSuite() {
+        return "";
+      }
+
+      @Override
+      public String getProtocol() {
+        return client.getClientVersion().toString();
+      }
+
+      @Override
+      public String getPeerHost() {
+        return underlying.getInetAddress().getHostName();
+      }
+
+      @Override
+      public int getPeerPort() {
+        return underlying.getPort();
+      }
+
+      @Override
+      public int getPacketBufferSize() {
+        return 0;
+      }
+
+      @Override
+      public int getApplicationBufferSize() {
+        return 0;
+      }
+    };
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return new String[0];
+  }
+
+  @Override
+  public String[] getEnabledCipherSuites() {
+    return new String[0];
+  }
+
+  @Override
+  public void setEnabledCipherSuites(String[] strings) {
+  }
+
+  @Override
+  public String[] getSupportedProtocols() {
+    return new String[0];
+  }
+
+  @Override
+  public String[] getEnabledProtocols() {
+    return new String[0];
+  }
+
+  @Override
+  public void setEnabledProtocols(String[] strings) {
+  }
+
+  @Override
+  public void addHandshakeCompletedListener(HandshakeCompletedListener handshakeCompletedListener) {
+  }
+
+  @Override
+  public void removeHandshakeCompletedListener(
+      HandshakeCompletedListener handshakeCompletedListener) {
+  }
+
+  @Override
+  public void startHandshake() throws IOException {
+  }
+
+  @Override
+  public void setUseClientMode(boolean b) {
+  }
+
+  @Override
+  public boolean getUseClientMode() {
+    return false;
+  }
+
+  @Override
+  public void setNeedClientAuth(boolean b) {
+  }
+
+  @Override
+  public boolean getNeedClientAuth() {
+    return false;
+  }
+
+  @Override
+  public void setWantClientAuth(boolean b) {
+  }
+
+  @Override
+  public boolean getWantClientAuth() {
+    return false;
+  }
+
+  @Override
+  public void setEnableSessionCreation(boolean b) {
+  }
+
+  @Override
+  public boolean getEnableSessionCreation() {
+    return false;
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import com.google.common.base.Throwables;
+
+import com.eaio.uuid.UUID;
+import com.spotify.sshagentproxy.AgentProxy;
+import com.spotify.sshagentproxy.Identity;
+
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509ExtensionUtils;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.crypto.tls.Certificate;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.operator.bc.BcDigestCalculatorProvider;
+
+import java.math.BigInteger;
+import java.security.Security;
+import java.util.Calendar;
+import java.util.Date;
+
+class X509CertificateFactory {
+
+  private static final int HOURS_BEFORE = 1;
+  private static final int HOURS_AFTER = 48;
+
+  static {
+    Security.addProvider(new BouncyCastleProvider());
+  }
+
+  public static Certificate get(final AgentProxy agentProxy, final Identity identity,
+                                final String username) {
+    final UUID uuid = new UUID();
+    final Calendar calendar = Calendar.getInstance();
+    final X500Name issuerDN = new X500Name("C=US,O=Spotify,CN=helios-client");
+    final X500Name subjectDN = new X500NameBuilder().addRDN(BCStyle.UID, username).build();
+    final SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(
+        ASN1Sequence.getInstance(identity.getPublicKey().getEncoded()));
+
+    calendar.add(Calendar.HOUR, -HOURS_BEFORE);
+    final Date notBefore = calendar.getTime();
+
+    calendar.add(Calendar.HOUR, HOURS_BEFORE + HOURS_AFTER);
+    final Date notAfter = calendar.getTime();
+
+    // Reuse the UUID time as a SN
+    final BigInteger serialNumber = BigInteger.valueOf(uuid.getTime()).abs();
+
+    final X509v3CertificateBuilder builder = new X509v3CertificateBuilder(issuerDN, serialNumber,
+                                                                          notBefore, notAfter,
+                                                                          subjectDN,
+                                                                          subjectPublicKeyInfo);
+
+    try {
+      final DigestCalculator digestCalculator = new BcDigestCalculatorProvider()
+          .get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+      final X509ExtensionUtils utils = new X509ExtensionUtils(digestCalculator);
+
+      builder.addExtension(Extension.subjectKeyIdentifier, false,
+                           utils.createSubjectKeyIdentifier(subjectPublicKeyInfo));
+      builder.addExtension(Extension.authorityKeyIdentifier, false,
+                           utils.createAuthorityKeyIdentifier(subjectPublicKeyInfo));
+      builder.addExtension(Extension.keyUsage, false,
+                           new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign));
+      builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+
+      final X509CertificateHolder holder = builder.build(new SshAgentContentSigner(agentProxy,
+                                                                                   identity));
+
+      return new Certificate(new org.bouncycastle.asn1.x509.Certificate[] {
+          holder.toASN1Structure(),
+      });
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import com.spotify.sshagentproxy.AgentProxy;
+import com.spotify.sshagentproxy.Identity;
+
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.crypto.tls.Certificate;
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class X509CertificateFactoryTest {
+
+  private static final String USERNAME = "rohan";
+
+  private static final String ROHAN_PUB_KEY =
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo6Uv9Ed/6g8IEdjponMNZ/s/IC/Lebo4wgUTegF7fvByb2Jk"
+      + "3ldeaNLt5Ds6jg8s1eF/5AlcN4xR844foOh85vFixgyh9bu6OceKk8rzHxYB9kqRpDgEaZzEGNAbV2EYenC07nMtGK"
+      + "rcNbTtKDVA7MPChzJ3qzNW+L4MTUtac8YrTWqaUaFyjL8bSkS5cF3rtnAQXWY3Js1bQnPmtRo6ZTBltu5RtvC9p2vc"
+      + "iuOID7br7s1eCGf2g1mGwdj7enr3O4TLUiTR7l7KZuM+ggQyIcoGf6PU3nTS5FgHlgrowyORqBONjye09lDw1io+n6"
+      + "XnXSfO3tCOAG/kTSW2zSPaPQIDAQAB";
+
+  private final AgentProxy agentProxy = mock(AgentProxy.class);
+  private final Identity identity = mock(Identity.class);
+
+  private PublicKey publicKey;
+
+  @Before
+  public void setUp() throws Exception {
+    X509EncodedKeySpec pubKeySpec = new X509EncodedKeySpec(Base64.decode(ROHAN_PUB_KEY));
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    publicKey = keyFactory.generatePublic(pubKeySpec);
+
+    when(identity.getPublicKey()).thenReturn(publicKey);
+  }
+
+  @Test
+  public void testGet() throws Exception{
+    final Certificate certificates = X509CertificateFactory.get(agentProxy, identity, USERNAME);
+    assertEquals(1, certificates.getLength());
+
+    final org.bouncycastle.asn1.x509.Certificate certificate = certificates.getCertificateAt(0);
+
+    assertEquals(USERNAME,
+                 certificate.getSubject().getRDNs(BCStyle.UID)[0].getFirst().getValue().toString());
+    assertArrayEquals(publicKey.getEncoded(), certificate.getSubjectPublicKeyInfo().getEncoded());
+  }
+
+}

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -162,7 +162,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -313,6 +313,16 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.53</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-unixsocket</artifactId>
+      <version>0.8</version>
     </dependency>
 
     <!--test deps-->

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Use the local SSH agent identity to generate a self-signed certificate for
TLS client authentication, and sign the handshake hash with ssh-agent.

This lets the client setup a secure SSL connection and prove ownership of
its SSH public key. It is up to the server to verify the public key against
a known-good list (like in LDAP).