### PR TITLE
Automatically deploy helios-solo for use with helios-testing

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -40,6 +40,11 @@ case "$1" in
     ;;
 
   test)
+    # fix DOCKER_HOST to be accessible from within containers
+    docker0_ip=$(/sbin/ifconfig docker0 | grep 'inet addr' | \
+      awk -F: '{print $2}' | awk '{print $1}')
+    export DOCKER_HOST="tcp://$docker0_ip:2375"
+
     case $CIRCLE_NODE_INDEX in
       0)
         # run all tests *except* helios-system-tests
@@ -86,11 +91,6 @@ case "$1" in
         # tag the helios-solo image we just built
         solo_image=$(cat helios-services/target/test-classes/solo-image.json | jq -r '.image')
         docker tag -f $solo_image spotify/helios-solo:latest
-
-        # fix DOCKER_HOST to be accessible from within containers
-        docker0_ip=$(/sbin/ifconfig docker0 | grep 'inet addr' | \
-          awk -F: '{print $2}' | awk '{print $1}')
-        export DOCKER_HOST="tcp://$docker0_ip:2375"
 
         # bring up helios-solo for integration tests
         cd solo

--- a/circle.yml
+++ b/circle.yml
@@ -20,8 +20,8 @@ machine:
     - helios/circle.sh post_machine
   services:
     - docker
+  # See circle.sh for DOCKER_HOST.
   environment:
-    DOCKER_HOST: tcp://127.0.0.1:2375
     MAVEN_OPTS: -Xmx128m
   # tells CircleCI that we want virtualenv so that we can pip install codecov without errors
   python:

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -34,10 +34,10 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
-	  <dependency>
-	    <groupId>com.typesafe</groupId>
-	    <artifactId>config</artifactId>
-	  </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
 
     <!--test deps-->
     <dependency>

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -38,6 +38,12 @@
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>docker-client</artifactId>
+      <version>3.2.1</version>
+      <classifier>shaded</classifier>
+    </dependency>
 
     <!--test deps-->
     <dependency>

