### PR TITLE
Fix race conditions that might lead to inconsistent DG state

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -397,11 +397,16 @@ public class ZooKeeperMasterModel implements MasterModel {
       Optional<Integer> version = Optional.absent();
       List<String> curHosts;
       try {
+        // addDeploymentGroup creates Paths.statusDeploymentGroupHosts(name) so it should always
+        // exist. If it doesn't, then the DG was (likely) deleted.
         final Node node = client.getNode(Paths.statusDeploymentGroupHosts(name));
         version = Optional.of(node.getStat().getVersion());
         curHosts = Json.read(node.getBytes(), new TypeReference<List<String>>() {});
-      } catch (NoNodeException | JsonMappingException e) {
+      } catch (JsonMappingException e) {
         curHosts = Collections.emptyList();
+      } catch (NoNodeException e) {
+        // DG was deleted -- abort.
+        return;
       }
 
       if (!version.isPresent() || !hosts.equals(curHosts)) {
@@ -409,8 +414,6 @@ public class ZooKeeperMasterModel implements MasterModel {
         final List<ZooKeeperOperation> ops = Lists.newArrayList();
         ops.add(set(Paths.statusDeploymentGroupHosts(name), Json.asBytes(hosts)));
 
-        client.ensurePath(Paths.statusDeploymentGroup(name));
-        client.ensurePath(Paths.statusDeploymentGroupTasks(name));
         final DeploymentGroup deploymentGroup = getDeploymentGroup(name);
         ImmutableList<Map<String, Object>> events = ImmutableList.of();
 
@@ -418,7 +421,7 @@ public class ZooKeeperMasterModel implements MasterModel {
           final DeploymentGroupStatus deploymentGroupStatus = getDeploymentGroupStatus(name);
           if (deploymentGroupStatus == null || deploymentGroupStatus.getState() != FAILED) {
             final RollingUpdateOp op =
-                getInitRollingUpdateOps(deploymentGroup, hosts, HOSTS_CHANGED);
+                getInitRollingUpdateOps(deploymentGroup, hosts, HOSTS_CHANGED, client);
             ops.addAll(op.operations());
             events = op.events();
           }
@@ -462,12 +465,11 @@ public class ZooKeeperMasterModel implements MasterModel {
     final ZooKeeperClient client = provider.get("rollingUpdate");
 
     operations.add(set(Paths.configDeploymentGroup(updated.getName()), updated));
-    final RollingUpdateOp op = getInitRollingUpdateOps(updated, MANUAL);
-    operations.addAll(op.operations());
 
     try {
-      client.ensurePath(Paths.statusDeploymentGroup(updated.getName()));
-      client.ensurePath(Paths.statusDeploymentGroupTasks(updated.getName()));
+      final RollingUpdateOp op = getInitRollingUpdateOps(updated, MANUAL, client);
+      operations.addAll(op.operations());
+
       client.transaction(operations);
 
       if (kafkaSender != null) {
@@ -486,15 +488,18 @@ public class ZooKeeperMasterModel implements MasterModel {
   }
 
   private RollingUpdateOp getInitRollingUpdateOps(final DeploymentGroup deploymentGroup,
-                                                  final RollingUpdateReason reason)
-      throws DeploymentGroupDoesNotExistException {
+                                                  final RollingUpdateReason reason,
+                                                  final ZooKeeperClient zooKeeperClient)
+      throws DeploymentGroupDoesNotExistException, KeeperException {
     final List<String> hosts = getDeploymentGroupHosts(deploymentGroup.getName());
-    return getInitRollingUpdateOps(deploymentGroup, hosts, reason);
+    return getInitRollingUpdateOps(deploymentGroup, hosts, reason, zooKeeperClient);
   }
 
   private RollingUpdateOp getInitRollingUpdateOps(final DeploymentGroup deploymentGroup,
                                                   final List<String> hosts,
-                                                  final RollingUpdateReason reason) {
+                                                  final RollingUpdateReason reason,
+                                                  final ZooKeeperClient zooKeeperClient)
+      throws KeeperException {
     final Map<String, HostStatus> hostsAndStatuses = Maps.newLinkedHashMap();
     for (final String host : hosts) {
       hostsAndStatuses.put(host, getHostStatus(host));
@@ -510,7 +515,7 @@ public class ZooKeeperMasterModel implements MasterModel {
 
     final RollingUpdateOpFactory opFactory = new RollingUpdateOpFactory(
         tasks, DEPLOYMENT_GROUP_EVENT_FACTORY);
-    return opFactory.start(deploymentGroup, reason);
+    return opFactory.start(deploymentGroup, reason, zooKeeperClient);
   }
 
   private Map<String, VersionedValue<DeploymentGroupTasks>> getDeploymentGroupTasks(

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateEmpty.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateEmpty.java
@@ -19,11 +19,11 @@ package com.spotify.helios.servicescommon.coordination;
 
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 
-class CreateEmpty implements ZooKeeperOperation {
+public class CreateEmpty implements ZooKeeperOperation {
 
   private final String path;
 
-  CreateEmpty(final String path) {
+  public CreateEmpty(final String path) {
     this.path = path;
   }
 
@@ -37,5 +37,28 @@ class CreateEmpty implements ZooKeeperOperation {
     return "CreateEmpty{" +
            "path='" + path + '\'' +
            '}';
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CreateEmpty that = (CreateEmpty) o;
+
+    if (path != null ? !path.equals(that.path) : that.path != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return path != null ? path.hashCode() : 0;
   }
 }


### PR DESCRIPTION
There were two related race conditions that could cause a DG get
inconsistent state, both triggered by removing the DG. The issue
manifests itself with a DG that has no config node but does have
the status and/or tasks paths.

This could happen if a remove happened at the same time as a
rolling-update was issued or if the host-update thread updated
the hosts for that DG as the DG was removed. The latter is much
more likely to happen.