### PR TITLE
override DOCKER_HOST of localhost/127.0.0.1 with unix sockets

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -81,8 +81,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
 
     this.dockerClient = checkNotNull(builder.dockerClient, "dockerClient");
     this.dockerHost = Optional.fromNullable(builder.dockerHost).or(DockerHost.fromEnv());
-    this.containerDockerHost = Optional.fromNullable(builder.containerDockerHost)
-            .or(containerDockerHostFromEnv());
+    this.containerDockerHost = containerDockerHost(builder);
     this.namespace = Optional.fromNullable(builder.namespace).or(randomString());
     this.env = containerEnv();
     this.binds = containerBinds();
@@ -112,20 +111,36 @@ public class HeliosSoloDeployment implements HeliosDeployment {
             .build();
   }
 
+  private DockerHost containerDockerHost(final Builder builder) {
+    if (builder.containerDockerHost != null) {
+      return containerDockerHost;
+    }
+
+    if (isBoot2Docker(dockerInfo())) {
+      return DockerHost.from(DefaultDockerClient.DEFAULT_UNIX_ENDPOINT, null);
+    }
+
+    // otherwise construct a DockerHost from environment variables, *unless* DOCKER_HOST is set to
+    // localhost or 127.0.0.1 - which will never work inside a container. For those cases, we
+    // override the settings and use the unix socket instead.
+    final DockerHost dockerHost = DockerHost.fromEnv();
+    if (dockerHost.address().equals("localhost") || dockerHost.address().equals("127.0.0.1")) {
+      final String endpoint = DockerHost.DEFAULT_UNIX_ENDPOINT;
+      log.warn("DOCKER_HOST points to localhost or 127.0.0.1. Replacing this with {} "
+               + "as localhost/127.0.0.1 will not work inside a container to talk to the docker "
+               + "daemon on the host itself.", endpoint);
+      return DockerHost.from(endpoint, dockerHost.dockerCertPath());
+    }
+
+    return dockerHost;
+  }
+
   @Override
   public HostAndPort address() {
       return deploymentAddress;
   }
 
