### PR TITLE
Make helios-solo not print ':' and 'sleep 1' indefinitely

### DIFF
--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -78,5 +78,6 @@ com.spotify.helios.master.MasterMain \
 $HELIOS_MASTER_OPTS \
 &
 
+set +x
 # Sleep or execute command line
 while :; do sleep 1; done


### PR DESCRIPTION
This is useful when running solo directly in systemd and you want 'journalctl -u helios-solo' to show something reasonable