### PR TITLE
allow SSL hostname verification to be disabled

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -30,6 +30,7 @@ import com.google.common.net.UrlEscapers;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.FutureFallback;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -38,6 +39,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.Resolver;
+import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.common.Version;
 import com.spotify.helios.common.VersionCompatibility;
 import com.spotify.helios.common.descriptors.Deployment;
@@ -73,7 +75,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -81,7 +85,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.Futures.withFallback;
-import static com.google.common.util.concurrent.MoreExecutors.getExitingScheduledExecutorService;
 import static com.spotify.helios.common.VersionCompatibility.HELIOS_SERVER_VERSION_HEADER;
 import static com.spotify.helios.common.VersionCompatibility.HELIOS_VERSION_STATUS_HEADER;
 import static java.lang.String.format;
@@ -534,10 +537,24 @@ public class HeliosClient implements AutoCloseable {
     }
 
     public HeliosClient build() {
-      return new HeliosClient(user, new RetryingRequestDispatcher(
-          endpointSupplier.get(), user,
-          MoreExecutors.listeningDecorator(getExitingScheduledExecutorService(
-              (ScheduledThreadPoolExecutor) newScheduledThreadPool(4), 0, SECONDS))));
+      return new HeliosClient(user, createDispatcher());
+    }
+
+    private RequestDispatcher createDispatcher() {
+      final ScheduledExecutorService executor = MoreExecutors.getExitingScheduledExecutorService(
+          (ScheduledThreadPoolExecutor) newScheduledThreadPool(4), 0, SECONDS);
+
+      final ListeningScheduledExecutorService listeningExecutor =
+          MoreExecutors.listeningDecorator(executor);
+
+      final RequestDispatcher dispatcher =
+          new DefaultRequestDispatcher(endpointSupplier.get(), user, listeningExecutor);
+
+      return new RetryingRequestDispatcher(dispatcher,
+          listeningExecutor,
+          new SystemClock(),
+          5,
+          TimeUnit.SECONDS);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -501,6 +501,7 @@ public class HeliosClient implements AutoCloseable {
 
     private String user;
     private Supplier<List<Endpoint>> endpointSupplier;
+    private boolean sslHostnameVerification = true;
 
     public Builder setUser(final String user) {
       this.user = user;
@@ -536,6 +537,15 @@ public class HeliosClient implements AutoCloseable {
       return this;
     }
 
+    /**
+     * Can be used to disable hostname verification for HTTPS connections to the Helios master.
+     * Defaults to being enabled.
+     */
+    public Builder setSslHostnameVerification(boolean enabled) {
+      this.sslHostnameVerification = enabled;
+      return this;
+    }
+
     public HeliosClient build() {
       return new HeliosClient(user, createDispatcher());
     }
@@ -547,8 +557,10 @@ public class HeliosClient implements AutoCloseable {
       final ListeningScheduledExecutorService listeningExecutor =
           MoreExecutors.listeningDecorator(executor);
 
-      final RequestDispatcher dispatcher =
-          new DefaultRequestDispatcher(endpointSupplier.get(), user, listeningExecutor);
+      final RequestDispatcher dispatcher = new DefaultRequestDispatcher(endpointSupplier.get(),
+          user,
+          listeningExecutor,
+          sslHostnameVerification);
 
       return new RetryingRequestDispatcher(dispatcher,
           listeningExecutor,

--- a/helios-client/src/main/java/com/spotify/helios/client/HostnameVerifierProvider.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HostnameVerifierProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+class HostnameVerifierProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(HostnameVerifierProvider.class);
+
+  private final boolean hostnameVerificationEnabled;
+  private final HostnameVerifier delegate;
+
+  public HostnameVerifierProvider(final boolean hostnameVerificationEnabled,
+                                  final HostnameVerifier delegate) {
+    this.hostnameVerificationEnabled = hostnameVerificationEnabled;
+    this.delegate = delegate;
+  }
+
+  public HostnameVerifier verifierFor(String hostname) {
+    // java 8 will make all these lines for the anon classes go poof
+
+    if (!hostnameVerificationEnabled) {
+      log.debug("hostname verification disabled");
+      return new HostnameVerifier() {
+        @Override
+        public boolean verify(final String s, final SSLSession sslSession) {
+          return true;
+        }
+      };
+    }
+
+    final String tHostname =
+        hostname.endsWith(".") ? hostname.substring(0, hostname.length() - 1) : hostname;
+
+    log.debug("configuring DefaultHostnameVerifier to expect hostname={}", tHostname);
+
+    return new HostnameVerifier() {
+      @Override
+      public boolean verify(final String s, final SSLSession sslSession) {
+        return delegate.verify(tHostname, sslSession);
+      }
+    };
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/RetryingRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/RetryingRequestDispatcher.java
@@ -111,6 +111,7 @@ class RetryingRequestDispatcher implements RequestDispatcher {
       public void onFailure(@NotNull Throwable t) {
         log.warn("Failed to connect, retrying in {} seconds.",
                  timeUnit.convert(delay, TimeUnit.SECONDS));
+        log.debug("Specific reason for connection failure", t);
         handleFailure(future, code, deadline, delay, timeUnit, t);
       }
     });

--- a/helios-client/src/main/java/com/spotify/helios/client/RetryingRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/RetryingRequestDispatcher.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.SettableFuture;
 
 import com.spotify.helios.common.Clock;
-import com.spotify.helios.common.SystemClock;
 
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -47,21 +46,12 @@ class RetryingRequestDispatcher implements RequestDispatcher {
   private static final Logger log = LoggerFactory.getLogger(RetryingRequestDispatcher.class);
 
   private static final long RETRY_TIMEOUT_MILLIS = SECONDS.toMillis(60);
-  private static final long DEFAULT_DELAY = 5;
-  private static final TimeUnit DEFAULT_DELAY_TIMEUNIT = SECONDS;
 
   private final ListeningScheduledExecutorService executorService;
   private final RequestDispatcher delegate;
   private final Clock clock;
   private final long delay;
   private final TimeUnit delayTimeUnit;
-
-  RetryingRequestDispatcher(final List<Endpoint> endpoints,
-                            final String user,
-                            final ListeningScheduledExecutorService executorService) {
-    this(new DefaultRequestDispatcher(endpoints, user, executorService), executorService,
-         new SystemClock(), DEFAULT_DELAY, DEFAULT_DELAY_TIMEUNIT);
-  }
 
   RetryingRequestDispatcher(final RequestDispatcher delegate,
                             final ListeningScheduledExecutorService executorService,

--- a/helios-client/src/test/java/com/spotify/helios/client/HostnameVerifierProviderTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HostnameVerifierProviderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client;
+
+import org.junit.Test;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class HostnameVerifierProviderTest {
+
+  private final HostnameVerifier delegate = mock(HostnameVerifier.class);
+  private final SSLSession sslSession = mock(SSLSession.class);
+
+  @Test
+  public void testHostnameVerificationDisabled() {
+    final HostnameVerifierProvider provider = new HostnameVerifierProvider(false, delegate);
+    final HostnameVerifier verifier = provider.verifierFor("any.host");
+
+    assertTrue(verifier.verify("example.com", sslSession));
+    verifyNoMoreInteractions(delegate, sslSession);
+  }
+
+  @Test
+  public void testHostnameVerificationEnabled() {
+    final String hostname = "example.com";
+
+    final HostnameVerifierProvider provider = new HostnameVerifierProvider(true, delegate);
+    final HostnameVerifier verifier = provider.verifierFor(hostname);
+
+    // verify that the returned provider just delegates to the delgate
+    when(delegate.verify(hostname, sslSession)).thenReturn(true);
+    assertTrue(verifier.verify(hostname, sslSession));
+
+    when(delegate.verify(hostname, sslSession)).thenReturn(false);
+    assertFalse(verifier.verify("foo.example.com", sslSession));
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/client/RetryingRequestDispatcherTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/RetryingRequestDispatcherTest.java
@@ -26,7 +26,6 @@ import com.spotify.helios.common.Clock;
 
 import org.hamcrest.CoreMatchers;
 import org.joda.time.Instant;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -53,14 +52,8 @@ public class RetryingRequestDispatcherTest {
   @Rule
   public final ExpectedException exception = ExpectedException.none();
 
-  private static RequestDispatcher delegate;
-  private static Clock clock;
-
-  @Before
-  public void setup() {
-    delegate = mock(RequestDispatcher.class);
-    clock = mock(Clock.class);
-  }
+  private final RequestDispatcher delegate = mock(RequestDispatcher.class);
+  private final Clock clock = mock(Clock.class);
 
   @Test
   public void testSuccess() throws Exception {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -265,6 +265,7 @@ public class CliParser {
     private final Argument verbose;
     private final Argument noLogSetup;
     private final Argument jsonArg;
+    private final Argument insecureHttps;
 
     private final ArgumentGroup globalArgs;
     private final boolean topLevel;
@@ -309,6 +310,14 @@ public class CliParser {
       noLogSetup = addArgument("--no-log-setup")
           .action(storeTrue())
           .help(SUPPRESS);
+
+      insecureHttps = addArgument("-k", "--insecure")
+          .action(storeTrue())
+          .help("Disables hostname verification of HTTPS connections. "
+                + "Similar to 'curl -k'. "
+                + "Useful when using -z flag to connect directly to a master using HTTPS which "
+                + "presents a certificate whose subject does not match the actual hostname."
+          );
     }
 
     private Argument addArgument(final String... nameOrFlags) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
   }
 
   public static HeliosClient getClient(final Target target, final PrintStream err,
-                                       final String username) {
+                                       final String username, final Namespace options) {
 
     List<URI> endpoints = Collections.emptyList();
     try {
@@ -69,6 +69,7 @@ public class Utils {
 
     return HeliosClient.newBuilder()
         .setEndpointSupplier(Endpoints.of(target.getEndpointSupplier()))
+        .setSslHostnameVerification(!options.getBoolean("insecure"))
         .setUser(username)
         .build();
   }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
@@ -118,7 +118,7 @@ public abstract class ControlCommand implements CliCommand {
                       final BufferedReader stdin)
       throws InterruptedException, IOException {
 
-    final HeliosClient client = Utils.getClient(target, err, username);
+    final HeliosClient client = Utils.getClient(target, err, username, options);
     if (client == null) {
       return false;
     }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
@@ -53,7 +53,7 @@ public abstract class MultiTargetControlCommand implements CliCommand {
 
     final Builder<TargetAndClient> clientBuilder = ImmutableList.<TargetAndClient>builder();
     for (final Target target : targets) {
-      final HeliosClient client = Utils.getClient(target, err, username);
+      final HeliosClient client = Utils.getClient(target, err, username, options);
       if (client == null) {
         return 1;
       }


### PR DESCRIPTION
Adds a CLI switch like curl's `-k`/`--insecure` to disable hostname
verification when using HTTPS to communicate with the Helios master.

This can be useful when attempting to connect to a single master instance
using `-z` where the certificate presented by the master has a subject that
doesn't match it's hostname (for example, if the certificate's subject is
`helios.spotify.net` but the server's hostname is
`server1.foo.spotify.net`).

To make the HostnameVerifier logic testable, extracted it's use in
DefaultRequestDispatcher to it's own class.