### PR TITLE
solo: Fix get_helios_version check in helios-use

### DIFF
--- a/solo/helios-use
+++ b/solo/helios-use
@@ -12,7 +12,7 @@ function get_helios_version() {
 
 function get_cli_version() {
 	if type -p helios >/dev/null; then
-		helios --version | grep -oe '[0-9\.]\+'
+		helios --version | grep 'Helios CLI' | grep -oe '[0-9\.]\+'
 	fi
 }
 


### PR DESCRIPTION
Due to a change in the formatting of the output from `helios --version`,
get_cli_version was returning a newline-separated string containing both
the CLI version and the target Docker version.

Fix it to only return the CLI version.