### PR TITLE
fix type error in KAFKA_QUOROM_PARAMETER

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
@@ -36,8 +36,6 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperUpdatingPersistentDirectory;
 
 import org.apache.curator.framework.state.ConnectionState;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,8 +90,7 @@ public class ZooKeeperAgentModel extends AbstractIdleService implements AgentMod
     this.historyWriter = new TaskHistoryWriter(
         host, client, stateDirectory.resolve(TASK_HISTORY_FILENAME));
 
-    this.kafkaSender = new KafkaSender(
-        kafkaProvider.getProducer(new StringSerializer(), new ByteArraySerializer()));
+    this.kafkaSender = new KafkaSender(kafkaProvider.getDefaultProducer());
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -24,7 +24,6 @@ import com.google.common.io.Resources;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import com.codahale.metrics.MetricRegistry;
-import com.spotify.helios.servicescommon.KafkaClientProvider;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
 import com.spotify.helios.master.resources.DeploymentGroupResource;
@@ -36,6 +35,7 @@ import com.spotify.helios.master.resources.VersionResource;
 import com.spotify.helios.rollingupdate.RollingUpdateService;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
+import com.spotify.helios.servicescommon.KafkaClientProvider;
 import com.spotify.helios.servicescommon.KafkaSender;
 import com.spotify.helios.servicescommon.ManagedStatsdReporter;
 import com.spotify.helios.servicescommon.ReactorFactory;
@@ -58,8 +58,6 @@ import com.spotify.helios.servicescommon.statistics.NoopMetrics;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerCollection;
@@ -167,8 +165,7 @@ public class MasterService extends AbstractIdleService {
 
     // Make a KafkaProducer for events that can be serialized to an array of bytes,
     // and wrap it in our KafkaSender.
-    final KafkaSender kafkaSender = new KafkaSender(
-        kafkaClientProvider.getProducer(new StringSerializer(), new ByteArraySerializer()));
+    final KafkaSender kafkaSender = new KafkaSender(kafkaClientProvider.getDefaultProducer());
 
     final ZooKeeperMasterModel model =
         new ZooKeeperMasterModel(zkClientProvider, config.getName(), kafkaSender);

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
@@ -40,7 +40,7 @@ public class KafkaClientProvider {
   private static final Logger log = LoggerFactory.getLogger(KafkaClientProvider.class);
 
   private static final String KAFKA_HELIOS_CLIENT_ID = "Helios";
-  private static final int KAFKA_QUORUM_PARAMETER = 1;
+  private static final String KAFKA_QUORUM_PARAMETER = "1";
   public static final int MAX_BLOCK_TIMEOUT = 5000;
 
   private final Optional<ImmutableMap<String, Object>> partialConfigs;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
@@ -24,7 +24,9 @@ import com.google.common.collect.ImmutableMap;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,19 +87,25 @@ public class KafkaClientProvider {
     });
   }
 
-  static KafkaClientProvider getTestingProvider() {
-    return new KafkaClientProvider(null);
+  /**
+   * Returns a producer that uses {@link org.apache.kafka.common.serialization.StringSerializer} for
+   * keys and {@link org.apache.kafka.common.serialization.ByteArraySerializer} for values.
+   */
+  public Optional<KafkaProducer<String, byte[]>> getDefaultProducer() {
+    return getProducer(new StringSerializer(), new ByteArraySerializer());
   }
 
-  public <K, V> Optional<KafkaProducer<K, V>> getProducer(@NotNull final Serializer<K> ks,
-                                                          @NotNull final Serializer<V> vs) {
+  /** Returns a producer with customized serializers for keys and values. */
+  public <K, V> Optional<KafkaProducer<K, V>> getProducer(
+      @NotNull final Serializer<K> keySerializer,
+      @NotNull final Serializer<V> valueSerializer) {
     try {
       return partialConfigs.transform(
           new Function<ImmutableMap<String, Object>, KafkaProducer<K, V>>() {
             @Nullable
             @Override
             public KafkaProducer<K, V> apply(ImmutableMap<String, Object> input) {
-              return new KafkaProducer<>(input, ks, vs);
+              return new KafkaProducer<>(input, keySerializer, valueSerializer);
             }
           });
     } catch (final Exception e) {

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/KafkaClientProviderTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/KafkaClientProviderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.servicescommon;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KafkaClientProviderTest {
+
+  @Test
+  public void testNoBrokersConfigured() {
+    final KafkaClientProvider provider = new KafkaClientProvider(null);
+
+    assertEquals("KafkaClientProvider should return absent when null list of seed hosts is passed",
+        Optional.absent(), provider.getDefaultProducer());
+  }
+
+  @Test
+  public void testReturnsProvider() {
+    final KafkaClientProvider provider = new KafkaClientProvider(ImmutableList.of("localhost"));
+
+    assertTrue("Expected KafkaProvider to return non-absent KafkaProducer "
+               + "when passed a list of seed hosts",
+        provider.getDefaultProducer().isPresent());
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/KafkaClientProviderTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/KafkaClientProviderTest.java
@@ -37,7 +37,9 @@ public class KafkaClientProviderTest {
 
   @Test
   public void testReturnsProvider() {
-    final KafkaClientProvider provider = new KafkaClientProvider(ImmutableList.of("localhost"));
+    // the actual host:port used in the test does not need to be an actual Kafka server
+    final ImmutableList<String> hosts = ImmutableList.of("localhost:2181");
+    final KafkaClientProvider provider = new KafkaClientProvider(hosts);
 
     assertTrue("Expected KafkaProvider to return non-absent KafkaProducer "
                + "when passed a list of seed hosts",


### PR DESCRIPTION
The Kafka `ProducerConfig` expects the value for `ACKS_CONFIG` to be a `String` and not an `int`, even though the value of the String looks to almost always be numeric (seems like it is a String since one possible value is `all` in addition to `1` or `0` or `-1`).

With this configuration error, the agent or master is never actually able to instantiate a KafkaProducer and not able to send any events to Kafka. This was introduced in ae50b2f.

Also added tests to KafkaClientProducer to verify it can produce a Kafka client; refactored the `getProvider()` method a bit as it is always called with the same exact arguments.