### PR TITLE
solo: Update Debian depends to allow docker-engine

### DIFF
--- a/src/deb/helios-solo/control
+++ b/src/deb/helios-solo/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: docker.io | lxc-docker, helios, jq, bind9-host
+Depends: docker.io | lxc-docker | docker-engine, helios, jq, bind9-host
 Provides: helios-standalone
 Conflicts: helios-standalone
 Replaces: helios-standalone


### PR DESCRIPTION
There is a new Debian package of Docker that's named "docker-engine".