### PR TITLE
fix infinite loop if masters return 502 Bad Gateway

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -42,7 +42,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 
-import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
@@ -130,16 +129,13 @@ public class AuthenticatingHttpConnector implements HttpConnector {
           } else if (agentProxy.isPresent() && identity != null) {
             delegate.setExtraHttpsHandler(new SshAgentHttpsHandler(
                 user, agentProxy.get(), identity));
+          } else {
+            // no authentication set up!
           }
 
           final HttpURLConnection connection = delegate.connect(ipUri, method, entity, headers);
 
           final int responseCode = connection.getResponseCode();
-          if (responseCode == HTTP_BAD_GATEWAY) {
-            log.debug("502 Bad Gateway");
-            continue;
-          }
-
           if (((responseCode == HTTP_FORBIDDEN) || (responseCode == HTTP_UNAUTHORIZED))
               && !ids.isEmpty()) {
             // there was some sort of security error. if we have any more SSH identities to try,

--- a/helios-client/src/main/java/com/spotify/helios/client/RetryingRequestDispatcher.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/RetryingRequestDispatcher.java
@@ -38,8 +38,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * A {@link RequestDispatcher} that retries. Uses {@link DefaultRequestDispatcher}
- * as a delegate.
+ * A {@link RequestDispatcher} that retries.
  */
 class RetryingRequestDispatcher implements RequestDispatcher {
 

--- a/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
@@ -115,6 +115,26 @@ public class AuthenticatingHttpConnectorTest {
     return identity;
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void misMatchedCertificateArguments1() {
+    new AuthenticatingHttpConnector("user",
+        Optional.<AgentProxy>absent(),
+        Optional.of(Paths.get("/foo")),
+        Optional.<Path>absent(),
+        EndpointIterator.of(endpoints),
+        connector);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void misMatchedCertificateArguments2() {
+    new AuthenticatingHttpConnector("user",
+        Optional.<AgentProxy>absent(),
+        Optional.<Path>absent(),
+        Optional.of(Paths.get("/foo")),
+        EndpointIterator.of(endpoints),
+        connector);
+  }
+
   @Test
   public void testNoIdentities_ResponseIsOK() throws Exception {
     final AuthenticatingHttpConnector authConnector = createAuthenticatingConnector(
@@ -125,9 +145,9 @@ public class AuthenticatingHttpConnectorTest {
 
     final HttpsURLConnection connection = mock(HttpsURLConnection.class);
     when(connector.connect(argThat(matchesAnyEndpoint(path)),
-                           eq(method),
-                           eq(entity),
-                           eq(headers))
+        eq(method),
+        eq(entity),
+        eq(headers))
     ).thenReturn(connection);
     when(connection.getResponseCode()).thenReturn(200);
 
@@ -146,9 +166,9 @@ public class AuthenticatingHttpConnectorTest {
 
     final HttpsURLConnection connection = mock(HttpsURLConnection.class);
     when(connector.connect(argThat(matchesAnyEndpoint(path)),
-                           eq(method),
-                           eq(entity),
-                           eq(headers))
+        eq(method),
+        eq(entity),
+        eq(headers))
     ).thenReturn(connection);
     when(connection.getResponseCode()).thenReturn(200);
 
@@ -214,6 +234,42 @@ public class AuthenticatingHttpConnectorTest {
     assertSame("If there is only one identity do not expect any additional endpoints to "
                + "be called after the first returns Unauthorized",
         returnedConnection, connection);
+  }
+
+  @Test
+  public void testTwoIdentities_ResponseIsUnauthorized() throws Exception {
+
+    final AgentProxy proxy = mock(AgentProxy.class);
+    final Identity id1 = mockIdentity();
+    final Identity id2 = mockIdentity();
+
+    final AuthenticatingHttpConnector authConnector =
+        createAuthenticatingConnector(Optional.of(proxy), ImmutableList.of(id1, id2));
+
+    final String path = "/another/one";
+
+    // set up two seperate connect() calls - the first returns 401 and the second 200 OK
+    final HttpsURLConnection connection1 = mock(HttpsURLConnection.class);
+    when(connection1.getResponseCode()).thenReturn(401);
+
+    final HttpsURLConnection connection2 = mock(HttpsURLConnection.class);
+    when(connection2.getResponseCode()).thenReturn(200);
+
+    when(connector.connect(argThat(matchesAnyEndpoint(path)),
+        eq(method),
+        eq(entity),
+        eq(headers))
+    ).thenReturn(connection1, connection2);
+
+    URI uri = new URI("https://helios" + path);
+
+    HttpURLConnection returnedConnection = authConnector.connect(uri, method, entity, headers);
+
+    verify(connector).setExtraHttpsHandler(sshAgentHttpsHandlerWithArgs(USER, proxy, id1));
+    verify(connector).setExtraHttpsHandler(sshAgentHttpsHandlerWithArgs(USER, proxy, id2));
+
+    assertSame("Expect returned connection to be the second one, with successful response code",
+        returnedConnection, connection2);
   }
 
   private static Endpoint endpoint(final URI uri, final InetAddress ip) {

--- a/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
@@ -263,4 +263,32 @@ public class AuthenticatingHttpConnectorTest {
       }
     });
   }
+
+  @Test
+  public void testOneIdentity_ServerReturns502BadGateway() throws Exception {
+    final AgentProxy proxy = mock(AgentProxy.class);
+    final Identity identity = mockIdentity();
+
+    final AuthenticatingHttpConnector authConnector =
+        createAuthenticatingConnector(Optional.of(proxy), ImmutableList.of(identity));
+
+    final String path = "/foobar";
+
+    final HttpsURLConnection connection = mock(HttpsURLConnection.class);
+    when(connector.connect(argThat(matchesAnyEndpoint(path)),
+        eq(method),
+        eq(entity),
+        eq(headers))
+    ).thenReturn(connection);
+    when(connection.getResponseCode()).thenReturn(502);
+
+    URI uri = new URI("https://helios" + path);
+
+    HttpURLConnection returnedConnection = authConnector.connect(uri, method, entity, headers);
+
+    assertSame("If there is only one identity do not expect any additional endpoints to "
+               + "be called after the first returns Unauthorized",
+        returnedConnection, connection);
+
+  }
 }


### PR DESCRIPTION
AuthenticatingHttpConnector handles a 502 Bad Gateway response by just
trying another iteration of the `while (true)`.

If for some reason the endpoints always return 502 (for example, the
service behind nginx is down) then this means the
AuthenticatingHttpConnector will loop forever (as long as the endpoints are
returning 502) with no way to interrupt.

This check for 502 Bad Gateway is better made in the DefaultHttpConnector
as it has nothing to do with authentication. A response with this status
code will have an exception thrown so that it is caught by
RetryingRequestDispatcher (and a new request is scheduled).

Also: broke out the separate "authentication flows" in
AuthenticatingHttpConnector to make it easier to follow the various flows for
different authentication types and avoid the hairy `while true` loop.