### PR TITLE
X509CertificateFactory: Log generated certificate

### DIFF
--- a/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
@@ -25,13 +25,17 @@ import org.bouncycastle.crypto.tls.Certificate;
 import org.bouncycastle.util.encoders.Base64;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 
+import static com.spotify.helios.common.Hash.sha1digest;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -58,6 +62,13 @@ public class X509CertificateFactoryTest {
     publicKey = keyFactory.generatePublic(pubKeySpec);
 
     when(identity.getPublicKey()).thenReturn(publicKey);
+    when(agentProxy.sign(any(Identity.class), any(byte[].class))).thenAnswer(new Answer<byte[]>() {
+      @Override
+      public byte[] answer(InvocationOnMock invocation) throws Throwable {
+        final byte[] bytesToSign = (byte[]) invocation.getArguments()[1];
+        return sha1digest(bytesToSign);
+      }
+    });
   }
 
   @Test


### PR DESCRIPTION
Log the PEM representation of any generated certificates to the debug log.
Handy if you want to do something like `openssl x509 -text` to see what the
generated certificate actually has in it.