### PR TITLE
enhancements for HeliosSoloDeployment and tests

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.testing;
 
+import com.google.common.net.HostAndPort;
+
 import com.spotify.helios.client.HeliosClient;
 
 /**
@@ -28,6 +30,12 @@ public interface HeliosDeployment extends AutoCloseable {
    * @return A helios client connected to the master(s) of this helios deployment.
    */
   HeliosClient client();
+
+  /**
+   * Returns the host and port information  that the deployment is available at.
+   */
+  // TODO (mbrown): should this be URI to capture scheme info also?
+  HostAndPort address();
 
   /**
    * Undeploy (shut down) this Helios deployment.

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -65,9 +65,9 @@ public class HeliosDeploymentResource extends ExternalResource {
         try {
           final Socket s = new Socket();
           s.connect(address, 100);
-          log.info("successfully connected to HeliosDeployment at {}", s.getRemoteSocketAddress());
+          log.info("successfully connected to address {} for {}", address, deployment);
           return true;
-        } catch (SocketTimeoutException | ConnectException e ) {
+        } catch (SocketTimeoutException | ConnectException e) {
           log.debug("could not yet connect to HeliosDeployment: {}", e.toString());
           return null;
         }
@@ -77,6 +77,7 @@ public class HeliosDeploymentResource extends ExternalResource {
 
   @Override
   protected void after() {
+    log.info("Tearing down {}", this.deployment);
     deployment.close();
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -17,15 +17,30 @@
 
 package com.spotify.helios.testing;
 
+import com.google.common.net.HostAndPort;
+
 import com.spotify.helios.client.HeliosClient;
 
 import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A HeliosDeploymentResource makes the supplied {@link HeliosDeployment} available to a JUnit
  * test, and guarantees to tear it down afterward.
  */
 public class HeliosDeploymentResource extends ExternalResource {
+
+  private static final Logger log = LoggerFactory.getLogger(HeliosDeploymentResource.class);
+
   private final HeliosDeployment deployment;
 
   /**
@@ -33,6 +48,31 @@ public class HeliosDeploymentResource extends ExternalResource {
    */
   HeliosDeploymentResource(final HeliosDeployment deployment) {
     this.deployment = deployment;
+  }
+
+  /** Ensure that the HeliosDeployment is up. */
+  @Override
+  protected void before() throws Throwable {
+    super.before();
+
+    Polling.awaitUnchecked(30, TimeUnit.SECONDS, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        final HostAndPort hap = deployment.address();
+        final SocketAddress address = new InetSocketAddress(hap.getHostText(), hap.getPort());
+        log.debug("attempting to connect to {}", address);
+
+        try {
+          final Socket s = new Socket();
+          s.connect(address, 100);
+          log.info("successfully connected to HeliosDeployment at {}", s.getRemoteSocketAddress());
+          return true;
+        } catch (SocketTimeoutException | ConnectException e ) {
+          log.debug("could not yet connect to HeliosDeployment: {}", e.toString());
+          return null;
+        }
+      }
+    });
   }
 
   @Override

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -138,7 +138,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   private List<String> containerEnv() {
-    final HashSet<String> env = new HashSet<String>();
+    final HashSet<String> env = new HashSet<>();
     env.add("DOCKER_HOST=" + containerDockerHost.bindURI().toString());
     if (!isNullOrEmpty(containerDockerHost.dockerCertPath())) {
       env.add("DOCKER_CERT_PATH=/certs");
@@ -147,7 +147,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   private List<String> containerBinds() {
-    final HashSet<String> binds = new HashSet<String>();
+    final HashSet<String> binds = new HashSet<>();
     if (containerDockerHost.bindURI().getScheme().equals("unix")) {
       binds.add(containerDockerHost.bindURI().getSchemeSpecificPart() + ":" +
               containerDockerHost.bindURI().getSchemeSpecificPart());
@@ -208,7 +208,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   private List<String> probeCommand(final String probeName) {
-    final List<String> cmd = new ArrayList<String>(ImmutableList.of("curl", "-f"));
+    final List<String> cmd = new ArrayList<>(ImmutableList.of("curl", "-f"));
     switch (containerDockerHost.uri().getScheme()) {
       case "unix":
         cmd.addAll(ImmutableList.of(
@@ -275,7 +275,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
    */
   private String deploySolo(final String heliosHost) throws HeliosDeploymentException {
     //TODO(negz): Don't make this.env immutable so early?
-    final List<String> env = new ArrayList<String>();
+    final List<String> env = new ArrayList<>();
     env.addAll(this.env);
     env.add("HELIOS_NAME=" + HELIOS_NAME_PREFIX + this.namespace);
     env.add("HOST_ADDRESS=" + heliosHost);

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
@@ -27,8 +27,8 @@ import static java.lang.System.nanoTime;
 
 class Polling {
 
-  private static <T> T await(final long timeout, final TimeUnit timeUnit, final Callable<T> callable)
-      throws Exception {
+  private static <T> T await(final long timeout, final TimeUnit timeUnit,
+                             final Callable<T> callable) throws Exception {
     final long deadline = nanoTime() + timeUnit.toNanos(timeout);
     while (nanoTime() < deadline) {
       final T value = callable.call();

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
@@ -27,7 +27,7 @@ import static java.lang.System.nanoTime;
 
 class Polling {
 
-  public static <T> T await(final long timeout, final TimeUnit timeUnit, final Callable<T> callable)
+  private static <T> T await(final long timeout, final TimeUnit timeUnit, final Callable<T> callable)
       throws Exception {
     final long deadline = nanoTime() + timeUnit.toNanos(timeout);
     while (nanoTime() < deadline) {

--- a/helios-testing/src/test/resources/logback-test.xml
+++ b/helios-testing/src/test/resources/logback-test.xml
@@ -9,6 +9,7 @@
   </appender>
 
   <logger name="com.spotify.helios.testing" level="info"/>
+  <logger name="com.spotify.helios.testing.HeliosDeploymentResource" level="debug"/>
 
   <root level="info">
     <appender-ref ref="STDOUT" />

--- a/helios-testing/src/test/resources/logback-test.xml
+++ b/helios-testing/src/test/resources/logback-test.xml
@@ -8,8 +8,11 @@
     </encoder>
   </appender>
 
+  <logger name="com.spotify.helios.client.RetryingRequestDispatcher" level="debug" />
+
   <logger name="com.spotify.helios.testing" level="info"/>
   <logger name="com.spotify.helios.testing.HeliosDeploymentResource" level="debug"/>
+  <logger name="com.spotify.helios.testing.HeliosSoloDeploymentTest" level="debug"/>
 
   <root level="info">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
1) wait for Solo to start before running test

Add a wait in the HeliosSoloDeployment TestRule to make sure that it can
connect to the HeliosSolo instance before continuing with the test that the
TestRule is used in.

This prevents a bunch of error messages in the test itself coming from the
HeliosClient that it could not connect.

2) log more details about HeliosSoloDeployment to help diagnosing test failures