### PR TITLE
Use BouncyCastle JAR with debug symbols

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-debug-jdk15on</artifactId>
       <version>1.53</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
For some reason the default BouncyCastle JAR does not have debug symbols in
it like every other JAR in the world does.