### PR TITLE
fix infinite loop if masters return 502 Bad Gateway

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -42,7 +42,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
-import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
@@ -130,16 +129,13 @@ public class AuthenticatingHttpConnector implements HttpConnector {
           } else if (agentProxy.isPresent() && identity != null) {
             delegate.setExtraHttpsHandler(new SshAgentHttpsHandler(
                 user, agentProxy.get(), identity));
+          } else {
+            // no authentication set up!
           }
 
           final HttpURLConnection connection = delegate.connect(ipUri, method, entity, headers);
 
           final int responseCode = connection.getResponseCode();
-          if (responseCode == HTTP_BAD_GATEWAY) {
-            log.debug("502 Bad Gateway");
-            continue;
-          }
-
           if (((responseCode == HTTP_FORBIDDEN) || (responseCode == HTTP_UNAUTHORIZED))
               && !ids.isEmpty()) {
             // there was some sort of security error. if we have any more SSH identities to try,

--- a/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
@@ -263,4 +263,32 @@ public class AuthenticatingHttpConnectorTest {
       }
     });
   }
+
+  @Test
+  public void testOneIdentity_ServerReturns502BadGateway() throws Exception {
+    final AgentProxy proxy = mock(AgentProxy.class);
+    final Identity identity = mockIdentity();
+
+    final AuthenticatingHttpConnector authConnector =
+        createAuthenticatingConnector(Optional.of(proxy), ImmutableList.of(identity));
+
+    final String path = "/foobar";
+
+    final HttpsURLConnection connection = mock(HttpsURLConnection.class);
+    when(connector.connect(argThat(matchesAnyEndpoint(path)),
+        eq(method),
+        eq(entity),
+        eq(headers))
+    ).thenReturn(connection);
+    when(connection.getResponseCode()).thenReturn(502);
+
+    URI uri = new URI("https://helios" + path);
+
+    HttpURLConnection returnedConnection = authConnector.connect(uri, method, entity, headers);
+
+    assertSame("If there is only one identity do not expect any additional endpoints to "
+               + "be called after the first returns Unauthorized",
+        returnedConnection, connection);
+
+  }
 }


### PR DESCRIPTION
AuthenticatingHttpConnector handles a 502 Bad Gateway response by just
trying another iteration of the `while (true)`.

If for some reason the endpoints always return 502 (for example, the
service behind nginx is down) then this means the
AuthenticatingHttpConnector will loop forever (as long as the endpoints
are returning 502) with no way to interrupt.

This undos a change in 27d3c25 where a 502 caused the http client to
just try again with a new endpoint (and which was carried over to the
HttpConnector stuff). This is not needed anymore since
RetryingRequestDispatcher was introduced in 1c2c451.