### PR TITLE
even more HeliosSoloDeploymentTest enhancements!

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -82,7 +82,7 @@ public class HeliosDeploymentResource extends ExternalResource {
     // this doesn't check that the agent is UP but should be sufficient to avoid conditions
     // like continuing with the test when starting up helios-solo before the agent is registered
     final HeliosClient client = client();
-    Polling.awaitUnchecked(5, TimeUnit.SECONDS, new Callable<Boolean>() {
+    Polling.awaitUnchecked(30, TimeUnit.SECONDS, new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
         final ListenableFuture<List<String>> future = client.listHosts();

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -91,6 +91,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     final String heliosPort;
     //TODO(negz): Determine and propagate NetworkManager DNS servers?
     try {
+      log.info("checking that docker can be reached from within a container");
       assertDockerReachableFromContainer();
       if (dockerHost.address().equals("localhost") || dockerHost.address().equals("127.0.0.1")) {
         heliosHost = containerGateway();
@@ -293,6 +294,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
             .image(HELIOS_IMAGE)
             .build();
 
+    log.info("starting container for helios-solo with image={}", HELIOS_IMAGE);
+
     final ContainerCreation creation;
     try {
       dockerClient.pull(HELIOS_IMAGE);
@@ -309,6 +312,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
       removeContainer(creation.id());
       throw new HeliosDeploymentException("helios-solo container start failed", e);
     }
+
+    log.info("helios-solo container started, containerId={}", creation.id());
 
     return creation.id();
   }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -256,6 +256,8 @@ public class TemporaryJobBuilder {
   public TemporaryJob deploy(final List<String> hosts) {
     this.hosts.addAll(hosts);
 
+    // check that the job has not already been deployed (this allows multiple calls to deploy()
+    // to be no-ops once deployed)
     if (job == null) {
       if (builder.getName() == null && builder.getVersion() == null) {
         // Both name and version are unset, use image name as job name and generate random version

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -43,7 +43,6 @@ public class HeliosSoloDeploymentTest {
     assertThat(testResult(HeliosSoloDeploymentTestImpl.class), isSuccessful());
   }
 
-
   public static class HeliosSoloDeploymentTestImpl {
 
     public static final String IMAGE_NAME = "onescience/alpine:latest";
@@ -64,6 +63,13 @@ public class HeliosSoloDeploymentTest {
     @Test
     public void testDeployToSolo() throws Exception {
       temporaryJobs.job()
+          // while ".*" is the default in the local testing profile, explicitly specify it here
+          // to avoid any extraneous environment variables for HELIOS_HOST_FILTER that might be set
+          // on the build agent executing this test from interfering with the behavior we want here.
+          // Since we are deploying on a self-contained helios-solo container, any
+          // HELIOS_HOST_FILTER value set for other tests will never match the agent hostname
+          // inside helios-solo.
+          .hostFilter(".*")
           .command(asList("sh", "-c", "nc -l -v -p 4711 -e true"))
           .image(IMAGE_NAME)
           .port("netcat", 4711)

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
@@ -47,9 +46,7 @@ public class HeliosSoloDeploymentTest {
 
   public static class HeliosSoloDeploymentTestImpl {
 
-    public static final String BUSYBOX = "busybox:latest";
-    public static final List<String> IDLE_COMMAND = asList(
-        "sh", "-c", "trap 'exit 0' SIGINT SIGTERM; while :; do sleep 1; done");
+    public static final String IMAGE_NAME = "onescience/alpine:latest";
 
     private static final Logger log = LoggerFactory.getLogger(HeliosSoloDeploymentTestImpl.class);
 
@@ -67,7 +64,10 @@ public class HeliosSoloDeploymentTest {
     @Test
     public void testDeployToSolo() throws Exception {
       temporaryJobs.job()
-          .command(IDLE_COMMAND)
+          .command(asList("sh", "-c", "nc -l -v -p 4711 -e true"))
+          .image(IMAGE_NAME)
+          .port("netcat", 4711)
+          .registration("foobar", "tcp", "netcat")
           .deploy();
 
       final Map<JobId, Job> jobs = DEPLOYMENT.client().jobs().get(15, SECONDS);
@@ -78,7 +78,7 @@ public class HeliosSoloDeploymentTest {
 
       assertEquals("wrong number of jobs running", 1, jobs.size());
       for (Job j : jobs.values()) {
-        assertEquals("wrong job running", BUSYBOX, j.getImage());
+        assertEquals("wrong job running", IMAGE_NAME, j.getImage());
       }
     }
   }

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -59,7 +59,10 @@ public class HeliosSoloDeploymentTest {
         HeliosSoloDeployment.fromEnv().build());
 
     @Rule
-    public final TemporaryJobs temporaryJobs = TemporaryJobs.create(DEPLOYMENT.client());
+    public final TemporaryJobs temporaryJobs = TemporaryJobs.builder()
+        .jobPrefix("HeliosSoloDeploymentTest")
+        .client(DEPLOYMENT.client())
+        .build();
 
     @Test
     public void testDeployToSolo() throws Exception {


### PR DESCRIPTION
- HeliosSoloDeploymentTest: have the job expose a port so that TemporaryJob will probe the port to ensure the container is up before continuing with the rest of the test that requires it to be up
- wait for the agent inside helios-solo to be up before starting the test (this applies to anyone using HeliosDeploymentResource, not just our test of it)
- log even more context of what HeliosSoloDeployment is doing on startup