### PR TITLE
Optimize DefaultRequestDispatcher and improve ssh-agent warning message

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
@@ -91,6 +91,14 @@ class DefaultRequestDispatcher implements RequestDispatcher {
         identities = getSshIdentities();
       } catch (Exception e) {
         log.debug("Couldn't get identities from ssh-agent", e);
+        log.warn(
+            "Your Helios cluster is setup to work over HTTPS based on the Helios DNS records "
+            + "found by this Helios CLI. This will provide client and server-side authentication. "
+            + "The team that operates your Helios cluster may choose to make this authentication "
+            + "optional for now in which case this is just a warning.\nWhen authentication is "
+            + "required, you'll need to run ssh-agent and set the SSH_AUTH_SOCK environment "
+            + "variable whenever you invoke this CLI."
+        );
       }
     }
   }

--- a/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/DefaultRequestDispatcher.java
@@ -19,6 +19,7 @@ package com.spotify.helios.client;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -76,6 +77,7 @@ class DefaultRequestDispatcher implements RequestDispatcher {
   private final EndpointIterator endpointIterator;
   private final ListeningExecutorService executorService;
   private final String user;
+  private List<Identity> identities = Collections.emptyList();
 
   DefaultRequestDispatcher(final List<Endpoint> endpoints,
                            final String user,
@@ -83,6 +85,14 @@ class DefaultRequestDispatcher implements RequestDispatcher {
     endpointIterator = EndpointIterator.of(endpoints);
     this.executorService = executorService;
     this.user = user;
+
+    if (endpointIterator.hasHttps()) {
+      try {
+        identities = getSshIdentities();
+      } catch (Exception e) {
+        log.debug("Couldn't get identities from ssh-agent", e);
+      }
+    }
   }
 
   @Override
@@ -153,7 +163,7 @@ class DefaultRequestDispatcher implements RequestDispatcher {
   }
 
   /**
-   * Sets up a connection, retrying on connect failure.
+   * Sets up a connection
    */
   private HttpURLConnection connect(final URI uri, final String method, final byte[] entity,
                                     final Map<String, List<String>> headers)
@@ -170,25 +180,20 @@ class DefaultRequestDispatcher implements RequestDispatcher {
         uriScheme, endpointUri.getUserInfo(), endpoint.getIp().getHostAddress(),
         endpointUri.getPort(), fullpath, uri.getQuery(), null);
 
-    AgentProxy agentProxy = null;
-    Deque<Identity> identities = Queues.newArrayDeque();
-    try {
-      if (uriScheme.equals("https")) {
-        agentProxy = AgentProxies.newInstance();
-        for (final Identity identity : agentProxy.list()) {
-          if (identity.getPublicKey().getAlgorithm().equals("RSA")) {
-            // only RSA keys will work with our TLS implementation
-            identities.offerLast(identity);
-          }
-        }
-      }
-    } catch (Exception e) {
-      log.debug("Couldn't get identities from ssh-agent", e);
+    final AgentProxy agentProxy;
+    final Deque<Identity> ids;
+    if (uriScheme.equalsIgnoreCase("https")) {
+      agentProxy = AgentProxies.newInstance();
+      ids = Queues.newArrayDeque(identities);
+    } else {
+      // Create null agentProxy and empty ids for connect0() later on to not perform TLS handshake
+      agentProxy = null;
+      ids = Queues.newArrayDeque();
     }
 
     try {
       while (true) {
-        final Identity identity = identities.poll();
+        final Identity identity = ids.poll();
 
         try {
           log.debug("connecting to {}", ipUri);
@@ -314,5 +319,20 @@ class DefaultRequestDispatcher implements RequestDispatcher {
   @Override
   public void close() {
     executorService.shutdownNow();
+  }
+
+  private static List<Identity> getSshIdentities() throws IOException {
+    final ImmutableList.Builder<Identity> builder = ImmutableList.builder();
+
+    try (final AgentProxy agentProxy = AgentProxies.newInstance()) {
+      for (final Identity identity : agentProxy.list()) {
+        if (identity.getPublicKey().getAlgorithm().equals("RSA")) {
+          // only RSA keys will work with our TLS implementation
+          builder.add(identity);
+        }
+      }
+    }
+
+    return builder.build();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/client/EndpointIterator.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/EndpointIterator.java
@@ -17,12 +17,16 @@
 
 package com.spotify.helios.client;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -68,5 +72,19 @@ class EndpointIterator implements Iterator<Endpoint> {
   @Override
   public void remove() {
     throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @return true if any endpoints' scheme is HTTPS
+   */
+  boolean hasHttps() {
+    return Iterables.any(endpoints, new Predicate<Endpoint>() {
+      @Override
+      public boolean apply(@Nullable Endpoint endpoint) {
+        return endpoint != null && endpoint.getUri() != null &&
+               endpoint.getUri().getScheme() != null &&
+               endpoint.getUri().getScheme().equalsIgnoreCase("https");
+      }
+    });
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/client/EndpointIteratorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/EndpointIteratorTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -72,7 +73,7 @@ public class EndpointIteratorTest {
 
   @Test
   public void test() throws Exception {
-    final Iterator<Endpoint> iterator = EndpointIterator.of(endpoints);
+    final EndpointIterator iterator = EndpointIterator.of(endpoints);
 
     final Set<URI> uris = Sets.newHashSet();
     final Set<InetAddress> ips = Sets.newHashSet();
@@ -87,6 +88,7 @@ public class EndpointIteratorTest {
     assertEquals(ips.size(), 4);
     assertThat(uris, containsInAnyOrder(uri1, uri2));
     assertThat(ips, containsInAnyOrder(IP_A, IP_B, IP_C, IP_D));
+    assertTrue(iterator.hasHttps());
   }
 
   @Test
@@ -95,5 +97,12 @@ public class EndpointIteratorTest {
     assertFalse(iterator.hasNext());
     exception.expect(NoSuchElementException.class);
     iterator.next();
+  }
+
+  @Test
+  public void testHasHttpsReturnsFalse() throws Exception {
+    final EndpointIterator iterator = EndpointIterator.of(
+        Endpoints.of(Collections.singletonList(uri1)));
+    assertFalse(iterator.hasHttps());
   }
 }


### PR DESCRIPTION
and only get them if an endpoint is HTTPS.
We were asking the ssh-agent for the list of identities
for every new connection to an endpoint.