### PR TITLE
HeliosDeploymentResource ctor needs to be public

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -49,7 +49,7 @@ public class HeliosDeploymentResource extends ExternalResource {
   /**
    * @param deployment The Helios deployment to expose to your JUnit tests.
    */
-  HeliosDeploymentResource(final HeliosDeployment deployment) {
+  public HeliosDeploymentResource(final HeliosDeployment deployment) {
     this.deployment = deployment;
   }
 


### PR DESCRIPTION
Since this class (from the testing library) is meant to be used by other
projects in their tests, the constructor really needs to not be
package-private.