### PR TITLE
log all of the tasks in a rolling update

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -108,7 +108,7 @@ public interface MasterModel {
 
   List<String> getDeploymentGroupHosts(String name) throws DeploymentGroupDoesNotExistException;
 
-  void updateDeploymentGroupHosts(String name, List<String> hosts)
+  void updateDeploymentGroupHosts(String groupName, List<String> hosts)
       throws DeploymentGroupDoesNotExistException;
 
   DeploymentGroupStatus getDeploymentGroupStatus(String name)


### PR DESCRIPTION
and also include the jobId associated with the deployment group at
rolling-update time.

This is intended to help troubleshoot issues after they have occurred.

example output:

```
13:11:34.106 helios[23840]: INFO  [dw-37 - POST /deployment-group/foo/rolling-update?user=mattbrown] ZooKeeperMasterModel: starting rolling-update on deployment-group: name=foo, job=foo:1:988d149ba248065aefea7151631b103e4d8088e5
13:11:34.115 helios[23840]: INFO  [dw-37 - POST /deployment-group/foo/rolling-update?user=mattbrown] ZooKeeperMasterModel: starting zookeeper transaction for rolling-update on deployment-group name=foo job=foo:1:988d149ba248065aefea7151631b103e4d8088e5. List of operations: [SetData{path='/config/deployment-groups/foo'}, CreateEmpty{path='/status/deployment-group-tasks/foo'}, Delete{path='/status/deployment-group-tasks/foo'}, SetData{path='/status/deployment-groups/foo'}]
13:11:34.125 helios[23840]: INFO  [dw-37 - POST /deployment-group/foo/rolling-update?user=mattbrown] ZooKeeperMasterModel: finished rolling-update on deployment-group: name=foo, job=foo:1:988d149ba248065aefea7151631b103e4d8088e5
```