### PR TITLE
fix broken helios-authentication integration tests

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -45,6 +45,9 @@ case "$1" in
         sed -i'' 's/<module>helios-system-tests<\/module>//' pom.xml
         mvn test -B
 
+        # run the lightweight "integration" tests in helios-authentication also
+        mvn -pl helios-authentication verify -B
+
         ;;
 
       1)

--- a/helios-authentication/src/it/00-test-harness/src/main/java/com/spotify/helios/auth/it/IntegrationTestPlugin.java
+++ b/helios-authentication/src/it/00-test-harness/src/main/java/com/spotify/helios/auth/it/IntegrationTestPlugin.java
@@ -25,6 +25,8 @@ import com.google.auto.service.AutoService;
 
 import com.spotify.helios.auth.AuthenticationPlugin;
 
+import java.util.Map;
+
 /**
  * Plugin implementation used in integration testing that AuthenticationPluginLoader can load
  * plugins from arbitrary paths not on the CLASSPATH.
@@ -38,7 +40,7 @@ public class IntegrationTestPlugin implements AuthenticationPlugin<String> {
   }
 
   @Override
-  public ServerAuthentication<String> serverAuthentication() {
+  public ServerAuthentication<String> serverAuthentication(Map<String, String> environment) {
     return null;
   }
 


### PR DESCRIPTION
This broke in `4ff70b4` and was not noticed because the "integration" tests
within helios-authentication are not being run at all by CircleCI
(oops).