### PR TITLE
Fix job registration domain during job creation

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/CliJobCreationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/CliJobCreationTest.java
@@ -71,6 +71,7 @@ public class CliJobCreationTest extends SystemTestBase {
     final Map<ServiceEndpoint, ServicePorts> registration = ImmutableMap.of(
         ServiceEndpoint.of("foo-service", "tcp"), ServicePorts.of("foo"),
         ServiceEndpoint.of("bar-service", "http"), ServicePorts.of("bar"));
+    final String registrationDomain = "my-domain";
     final Map<String, String> env = ImmutableMap.of("BAD", "f00d");
     final Map<String, String> volumes = Maps.newHashMap();
     volumes.put("/etc/spotify/secret-keys.yaml:ro", "/etc/spotify/secret-keys.yaml");
@@ -81,6 +82,7 @@ public class CliJobCreationTest extends SystemTestBase {
         .setEnv(env)
         .setPorts(ports)
         .setRegistration(registration)
+        .setRegistrationDomain(registrationDomain)
         .setVolumes(volumes)
         .setCreatingUser(TEST_USER)
         .setToken("foo-token")

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -439,7 +439,10 @@ public class JobCreateCommand extends ControlCommand {
       explicitRegistration.put(ServiceEndpoint.of(service, proto), ServicePorts.of(port));
     }
 
-    builder.setRegistrationDomain(options.getString(registrationDomainArg.getDest()));
+    final String registrationDomain = options.getString(registrationDomainArg.getDest());
+    if (!isNullOrEmpty(registrationDomain)) {
+      builder.setRegistrationDomain(registrationDomain);
+    }
 
     // Merge service registrations
     final Map<ServiceEndpoint, ServicePorts> registration = Maps.newHashMap();


### PR DESCRIPTION
Do not overwrite config value in file with default value
of empty string from CLI args.