--- a/helios-testing/src/main/java/com/spotify/helios/testing/DockerHost.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DockerHost.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.servicescommon;
+
+import com.google.common.net.HostAndPort;
+
+import java.net.URI;
+
+import static com.google.common.base.Optional.fromNullable;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.System.getenv;
+
+/**
+ * Represents a dockerd endpoint. A codified DOCKER_HOST.
+ */
+public class DockerHost {
+
+  public static final int DEFAULT_PORT = 2375;
+  public static final String DEFAULT_HOST = "localhost";
+  public static final String DEFAULT_UNIX_ENDPOINT = "unix:///var/run/docker.sock";
+
+  private final String host;
+  private final URI uri;
+  private final String address;
+  private final int port;
+  private final String dockerCertPath;
+
+  private DockerHost(final String endpoint, final String dockerCertPath) {
+    if (endpoint.startsWith("unix://")) {
+      this.port = 0;
+      this.address = "localhost";
+      this.host = endpoint;
+      this.uri = URI.create(endpoint);
+    } else {
+      final String stripped = endpoint.replaceAll(".*://", "");
+      final HostAndPort hostAndPort = HostAndPort.fromString(stripped);
+      final String hostText = hostAndPort.getHostText();
+      final String scheme = isNullOrEmpty(dockerCertPath) ? "http" : "https";
+
+      this.port = hostAndPort.getPortOrDefault(defaultPort());
+      this.address = isNullOrEmpty(hostText) ? DEFAULT_HOST : hostText;
+      this.host = address + ":" + port;
+      this.uri = URI.create(scheme + "://" + address + ":" + port);
+    }
+
+    this.dockerCertPath = dockerCertPath;
+  }
+
+  /**
+   * Get a docker endpoint usable for instantiating a new DockerHost with DockerHost.from(endpoint).
+   *
+   * @return The hostname.
+   */
+  public String host() {
+    return host;
+  }
+
+  /**
+   * Get the docker rest uri.
+   *
+   * @return The uri of the host.
+   */
+  public URI uri() {
+    return uri;
+  }
+
+  /**
+   * Get the docker endpoint port.
+   *
+   * @return The port.
+   */
+  public int port() {
+    return port;
+  }
+
+  /**
+   * Get the docker ip address or hostname.
+   *
+   * @return The ip address or hostname.
+   */
+  public String address() {
+    return address;
+  }
+
+  /**
+   * Get the path to certificate and key for connecting to Docker via HTTPS.
+   *
+   * @return The path to the certificate.
+   */
+  public String dockerCertPath() {
+    return dockerCertPath;
+  }
+
+  /**
+   * Create a {@link DockerHost} from DOCKER_HOST and DOCKER_PORT env vars.
+   *
+   * @return The DockerHost object.
+   */
+  public static DockerHost fromEnv() {
+    String defaultEndpoint;
+    if (System.getProperty("os.name").toLowerCase().equals("linux")) {
+      defaultEndpoint = DEFAULT_UNIX_ENDPOINT;
+    } else {
+      defaultEndpoint = DEFAULT_HOST + ":" + defaultPort();
+    }
+
+    final String host = fromNullable(getenv("DOCKER_HOST")).or(defaultEndpoint);
+    final String dockerCertPath = getenv("DOCKER_CERT_PATH");
+
+    return new DockerHost(host, dockerCertPath);
+  }
+
+  /**
+   * Create a {@link DockerHost} from an explicit address or uri.
+   *
+   * @param endpoint The docker endpoint.
+   * @param dockerCertPath The certificate path.
+   * @return The DockerHost object.
+   */
+  public static DockerHost from(final String endpoint, final String dockerCertPath) {
+    return new DockerHost(endpoint, dockerCertPath);
+  }
+
+  private static int defaultPort() {
+    final String port = getenv("DOCKER_PORT");
+    if (port == null) {
+      return DEFAULT_PORT;
+    }
+    try {
+      return Integer.valueOf(port);
+    } catch (NumberFormatException e) {
+      return DEFAULT_PORT;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return host();
+  }
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/DockerHost.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DockerHost.java
@@ -15,7 +15,8 @@
  * under the License.
  */
 
-package com.spotify.helios.servicescommon;
+// TODO(negz): Dedupe with com.spotify.helios.servicescommon, move into docker-client?
+package com.spotify.helios.testing;
 
 import com.google.common.net.HostAndPort;
 
@@ -36,6 +37,7 @@ public class DockerHost {
 
   private final String host;
   private final URI uri;
+  private final URI bindURI;
   private final String address;
   private final int port;
   private final String dockerCertPath;
@@ -43,9 +45,10 @@ public class DockerHost {
   private DockerHost(final String endpoint, final String dockerCertPath) {
     if (endpoint.startsWith("unix://")) {
       this.port = 0;
-      this.address = "localhost";
+      this.address = DEFAULT_HOST;
       this.host = endpoint;
       this.uri = URI.create(endpoint);
+      this.bindURI = URI.create(endpoint);
     } else {
       final String stripped = endpoint.replaceAll(".*://", "");
       final HostAndPort hostAndPort = HostAndPort.fromString(stripped);
@@ -56,6 +59,7 @@ public class DockerHost {
       this.address = isNullOrEmpty(hostText) ? DEFAULT_HOST : hostText;
       this.host = address + ":" + port;
       this.uri = URI.create(scheme + "://" + address + ":" + port);
+      this.bindURI = URI.create("tcp://" + address + ":" + port);
     }
 
     this.dockerCertPath = dockerCertPath;
@@ -79,6 +83,14 @@ public class DockerHost {
     return uri;
   }
 
+  /**
+   * Get the docker rest bind uri.
+   *
+   * @return The uri of the host for binding ports (or setting $DOCKER_HOST).
+   */
+  public URI bindURI() {
+    return bindURI;
+  }
   /**
    * Get the docker endpoint port.
    *

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.spotify.helios.client.HeliosClient;
+
+public interface HeliosDeployment extends AutoCloseable {
+  HeliosClient client();
+  void close();
+}
+

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
@@ -19,8 +19,19 @@ package com.spotify.helios.testing;
 
 import com.spotify.helios.client.HeliosClient;
 
+/**
+ * A HeliosDeployment represents a collection of Helios masters and agents upon which jobs may be
+ * run.
+ */
 public interface HeliosDeployment extends AutoCloseable {
+  /**
+   * @return A helios client connected to the master(s) of this helios deployment.
+   */
   HeliosClient client();
+
+  /**
+   * Undeploy (shut down) this Helios deployment.
+   */
   void close();
 }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentException.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+public class HeliosDeploymentException extends Exception {
+
+  public HeliosDeploymentException(final String message) {
+    super(message);
+  }
+
+  public HeliosDeploymentException(final Throwable cause) {
+    super(cause);
+  }
+
+  public HeliosDeploymentException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.spotify.helios.client.HeliosClient;
+
+import org.junit.rules.ExternalResource;
+
+public class HeliosDeploymentResource extends ExternalResource {
+  HeliosDeployment deployment;
+
+  HeliosDeploymentResource(final HeliosDeployment deployment) {
+    this.deployment = deployment;
+  }
+
+  @Override
+  protected void after() {
+    deployment.close();
+  }
+
+  public HeliosClient client() {
+    return deployment.client();
+  }
+
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -21,9 +21,16 @@ import com.spotify.helios.client.HeliosClient;
 
 import org.junit.rules.ExternalResource;
 
+/**
+ * A HeliosDeploymentResource makes the supplied {@link HeliosDeployment} available to a JUnit
+ * test, and guarantees to tear it down afterward.
+ */
 public class HeliosDeploymentResource extends ExternalResource {
   HeliosDeployment deployment;
 
+  /**
+   * @param deployment The Helios deployment to expose to your JUnit tests.
+   */
   HeliosDeploymentResource(final HeliosDeployment deployment) {
     this.deployment = deployment;
   }
@@ -33,6 +40,11 @@ public class HeliosDeploymentResource extends ExternalResource {
     deployment.close();
   }
 
+  /**
+   *
+   * @return A Helios client connected to the Helios deployment supplied when instantiating the
+   * HeliosDeploymentResource.
+   */
   public HeliosClient client() {
     return deployment.client();
   }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -26,7 +26,7 @@ import org.junit.rules.ExternalResource;
  * test, and guarantees to tear it down afterward.
  */
 public class HeliosDeploymentResource extends ExternalResource {
-  HeliosDeployment deployment;
+  private final HeliosDeployment deployment;
 
   /**
    * @param deployment The Helios deployment to expose to your JUnit tests.

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -18,6 +18,7 @@
 package com.spotify.helios.testing;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
@@ -90,7 +91,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     try {
       assertDockerReachableFromContainer();
       if (dockerHost.address().equals("localhost") || dockerHost.address().equals("127.0.0.1")) {
-          heliosHost = containerGateway();
+        heliosHost = containerGateway();
       } else {
         heliosHost = dockerHost.address();
       }
@@ -125,7 +126,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
       return this.dockerClient.info();
     } catch (DockerException | InterruptedException e) {
       // There's not a lot we can do if Docker is unreachable.
-      throw new AssertionError(e);
+      throw Throwables.propagate(e);
     }
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerCertificateException;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.DockerException;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.ContainerExit;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.Info;
+import com.spotify.docker.client.messages.NetworkSettings;
+import com.spotify.docker.client.messages.PortBinding;
+import com.spotify.helios.client.HeliosClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Collections.singletonList;
+
+public class HeliosSoloDeployment implements HeliosDeployment {
+
+  private static final Logger log = LoggerFactory.getLogger(HeliosSoloDeployment.class);
+
+  public static final String BOOT2DOCKER_SIGNATURE = "Boot2Docker";
+  public static final String PROBE_IMAGE = "onescience/alpine:latest";
+  public static final String HELIOS_IMAGE = "spotify/helios-solo:latest";
+  public static final String HELIOS_NAME_PREFIX = "solo.local.";
+  public static final String HELIOS_CONTAINER_PREFIX = "helios-solo-container-";
+  public static final int HELIOS_MASTER_PORT = 5801;
+
+  final DockerClient dockerClient;
+  final DockerHost dockerHost;
+  final DockerHost containerDockerHost;
+  final String namespace;
+  final List<String> env;
+  final List<String> binds;
+  final String heliosContainerId;
+  final HeliosClient heliosClient;
+
+  HeliosSoloDeployment(final Builder builder) {
+    final String username = Optional.fromNullable(builder.heliosUsername).or(randomString());
+
+    this.dockerClient = checkNotNull(builder.dockerClient, "dockerClient");
+    this.dockerHost = Optional.fromNullable(builder.dockerHost).or(DockerHost.fromEnv());
+    this.containerDockerHost = Optional.fromNullable(builder.containerDockerHost)
+            .or(containerDockerHostFromEnv());
+    this.namespace = Optional.fromNullable(builder.namespace).or(randomString());
+    this.env = containerEnv();
+    this.binds = containerBinds();
+
+    final String heliosHost;
+    final String heliosPort;
+    //TODO(negz): Determine and propagate NetworkManager DNS servers?
+    try {
+      assertDockerReachableFromContainer();
+      if (dockerHost.address().equals("localhost") || dockerHost.address().equals("127.0.0.1")) {
+          heliosHost = containerGateway();
+      } else {
+        heliosHost = dockerHost.address();
+      }
+      this.heliosContainerId = deploySolo(heliosHost);
+      heliosPort = getHeliosMasterPort(this.heliosContainerId, HELIOS_MASTER_PORT);
+    } catch (HeliosDeploymentException e) {
+      throw new AssertionError("Unable to deploy helios-solo container.", e);
+    }
+
+    // Running the String host:port through HostAndPort does some validation for us.
+    this.heliosClient = HeliosClient.newBuilder()
+            .setUser(username)
+            .setEndpoints("http://" +
+                    HostAndPort.fromString(dockerHost.address() + ":" + heliosPort))
+            .build();
+  }
+
+  private DockerHost containerDockerHostFromEnv() {
+    if (isBoot2Docker(dockerInfo())) {
+      return DockerHost.from(DefaultDockerClient.DEFAULT_UNIX_ENDPOINT, null);
+    } else {
+      return DockerHost.fromEnv();
+    }
+  }
+
+  private Boolean isBoot2Docker(final Info dockerInfo) {
+    return dockerInfo.operatingSystem().contains(BOOT2DOCKER_SIGNATURE);
+  }
+
+  private Info dockerInfo() {
+    try {
+      return this.dockerClient.info();
+    } catch (DockerException | InterruptedException e) {
+      // There's not a lot we can do if Docker is unreachable.
+      throw new AssertionError(e);
+    }
+  }
+
+  private List<String> containerEnv() {
+    final HashSet<String> env = new HashSet<String>();
+    env.add("DOCKER_HOST=" + containerDockerHost.bindURI().toString());
+    if (!isNullOrEmpty(containerDockerHost.dockerCertPath())) {
+      env.add("DOCKER_CERT_PATH=/certs");
+    }
+    return ImmutableList.copyOf(env);
+  }
+
+  private List<String> containerBinds() {
+    final HashSet<String> binds = new HashSet<String>();
+    if (containerDockerHost.bindURI().getScheme().equals("unix")) {
+      binds.add(containerDockerHost.bindURI().getSchemeSpecificPart() + ":" +
+              containerDockerHost.bindURI().getSchemeSpecificPart());
+    }
+    if (!isNullOrEmpty(containerDockerHost.dockerCertPath())) {
+      binds.add(containerDockerHost.dockerCertPath() + ":/certs");
+    }
+    return ImmutableList.copyOf(binds);
+  }
+
+  private void assertDockerReachableFromContainer() throws HeliosDeploymentException {
+    final String probeName = randomString();
+    final HostConfig hostConfig = HostConfig.builder()
+            .binds(binds)
+            .build();
+    final ContainerConfig containerConfig = ContainerConfig.builder()
+            .env(env)
+            .hostConfig(hostConfig)
+            .image(PROBE_IMAGE)
+            .cmd(probeCommand(probeName))
+            .build();
+
+    final ContainerCreation creation;
+    try {
+      dockerClient.pull(PROBE_IMAGE);
+      creation = dockerClient.createContainer(containerConfig, probeName);
+    } catch (DockerException | InterruptedException e) {
+      throw new HeliosDeploymentException("helios-solo probe container creation failed", e);
+    }
+
+    final ContainerExit exit;
+    try {
+      dockerClient.startContainer(creation.id());
+      exit = dockerClient.waitContainer(creation.id());
+    } catch (DockerException | InterruptedException e) {
+      killContainer(creation.id());
+      removeContainer(creation.id());
+      throw new HeliosDeploymentException("helios-solo probe container failed", e);
+    }
+
+    if (exit.statusCode() != 0) {
+      removeContainer(creation.id());
+      throw new HeliosDeploymentException(String.format(
+              "Docker was not reachable (curl exit status %d) using DOCKER_HOST=%s and "
+                      + "DOCKER_CERT_PATH=%s from within a container. Please ensure that "
+                      + "DOCKER_HOST contains a full hostname or IP address, not localhost, "
+                      + "127.0.0.1, etc.",
+              exit.statusCode(),
+              containerDockerHost.bindURI(),
+              containerDockerHost.dockerCertPath()));
+    }
+
+    removeContainer(creation.id());
+  }
+
+  private List<String> probeCommand(final String probeName) {
+    final List<String> cmd = new ArrayList<String>(ImmutableList.of("curl", "-f"));
+    switch (containerDockerHost.uri().getScheme()) {
+      case "unix":
+        cmd.addAll(ImmutableList.of(
+                "--unix-socket", containerDockerHost.uri().getSchemeSpecificPart(),
+                "http:/containers/" + probeName + "/json"));
+        break;
+      case "https":
+        cmd.addAll(ImmutableList.of(
+                "--insecure",
+                "--cert", "/certs/cert.pem",
+                "--key", "/certs/key.pem",
+                containerDockerHost.uri() + "/containers/" + probeName + "/json"));
+        break;
+      default:
+        cmd.add(containerDockerHost.uri() + "/containers/" + probeName + "/json");
+        break;
+    }
+    return ImmutableList.copyOf(cmd);
+  }
+
+  // TODO(negz): Merge with dockerReachableFromContainer() ?
+  private String containerGateway() throws HeliosDeploymentException {
+    final ContainerConfig containerConfig = ContainerConfig.builder()
+            .env(env)
+            .hostConfig(HostConfig.builder().build())
+            .image(PROBE_IMAGE)
+            .cmd(ImmutableList.of("sh", "-c", "while true;do sleep 10;done"))
+            .build();
+
+    final ContainerCreation creation;
+    try {
+      dockerClient.pull(PROBE_IMAGE);
+      creation = dockerClient.createContainer(containerConfig);
+    } catch (DockerException | InterruptedException e) {
+      throw new HeliosDeploymentException("helios-solo gateway probe container creation failed", e);
+    }
+
+    try {
+      dockerClient.startContainer(creation.id());
+      final String gateway = dockerClient.inspectContainer(creation.id())
+              .networkSettings().gateway();
+      killContainer(creation.id());
+      removeContainer(creation.id());
+      return gateway;
+    } catch (DockerException | InterruptedException e) {
+      killContainer(creation.id());
+      removeContainer(creation.id());
+      throw new HeliosDeploymentException("helios-solo gateway probe failed", e);
+    }
+  }
+
+  private String deploySolo(final String heliosHost) throws HeliosDeploymentException {
+    //TODO(negz): Don't make this.env immutable so early?
+    final List<String> env = new ArrayList<String>();
+    env.addAll(this.env);
+    env.add("HELIOS_NAME=" + HELIOS_NAME_PREFIX + this.namespace);
+    env.add("HOST_ADDRESS=" + heliosHost);
+
+    final String heliosPort = String.format("%d/tcp", HELIOS_MASTER_PORT);
+    final Map<String, List<PortBinding>> portBindings = ImmutableMap.of(
+            heliosPort, singletonList(PortBinding.of("0.0.0.0", "")));
+    final HostConfig hostConfig = HostConfig.builder()
+            .portBindings(portBindings)
+            .binds(binds)
+            .build();
+    final ContainerConfig containerConfig = ContainerConfig.builder()
+            .env(ImmutableList.copyOf(env))
+            .hostConfig(hostConfig)
+            .image(HELIOS_IMAGE)
+            .build();
+
+    final ContainerCreation creation;
+    try {
+      dockerClient.pull(HELIOS_IMAGE);
+      final String containerName = HELIOS_CONTAINER_PREFIX + this.namespace;
+      creation = dockerClient.createContainer(containerConfig, containerName);
+    } catch (DockerException | InterruptedException e) {
+      throw new HeliosDeploymentException("helios-solo container creation failed", e);
+    }
+
+    try {
+      dockerClient.startContainer(creation.id());
+    } catch (DockerException | InterruptedException e) {
+      killContainer(creation.id());
+      removeContainer(creation.id());
+      throw new HeliosDeploymentException("helios-solo container start failed", e);
+    }
+
+    return creation.id();
+  }
+
+
+  private void killContainer(String id) {
+    try {
+      dockerClient.killContainer(id);
+    } catch (DockerException | InterruptedException e) {
+      log.warn("unable to kill container {}", id, e);
+    }
+  }
+  private void removeContainer(String id) {
+    try {
+      dockerClient.removeContainer(id);
+    } catch (DockerException | InterruptedException e) {
+      log.warn("unable to remove container {}", id, e);
+    }
+  }
+
+  private String getHeliosMasterPort(final String containerId, final int port)
+          throws HeliosDeploymentException {
+    final String heliosPort = String.format("%d/tcp", port);
+    try {
+      final NetworkSettings settings = dockerClient.inspectContainer(containerId).networkSettings();
+      for (Map.Entry<String, List<PortBinding>> entry : settings.ports().entrySet()) {
+        if (entry.getKey().equals(heliosPort)) {
+          for (PortBinding portBinding : entry.getValue()) {
+            return portBinding.hostPort();
+          }
+        }
+      }
+    } catch (DockerException | InterruptedException e) {
+      throw new HeliosDeploymentException(String.format(
+              "unable to find port binding for %s in container %s.",
+              heliosPort,
+              containerId),
+              e);
+    }
+    throw new HeliosDeploymentException(String.format(
+            "unable to find port binding for %s in container %s.",
+            heliosPort,
+            containerId));
+  }
+
+  private String randomString() {
+    return Integer.toHexString(new Random().nextInt());
+  }
+
+  public HeliosClient client() {
+    return this.heliosClient;
+  }
+
+  public void close() {
+    killContainer(heliosContainerId);
+    removeContainer(heliosContainerId);
+    this.dockerClient.close();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static Builder fromEnv() {
+    try {
+      DefaultDockerClient.fromEnv().uri();
+      return builder().dockerClient(DefaultDockerClient.fromEnv().build());
+    } catch (DockerCertificateException e) {
+      // TODO(negz): Just propagate this rather than return null and fail later on checkNotNull?
+      log.error("unable to create Docker client from environment", e);
+      return builder();
+    }
+  }
+
+  public static class Builder {
+    private DockerClient dockerClient;
+    private DockerHost dockerHost;
+    private DockerHost containerDockerHost;
+    private String namespace;
+    private String heliosUsername;
+
+    public Builder dockerClient(final DockerClient dockerClient) {
+      this.dockerClient = dockerClient;
+      return this;
+    }
+
+    public Builder dockerHost(final DockerHost dockerHost) {
+      this.dockerHost = dockerHost;
+      return this;
+    }
+
+    public Builder containerDockerHost(final DockerHost dockerHost) {
+      this.containerDockerHost = containerDockerHost;
+      return this;
+    }
+
+    public Builder namespace(final String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    public Builder heliosUsername(final String username) {
+      this.heliosUsername = username;
+      return this;
+    }
+
+    public HeliosDeployment build() {
+      return new HeliosSoloDeployment(this);
+    }
+  }
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -513,6 +513,20 @@ public class TemporaryJobs implements TestRule {
 
   public static class Builder {
 
+    private final Map<String, String> env;
+    private final Config config;
+    private String user = DEFAULT_USER;
+    private Prober prober = DEFAULT_PROBER;
+    private Deployer deployer;
+    private String hostFilter;
+    private HeliosClient client;
+    private String prefixDirectory;
+    private String testReportDirectory;
+    private String jobPrefix;
+    private String jobDeployedMessageFormat;
+    private HostPickingStrategy hostPickingStrategy = HostPickingStrategies.randomOneHost();
+    private long deployTimeoutMillis = DEFAULT_DEPLOY_TIMEOUT_MILLIS;
+
     Builder(String profile, Config rootConfig, Map<String, String> env) {
       this.env = env;
 
@@ -647,20 +661,6 @@ public class TemporaryJobs implements TestRule {
             + "value for hostPickingStrategyKey which is used to seed the random number generator");
       }
     }
-
-    private final Map<String, String> env;
-    private final Config config;
-    private String user = DEFAULT_USER;
-    private Prober prober = DEFAULT_PROBER;
-    private Deployer deployer;
-    private String hostFilter;
-    private HeliosClient client;
-    private String prefixDirectory;
-    private String testReportDirectory;
-    private String jobPrefix;
-    private String jobDeployedMessageFormat;
-    private HostPickingStrategy hostPickingStrategy = HostPickingStrategies.randomOneHost();
-    private long deployTimeoutMillis = DEFAULT_DEPLOY_TIMEOUT_MILLIS;
 
     public Builder domain(final String domain) {
       return client(HeliosClient.newBuilder()

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.experimental.results.ResultMatchers.isSuccessful;
+
+public class HeliosSoloDeploymentTest {
+
+  @Test
+  public void heliosSoloDeploymentTest() {
+    assertThat(testResult(HeliosSoloDeploymentTestImpl.class), isSuccessful());
+  }
+
+
+  public static class HeliosSoloDeploymentTestImpl {
+
+    public static final String BUSYBOX = "busybox:latest";
+    public static final List<String> IDLE_COMMAND = asList(
+            "sh", "-c", "trap 'exit 0' SIGINT SIGTERM; while :; do sleep 1; done");
+
+    private TemporaryJob soloJob;
+
+    // TODO(negz): We want one deployment per test run, not one per test class.
+    @ClassRule
+    public static final HeliosDeploymentResource DEPLOYMENT = new HeliosDeploymentResource(
+            HeliosSoloDeployment.fromEnv().build());
+
+    @Rule
+    public final TemporaryJobs temporaryJobs = TemporaryJobs.create(DEPLOYMENT.client());
+
+    @Test
+    public void testDeployToSolo() throws Exception {
+      final TemporaryJob job = temporaryJobs.job()
+              .command(IDLE_COMMAND)
+              .deploy();
+
+      final Map<JobId, Job> jobs = DEPLOYMENT.client().jobs().get(15, SECONDS);
+      assertEquals("wrong number of jobs running", 1, jobs.size());
+      for (Job j : jobs.values()) {
+        assertEquals("wrong job running", BUSYBOX, j.getImage());
+      }
+
+      job.undeploy();
+    }
+  }
+}

--- a/helios-testing/src/test/resources/logback-test.xml
+++ b/helios-testing/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.spotify.helios.testing" level="info"/>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
Todo in future PRs:
* Actually plumb the `HeliosDeployment` up up to `TemporaryJobs`. Currently a new instance of `TemporaryJobs` is created per test. We need a way to deploy one `HeliosDeployment` for an entire test run (i.e. multiple classes).
* Propagate DNS for machines using NetworkManager (Java DBUS interface?). 