### PR TITLE
Allow JUnit parallelism for Jenkins builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,6 @@
               <reuseForks>false</reuseForks>
               <argLine>${surefireArgLine}</argLine>
               <systemPropertyVariables>
-                <junit.parallel.threads>1</junit.parallel.threads>
                 <logToFile>false</logToFile>
                 <heliosLoggingLevel>WARN</heliosLoggingLevel>
                 <externalLoggingLevel>OFF</externalLoggingLevel>


### PR DESCRIPTION
We removed <junit.parallel.threads>1</> for all other build profiles, not
sure why we left it in for Jenkins.