### PR TITLE
simplify usage of KafkaSender

### DIFF
--- a/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
@@ -33,6 +33,7 @@ import com.spotify.helios.master.JobDoesNotExistException;
 import com.spotify.helios.master.JobNotDeployedException;
 import com.spotify.helios.master.JobStillDeployedException;
 import com.spotify.helios.master.ZooKeeperMasterModel;
+import com.spotify.helios.servicescommon.KafkaSender;
 import com.spotify.helios.servicescommon.coordination.DefaultZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.Paths;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
@@ -62,6 +63,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ZooKeeperMasterModelIntegrationTest {
@@ -103,8 +105,12 @@ public class ZooKeeperMasterModelIntegrationTest {
     client.ensurePath(Paths.statusMasters());
     client.ensurePath(Paths.historyJobs());
 
-    model = new ZooKeeperMasterModel(
-        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop()));
+    final ZooKeeperClientProvider zkProvider =
+        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop());
+
+    final KafkaSender kafkaSender = mock(KafkaSender.class);
+
+    model = new ZooKeeperMasterModel(zkProvider, getClass().getName(), kafkaSender);
   }
 
   @Test

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskHistoryWriterTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskHistoryWriterTest.java
@@ -29,6 +29,7 @@ import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.common.descriptors.TaskStatus.State;
 import com.spotify.helios.common.descriptors.TaskStatusEvent;
 import com.spotify.helios.master.ZooKeeperMasterModel;
+import com.spotify.helios.servicescommon.KafkaSender;
 import com.spotify.helios.servicescommon.coordination.DefaultZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.Paths;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
@@ -90,8 +91,14 @@ public class TaskHistoryWriterTest {
 
     client = new DefaultZooKeeperClient(zk.curator());
     makeWriter(client);
-    masterModel = new ZooKeeperMasterModel(new ZooKeeperClientProvider(client,
-        ZooKeeperModelReporter.noop()));
+
+    final ZooKeeperClientProvider zkProvider =
+        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop());
+
+    final KafkaSender kafkaSender = mock(KafkaSender.class);
+
+    masterModel = new ZooKeeperMasterModel(zkProvider, "test", kafkaSender);
+
     client.ensurePath(Paths.configJobs());
     client.ensurePath(Paths.configJobRefs());
     client.ensurePath(Paths.historyJobHostEvents(JOB_ID, HOSTNAME));

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/UndeployFilteringTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/UndeployFilteringTest.java
@@ -28,6 +28,7 @@ import com.spotify.helios.common.descriptors.TaskStatus.State;
 import com.spotify.helios.common.protocol.CreateJobResponse;
 import com.spotify.helios.common.protocol.JobDeployResponse;
 import com.spotify.helios.master.ZooKeeperMasterModel;
+import com.spotify.helios.servicescommon.KafkaSender;
 import com.spotify.helios.servicescommon.coordination.DefaultZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.Paths;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
@@ -47,6 +48,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class UndeployFilteringTest extends SystemTestBase {
 
@@ -70,10 +72,15 @@ public class UndeployFilteringTest extends SystemTestBase {
   public void setUp() throws Exception {
     // make zookeeper interfaces
     curator = zk().curator();
+
     zkcp = new ZooKeeperClientProvider(
         new DefaultZooKeeperClient(curator), ZooKeeperModelReporter.noop());
-    zkMasterModel = new ZooKeeperMasterModel(zkcp);
+
+    final KafkaSender kafkaSender = mock(KafkaSender.class);
+
+    zkMasterModel = new ZooKeeperMasterModel(zkcp, getClass().getName(), kafkaSender);
     startDefaultMaster();
+
     agent = startDefaultAgent(TEST_HOST);
     client = defaultClient();
     awaitHostRegistered(client, TEST_HOST, LONG_WAIT_SECONDS, SECONDS);


### PR DESCRIPTION
- KafkaSender is never null in non-test code, so save some indents by
  not checking for null
- same loop for sending a list of events appears a few times