### PR TITLE
enhancements to setting client certificates from a file

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -132,7 +132,9 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     final ClientCertificatePath clientCertificatePath = this.clientCertificatePath.get();
     log.debug("configuring CertificateFileHttpsHandler with {}", clientCertificatePath);
 
-    delegate.setExtraHttpsHandler(new CertificateFileHttpsHandler(user, clientCertificatePath));
+    delegate.setExtraHttpsHandler(
+        new CertificateFileHttpsHandler(user, false, clientCertificatePath)
+    );
 
     return doConnect(ipUri, method, entity, headers);
   }
@@ -151,7 +153,8 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     while (!queue.isEmpty()) {
       final Identity identity = queue.poll();
 
-      delegate.setExtraHttpsHandler(new SshAgentHttpsHandler(user, agentProxy.get(), identity));
+      delegate.setExtraHttpsHandler(
+          new SshAgentHttpsHandler(user, false, agentProxy.get(), identity));
 
       connection = doConnect(uri, method, entity, headers);
 

--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -37,7 +37,6 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -56,8 +55,7 @@ public class AuthenticatingHttpConnector implements HttpConnector {
 
   private final String user;
   private final Optional<AgentProxy> agentProxy;
-  private final Optional<Path> clientCertificatePath;
-  private final Optional<Path> clientKeyPath;
+  private final Optional<ClientCertificatePath> clientCertificatePath;
   private final List<Identity> identities;
   private final EndpointIterator endpointIterator;
 
@@ -65,31 +63,23 @@ public class AuthenticatingHttpConnector implements HttpConnector {
 
   public AuthenticatingHttpConnector(final String user,
                                      final Optional<AgentProxy> agentProxyOpt,
-                                     final Optional<Path> clientCertificatePath,
-                                     final Optional<Path> clientKeyPath,
+                                     final Optional<ClientCertificatePath> clientCertificatePath,
                                      final EndpointIterator endpointIterator,
                                      final DefaultHttpConnector delegate) {
-    this(user, agentProxyOpt, clientCertificatePath, clientKeyPath, endpointIterator,
+    this(user, agentProxyOpt, clientCertificatePath, endpointIterator,
          delegate, getSshIdentities(agentProxyOpt));
   }
 
   @VisibleForTesting
   AuthenticatingHttpConnector(final String user,
                               final Optional<AgentProxy> agentProxyOpt,
-                              final Optional<Path> clientCertificatePath,
-                              final Optional<Path> clientKeyPath,
+                              final Optional<ClientCertificatePath> clientCertificatePath,
                               final EndpointIterator endpointIterator,
                               final DefaultHttpConnector delegate,
                               final List<Identity> identities) {
-    if (clientCertificatePath.isPresent() != clientKeyPath.isPresent()) {
-      throw new IllegalArgumentException(
-          "both or neither of clientCertificatePath and clientKeyPath must be specified");
-    }
-
     this.user = user;
     this.agentProxy = agentProxyOpt;
     this.clientCertificatePath = clientCertificatePath;
-    this.clientKeyPath = clientKeyPath;
     this.endpointIterator = endpointIterator;
     this.delegate = delegate;
     this.identities = identities;
@@ -112,7 +102,7 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     try {
       log.debug("connecting to {}", ipUri);
 
-      if (clientCertificatePath.isPresent() && clientKeyPath.isPresent()) {
+      if (clientCertificatePath.isPresent()) {
         // prioritize using the certificate file if set
         return connectWithCertificateFile(ipUri, method, entity, headers);
       } else if (agentProxy.isPresent() && !identities.isEmpty()) {
@@ -139,8 +129,10 @@ public class AuthenticatingHttpConnector implements HttpConnector {
                                                        final Map<String, List<String>> headers)
       throws HeliosException {
 
-    delegate.setExtraHttpsHandler(
-        new CertificateFileHttpsHandler(user, clientCertificatePath.get(), clientKeyPath.get()));
+    final ClientCertificatePath clientCertificatePath = this.clientCertificatePath.get();
+    log.debug("configuring CertificateFileHttpsHandler with {}", clientCertificatePath);
+
+    delegate.setExtraHttpsHandler(new CertificateFileHttpsHandler(user, clientCertificatePath));
 
     return doConnect(ipUri, method, entity, headers);
   }

--- a/helios-client/src/main/java/com/spotify/helios/client/ClientCertificatePath.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/ClientCertificatePath.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+
+import java.nio.file.Path;
+
+/** Holds the Paths to files necessary to construct a ClientCerticate. */
+public class ClientCertificatePath {
+
+  private final Path certificatePath;
+  private final Path keyPath;
+
+  public ClientCertificatePath(final Path certificatePath, final Path keyPath) {
+    this.certificatePath = checkExists(certificatePath);
+    this.keyPath = checkExists(keyPath);
+  }
+
+  private static Path checkExists(Path path) {
+    Preconditions.checkNotNull(path);
+    Preconditions.checkArgument(path.toFile().canRead(),
+        path + " does not exist or cannot be read");
+    return path;
+  }
+
+  public Path getCertificatePath() {
+    return certificatePath;
+  }
+
+  public Path getKeyPath() {
+    return keyPath;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ClientCertificatePath that = (ClientCertificatePath) o;
+
+    if (!certificatePath.equals(that.certificatePath)) {
+      return false;
+    }
+    return keyPath.equals(that.keyPath);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = certificatePath.hashCode();
+    result = 31 * result + keyPath.hashCode();
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("certificatePath", certificatePath)
+        .add("keyPath", keyPath)
+        .toString();
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -508,16 +508,23 @@ public class HeliosClient implements AutoCloseable {
     private static final String HELIOS_CERT_PATH = "HELIOS_CERT_PATH";
 
     private String user;
-    private Path clientCertificatePath;
-    private Path clientKeyPath;
+    private ClientCertificatePath clientCertificatePath;
     private Supplier<List<Endpoint>> endpointSupplier;
     private boolean sslHostnameVerification = true;
 
     private Builder() {
       final String heliosCertPath = System.getenv(HELIOS_CERT_PATH);
       if (!isNullOrEmpty(heliosCertPath)) {
-        this.clientCertificatePath = Paths.get(heliosCertPath, "cert.pem");
-        this.clientKeyPath = Paths.get(heliosCertPath, "key.pem");
+        final Path certPath = Paths.get(heliosCertPath, "cert.pem");
+        final Path keyPath = Paths.get(heliosCertPath, "key.pem");
+
+        if (certPath.toFile().canRead() && keyPath.toFile().canRead()) {
+          this.clientCertificatePath = new ClientCertificatePath(certPath, keyPath);
+        } else {
+          log.warn("{} is set to {}, but {} and/or {} do not exist or cannot be read. "
+                   + "Will not send client certificate in HeliosClient requests.",
+              HELIOS_CERT_PATH, heliosCertPath, certPath, keyPath);
+        }
       }
     }
 
@@ -564,13 +571,8 @@ public class HeliosClient implements AutoCloseable {
       return this;
     }
 
-    public Builder setClientCertificatePath(final Path clientCertificatePath) {
+    public Builder setClientCertificatePath(final ClientCertificatePath clientCertificatePath) {
       this.clientCertificatePath = clientCertificatePath;
-      return this;
-    }
-
-    public Builder setClientKeyPath(final Path clientKeyPath) {
-      this.clientKeyPath = clientKeyPath;
       return this;
     }
 
@@ -602,9 +604,6 @@ public class HeliosClient implements AutoCloseable {
       final DefaultHttpConnector connector = new DefaultHttpConnector(endpointIterator, 10000,
                                                                       sslHostnameVerification);
 
-      Optional<Path> clientCertificatePath = Optional.fromNullable(this.clientCertificatePath);
-      Optional<Path> clientKeyPath = Optional.fromNullable(this.clientKeyPath);
-
       Optional<AgentProxy> agentProxyOpt = Optional.absent();
       try {
         agentProxyOpt = Optional.of(AgentProxies.newInstance());
@@ -615,8 +614,11 @@ public class HeliosClient implements AutoCloseable {
         log.debug("{}", e);
       }
 
-      return new AuthenticatingHttpConnector(user, agentProxyOpt, clientCertificatePath,
-                                             clientKeyPath, endpointIterator, connector);
+      return new AuthenticatingHttpConnector(user,
+          agentProxyOpt,
+          Optional.fromNullable(clientCertificatePath),
+          endpointIterator,
+          connector);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
@@ -135,8 +135,8 @@ public class X509CertificateFactory {
   }
 
   public static class CertificateAndKeyPair {
-    private Certificate certificate;
-    private KeyPair keyPair;
+    private final Certificate certificate;
+    private final KeyPair keyPair;
 
     public CertificateAndKeyPair(final Certificate certificate,
                                  final KeyPair keyPair) {

--- a/helios-client/src/test/java/com/spotify/helios/client/ClientCertificatePathTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/ClientCertificatePathTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ClientCertificatePathTest {
+
+  private Path tempFile;
+
+  @Before
+  public void setUp() throws Exception {
+    tempFile = Files.createTempFile(getClass().getSimpleName(), "tmp");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCertificateDoesNotExist() {
+    new ClientCertificatePath(Paths.get("some-unknown-file"), tempFile);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testKeyDoesNotExist() {
+    new ClientCertificatePath(tempFile, Paths.get("some-unknown-file"));
+  }
+
+  @Test
+  public void testEverythingExists() {
+    new ClientCertificatePath(tempFile, tempFile);
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/client/HttpsHandlersTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HttpsHandlersTest.java
@@ -47,8 +47,10 @@ public class HttpsHandlersTest {
 
     final Path certificate = Paths.get(getResource("UIDCACert.pem").getPath());
     final Path key = Paths.get(getResource("UIDCACert.key").getPath());
+    final ClientCertificatePath clientCertificatePath = new ClientCertificatePath(certificate, key);
+
     final HttpsHandlers.CertificateFileHttpsHandler h =
-        new HttpsHandlers.CertificateFileHttpsHandler("foo", certificate, key);
+        new HttpsHandlers.CertificateFileHttpsHandler("foo", clientCertificatePath);
 
     assertNotNull(h.getCertificate());
     assertNotNull(h.getPrivateKey());


### PR DESCRIPTION
When HELIOS_CERT_PATH is set, test the existence of the certificate file much earlier in the process. If the files pointed to by the environment variable cannot be read or don't exist, warn the user and make the request without a certificate.

Also add a condition for ignoring exceptions when setting up the client cert if the file contents are invalid or can't be parsed or whatever.

It might make more sense to have the latter be controlled by a CLI flag (instead of having a boolean condition in the code that is only ever set to `false`), but then again if `--fail-on-certificate-parse-error` existed I'm not sure why anyone would really want to use it - if the master requires a cert anyway it will reject the request.

```
$ HELIOS_CERT_PATH=/foo bin/helios -d blah masters
running in helios project, using /Users/mattbrown/code/helios/helios-tools/target/helios-tools-0.8.0-SNAPSHOT-shaded.jar
14:15:32.641 WARN  HeliosClient: HELIOS_CERT_PATH is set to /foo, but /foo/cert.pem and/or /foo/key.pem do not exist or cannot be read. Will not send client certificate in HeliosClient requests.
blah-heliosmaster-a1
blah-heliosmaster-a3
blah-heliosmaster-a4
blah-heliosmaster-a5
blah-heliosmaster-a2

$ mkdir /tmp/cert && touch /tmp/cert/cert.pem && touch /tmp/cert/key.pem
$ HELIOS_CERT_PATH=/tmp/cert bin/helios -d blah masters
running in helios project, using /Users/mattbrown/code/helios/helios-tools/target/helios-tools-0.8.0-SNAPSHOT-shaded.jar
14:17:37.681 WARN  HttpsHandlers$CertificateFileHttpsHandler: Error when setting up client certificates from ClientCertificatePath{certificatePath=/tmp/cert/cert.pem, keyPath=/tmp/cert/key.pem}. Error was java.security.cert.CertificateException: Could not parse certificate: java.io.IOException: Empty input. No certificate will be sent with request.
blah-heliosmaster-a1
blah-heliosmaster-a3
blah-heliosmaster-a4
blah-heliosmaster-a5
blah-heliosmaster-a2
```

Also added a log line to make it explicit when the client certificate is being set up:
```
[mattbrown@mattbrown-air helios]$ HELIOS_CERT_PATH=/tmp/goodcert ~/code/helios/bin/helios -vvv -d blah masters
running in helios project, using /Users/mattbrown/code/helios/helios-tools/target/helios-tools-0.8.0-SNAPSHOT-shaded.jar
...
14:57:27.296 DEBUG AuthenticatingHttpConnector: configuring CertificateFileHttpsHandler with ClientCertificatePath{certificatePath=/tmp/goodcert/cert.pem, keyPath=/tmp/goodcert/key.pem}
```