### PR TITLE
Instrument unit tests in CircleCI builds and upload to codecov

### DIFF
--- a/circle.sh
+++ b/circle.sh
@@ -44,7 +44,7 @@ case "$1" in
       0)
         # run all tests *except* helios-system-tests
         sed -i'' 's/<module>helios-system-tests<\/module>//' pom.xml
-        mvn test -B
+        mvn test -B -Pjacoco
 
         ;;
 
@@ -118,7 +118,7 @@ case "$1" in
     cp */target/surefire-reports/*.xml $CI_REPORTS || true
     cp */target/failsafe-reports/*.xml $CI_REPORTS || true
     codecov
-    
+
     ;;
 
 esac

--- a/circle.sh
+++ b/circle.sh
@@ -29,6 +29,7 @@ case "$1" in
 
   dependencies)
     mvn clean install -T 2 -Dmaven.javadoc.skip=true -DskipTests=true -B -V
+    pip install codecov
 
     ;;
 
@@ -116,7 +117,8 @@ case "$1" in
   collect_test_reports)
     cp */target/surefire-reports/*.xml $CI_REPORTS || true
     cp */target/failsafe-reports/*.xml $CI_REPORTS || true
-
+    codecov
+    
     ;;
 
 esac

--- a/circle.yml
+++ b/circle.yml
@@ -23,6 +23,9 @@ machine:
   environment:
     DOCKER_HOST: tcp://127.0.0.1:2375
     MAVEN_OPTS: -Xmx128m
+  # tells CircleCI that we want virtualenv so that we can pip install codecov without errors
+  python:
+    version: 2.7.10
 
 general:
   artifacts:

--- a/pom.xml
+++ b/pom.xml
@@ -284,6 +284,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <autoReleaseAfterClose>true</autoReleaseAfterClose>
     <jacoco.version>0.7.1.201405082137</jacoco.version>
+    <surefire.version>2.16</surefire.version>
     <surefireArgLine>-Xmx128m -XX:+TieredCompilation -XX:TieredStopAtLevel=1</surefireArgLine>
   </properties>
 
@@ -310,7 +311,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.16</version>
+            <version>${surefire.version}</version>
             <configuration>
               <enableAssertions>false</enableAssertions>
               <forkCount>1C</forkCount>
@@ -342,7 +343,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.16</version>
+            <version>${surefire.version}</version>
             <configuration>
               <enableAssertions>false</enableAssertions>
               <forkCount>4</forkCount>
@@ -377,7 +378,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.16</version>
+            <version>${surefire.version}</version>
             <configuration>
               <enableAssertions>false</enableAssertions>
               <forkCount>1C</forkCount>
@@ -408,7 +409,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.16</version>
+            <version>${surefire.version}</version>
             <configuration>
               <enableAssertions>false</enableAssertions>
               <systemPropertyVariables>
@@ -428,7 +429,9 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
             <configuration>
               <skip>true</skip>
             </configuration>
@@ -542,7 +545,9 @@
             </executions>
           </plugin>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
             <configuration>
               <argLine>${jacocoArgLine} ${surefireArgLine}</argLine>
             </configuration>


### PR DESCRIPTION
Upload coverage results to codecov, which has a pretty UI.

I think that visualizing the coverage info (outside of our internal Jenkins instance) could be helpful in pointing out areas where unit tests are lacking. It doesn't tell us how useful the tests themselves are but at least helps find areas with big holes.

[Here is an example report](https://codecov.io/github/mattnworb/helios?ref=d9043efebfacee0d3cc29d3b34c8dcd620e85c1f).

Uploading coverage for the helios-system-tests might be trickier since each batch executes in a separate container, and I'm not positive if when jacoco sets up it's agent in the `helios-system-tests` modules that it recognizes that it should instrument code in `helios-client` etc too.