### PR TITLE
less-scary error message when SSH_AUTH_SOCK is not set

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -210,7 +210,9 @@ public class AuthenticatingHttpConnector implements HttpConnector {
       } catch (Exception e) {
         // We catch everything because right now the masters do not require authentication.
         // So delay reporting errors to the user until the servers return 401 Unauthorized.
-        log.debug("Couldn't get identities from ssh-agent", e);
+        log.debug("Unable to get identities from ssh-agent. Note that this might not indicate"
+                  + " an actual problem unless your Helios cluster requires authentication"
+                  + " for all requests.", e);
       }
     }
 


### PR DESCRIPTION
Although we only output the previous message at DEBUG, this log message
can be confusing for users if they have failed tests or another problem
with their client talking to Helios that leads them to think that the
SSH_AUTH_SOCK is the real issue.

So try to wordsmith the message a little bit to indicate it probably
isn't a real issue in all cases.