-  private DockerHost containerDockerHostFromEnv() {
-    if (isBoot2Docker(dockerInfo())) {
-      return DockerHost.from(DefaultDockerClient.DEFAULT_UNIX_ENDPOINT, null);
-    } else {
-      return DockerHost.fromEnv();
-    }
-  }
-
-  private Boolean isBoot2Docker(final Info dockerInfo) {
+  private boolean isBoot2Docker(final Info dockerInfo) {
     return dockerInfo.operatingSystem().contains(BOOT2DOCKER_SIGNATURE);
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -211,12 +211,12 @@ public class HeliosSoloDeployment implements HeliosDeployment {
       exit = dockerClient.waitContainer(creation.id());
     } catch (DockerException | InterruptedException e) {
       killContainer(creation.id());
-      removeContainer(creation.id());
       throw new HeliosDeploymentException("helios-solo probe container failed", e);
+    } finally {
+      removeContainer(creation.id());
     }
 
     if (exit.statusCode() != 0) {
-      removeContainer(creation.id());
       throw new HeliosDeploymentException(String.format(
               "Docker was not reachable (curl exit status %d) using DOCKER_HOST=%s and "
                       + "DOCKER_CERT_PATH=%s from within a container. Please ensure that "
@@ -227,7 +227,6 @@ public class HeliosSoloDeployment implements HeliosDeployment {
               containerDockerHost.dockerCertPath()));
     }
 
-    removeContainer(creation.id());
     return gateway;
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -165,8 +165,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   private List<String> containerBinds() {
     final HashSet<String> binds = new HashSet<>();
     if (containerDockerHost.bindURI().getScheme().equals("unix")) {
-      binds.add(containerDockerHost.bindURI().getSchemeSpecificPart() + ":" +
-              containerDockerHost.bindURI().getSchemeSpecificPart());
+      final String path = containerDockerHost.bindURI().getPath();
+      binds.add(path + ":" + path);
     }
     if (!isNullOrEmpty(containerDockerHost.dockerCertPath())) {
       binds.add(containerDockerHost.dockerCertPath() + ":/certs");
@@ -387,7 +387,6 @@ public class HeliosSoloDeployment implements HeliosDeployment {
    */
   public static Builder fromEnv()  {
     try {
-      DefaultDockerClient.fromEnv().uri();
       return builder().dockerClient(DefaultDockerClient.fromEnv().build());
     } catch (DockerCertificateException e) {
       throw new RuntimeException("unable to create Docker client from environment", e);

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -18,23 +18,44 @@
 package com.spotify.helios.testing;
 
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.ContainerExit;
+import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.Info;
+import com.spotify.docker.client.messages.NetworkSettings;
+import com.spotify.docker.client.messages.PortBinding;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class HeliosSoloDeploymentTest {
 
@@ -87,5 +108,69 @@ public class HeliosSoloDeploymentTest {
         assertEquals("wrong job running", IMAGE_NAME, j.getImage());
       }
     }
+  }
+
+  @Test
+  public void testDockerHostContainsLocalhost() throws Exception {
+    final  DockerClient dockerClient = mock(DockerClient.class);
+
+    // the anonymous classes to override a method are to workaround the docker-client "messages"
+    // having no mutators, fun
+    when(dockerClient.info()).thenReturn(new Info() {
+      @Override
+      public String operatingSystem() {
+        return "foo";
+      }
+    });
+
+    // mock the call to dockerClient.createContainer so we can test the arguments passed to it
+    final ArgumentCaptor<ContainerConfig> containerConfig =
+        ArgumentCaptor.forClass(ContainerConfig.class);
+
+    final ContainerCreation creation = mock(ContainerCreation.class);
+    final String containerId = "abc123";
+    when(creation.id()).thenReturn(containerId);
+
+    // we have to mock out several other calls to get the HeliosSoloDeployment ctor
+    // to return non-exceptionally:
+
+    when(dockerClient.createContainer(containerConfig.capture(), anyString())).thenReturn(creation);
+
+    when(dockerClient.inspectContainer(containerId)).thenReturn(new ContainerInfo() {
+      @Override
+      public NetworkSettings networkSettings() {
+        final PortBinding binding = PortBinding.of("192.168.1.1",  5801);
+        final Map<String, List<PortBinding>> ports =
+            ImmutableMap.<String, List<PortBinding>>of("5801/tcp", ImmutableList.of(binding));
+
+        return NetworkSettings.builder()
+            .gateway("a-gate-way")
+            .ports(ports)
+            .build();
+      }
+    });
+
+    when(dockerClient.waitContainer(containerId)).thenReturn(new ContainerExit() {
+      @Override
+      public Integer statusCode() {
+        return 0;
+      }
+    });
+
+    // finally build the thing ...
+    HeliosSoloDeployment.builder()
+        .dockerClient(dockerClient)
+        .build();
+
+    // .. so we can test what was passed
+    boolean foundSolo = false;
+    for (ContainerConfig cc : containerConfig.getAllValues()) {
+      if (cc.image().contains("helios-solo")) {
+        assertThat(containerConfig.getValue().hostConfig().binds(),
+                   hasItem("/var/run/docker.sock:/var/run/docker.sock"));
+        foundSolo = true;
+      }
+    }
+    assertTrue("Could not find helios-solo container creation", foundSolo);
   }
 }

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -109,7 +109,7 @@ public class HeliosSoloDeploymentTest {
 
   @Test
   public void testDockerHostContainsLocalhost() throws Exception {
-    final  DockerClient dockerClient = mock(DockerClient.class);
+    final DockerClient dockerClient = mock(DockerClient.class);
 
     // the anonymous classes to override a method are to workaround the docker-client "messages"
     // having no mutators, fun
@@ -136,7 +136,7 @@ public class HeliosSoloDeploymentTest {
     when(dockerClient.inspectContainer(containerId)).thenReturn(new ContainerInfo() {
       @Override
       public NetworkSettings networkSettings() {
-        final PortBinding binding = PortBinding.of("192.168.1.1",  5801);
+        final PortBinding binding = PortBinding.of("192.168.1.1", 5801);
         final Map<String, List<PortBinding>> ports =
             ImmutableMap.<String, List<PortBinding>>of("5801/tcp", ImmutableList.of(binding));
 
@@ -157,6 +157,8 @@ public class HeliosSoloDeploymentTest {
     // finally build the thing ...
     HeliosSoloDeployment.builder()
         .dockerClient(dockerClient)
+        // a custom dockerhost to trigger the localhost logic
+        .dockerHost(DockerHost.from("tcp://localhost:2375", ""))
         .build();
 
     // .. so we can test what was passed

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -41,13 +41,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
...when using HeliosSoloDeployment.

If DOCKER_HOST is 127.0.0.1 or localhost, then the test in
`checkDockerAndGateway()` to make sure that the docker process is reachable
from a container will never work (nor will the actual helios-solo process),
so try to at least replace the endpoint used to talk to docker with the
default unix socket endpoint.