### PR TITLE
Decrease Kafka metadata fetch timeout

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/KafkaClientProvider.java
@@ -41,7 +41,7 @@ public class KafkaClientProvider {
 
   private static final String KAFKA_HELIOS_CLIENT_ID = "Helios";
   private static final String KAFKA_QUORUM_PARAMETER = "1";
-  public static final int MAX_BLOCK_TIMEOUT = 5000;
+  public static final int MAX_BLOCK_TIMEOUT = 1000;
 
   private final Optional<ImmutableMap<String, Object>> partialConfigs;
 


### PR DESCRIPTION
Decrease from 5 to 1 second. Even though we don't block,
the Helios client will timeout in less than 5 seconds.