### PR TITLE
Agent re-registration now preserves jobs deployed on the replaced host

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
@@ -120,8 +120,7 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
                    + "I'll assume it's dead and deregister it.", name, hostInfoPath);
         }
 
-        ZooKeeperRegistrarUtil.deregisterHost(client, name);
-        ZooKeeperRegistrarUtil.registerHost(client, idPath, name, id);
+        ZooKeeperRegistrarUtil.reRegisterHost(client, name, id);
       } else {
         log.info("Matching agent id node already present, not registering agent {}: {}", id, name);
       }

--- a/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
@@ -17,15 +17,13 @@
 
 package com.spotify.helios.master;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-
 import com.spotify.helios.agent.InterruptingScheduledService;
 import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.common.descriptors.AgentInfo;
 import com.spotify.helios.common.descriptors.HostStatus;
 
+import org.apache.commons.lang.time.DurationFormatUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +31,8 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * De-registers dead agents, where an agent that has been DOWN for more than X time is considered
@@ -48,6 +48,13 @@ public class DeadAgentReaper extends InterruptingScheduledService {
 
   private final MasterModel masterModel;
   private final long timeoutMillis;
+  private final Clock clock;
+
+  public DeadAgentReaper(final MasterModel masterModel,
+                         final long timeout,
+                         final TimeUnit timeUnit) {
+    this(masterModel, timeout, timeUnit, SYSTEM_CLOCK);
+  }
 
   /**
    * We check for dead agents every 30 minutes, which means the actual timeout the specified timeout
@@ -55,38 +62,23 @@ public class DeadAgentReaper extends InterruptingScheduledService {
    */
   public DeadAgentReaper(final MasterModel masterModel,
                          final long timeout,
-                         final TimeUnit timeUnit) {
+                         final TimeUnit timeUnit,
+                         final Clock clock) {
     this.masterModel = masterModel;
+    checkArgument(timeout > 0);
     this.timeoutMillis = timeUnit.toMillis(timeout);
+    this.clock = clock;
   }
 
   @Override
   protected void runOneIteration() {
     log.debug("Reaping agents");
-    final List<String> deadAgents = getDeadAgents(masterModel, timeoutMillis, SYSTEM_CLOCK);
-    log.debug("Reaping {} dead agents: {}", deadAgents.size(), deadAgents);
-
-    for (final String agent : deadAgents) {
-      log.info("Reaping dead agent {}", agent);
-      try {
-        masterModel.deregisterHost(agent);
-      } catch (Exception e) {
-        log.error("Failed to reap dead agent {}", agent, e);
-      }
-    }
-  }
-
-  @VisibleForTesting
-  static List<String> getDeadAgents(final MasterModel masterModel, final long timeoutMillis,
-                                    final Clock clock) {
-    final List<String> deadAgents = Lists.newArrayList();
     final List<String> agents = masterModel.listHosts();
-
     for (final String agent : agents) {
       try {
         final HostStatus hostStatus = masterModel.getHostStatus(agent);
         if (hostStatus == null || hostStatus.getStatus() != HostStatus.Status.DOWN) {
-          // Hot not found or host not DOWN -- nothing to do, move on to the next host
+          // Host not found or host not DOWN -- nothing to do, move on to the next host
           continue;
         }
 
@@ -99,14 +91,18 @@ public class DeadAgentReaper extends InterruptingScheduledService {
         final long downDurationMillis = clock.now().getMillis() - downSince;
 
         if (downDurationMillis >= timeoutMillis) {
-          deadAgents.add(agent);
+          try {
+            log.info("Reaping dead agent '{}' (DOWN for {} hours)",
+                     DurationFormatUtils.formatDurationHMS(downDurationMillis));
+            masterModel.deregisterHost(agent);
+          } catch (Exception e) {
+            log.warn("Failed to reap agent '{}'", agent, e);
+          }
         }
       } catch (Exception e) {
         log.warn("Failed to determine if agent '{}' should be reaped", agent, e);
       }
     }
-
-    return deadAgents;
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * De-registers dead agents, where an agent that has been DOWN for more than X time is considered
+ * De-registers dead agents, where an agent that has been DOWN for more than X hours is considered
  * dead.
  */
 public class DeadAgentReaper extends InterruptingScheduledService {
@@ -51,22 +51,16 @@ public class DeadAgentReaper extends InterruptingScheduledService {
   private final Clock clock;
 
   public DeadAgentReaper(final MasterModel masterModel,
-                         final long timeout,
-                         final TimeUnit timeUnit) {
-    this(masterModel, timeout, timeUnit, SYSTEM_CLOCK);
+                         final long timeoutHours) {
+    this(masterModel, timeoutHours, SYSTEM_CLOCK);
   }
 
-  /**
-   * We check for dead agents every 30 minutes, which means the actual timeout the specified timeout
-   * plus up to 30 minutes. I.e. very low timeouts will not work in practice.
-   */
   public DeadAgentReaper(final MasterModel masterModel,
-                         final long timeout,
-                         final TimeUnit timeUnit,
+                         final long timeoutHours,
                          final Clock clock) {
     this.masterModel = masterModel;
-    checkArgument(timeout > 0);
-    this.timeoutMillis = timeUnit.toMillis(timeout);
+    checkArgument(timeoutHours > 0);
+    this.timeoutMillis = TimeUnit.HOURS.toMillis(timeoutHours);
     this.clock = clock;
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+
+import com.spotify.helios.agent.InterruptingScheduledService;
+import com.spotify.helios.common.Clock;
+import com.spotify.helios.common.SystemClock;
+import com.spotify.helios.common.descriptors.AgentInfo;
+import com.spotify.helios.common.descriptors.HostStatus;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * De-registers dead agents, where an agent that has been DOWN for more than X time is considered
+ * dead.
+ */
+public class DeadAgentReaper extends InterruptingScheduledService {
+
+  private static final Clock SYSTEM_CLOCK = new SystemClock();
+  private static final long INTERVAL = 30;
+  private static final TimeUnit INTERVAL_TIME_UNIT = TimeUnit.MINUTES;
+
+  private static final Logger log = LoggerFactory.getLogger(DeadAgentReaper.class);
+
+  private final MasterModel masterModel;
+  private final long timeoutMillis;
+
+  /**
+   * We check for dead agents every 30 minutes, which means the actual timeout the specified timeout
+   * plus up to 30 minutes. I.e. very low timeouts will not work in practice.
+   */
+  public DeadAgentReaper(final MasterModel masterModel,
+                         final long timeout,
+                         final TimeUnit timeUnit) {
+    this.masterModel = masterModel;
+    this.timeoutMillis = timeUnit.toMillis(timeout);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    log.debug("Reaping agents");
+    final List<String> deadAgents = getDeadAgents(masterModel, timeoutMillis, SYSTEM_CLOCK);
+    log.debug("Reaping {} dead agents: {}", deadAgents.size(), deadAgents);
+
+    for (final String agent : deadAgents) {
+      log.info("Reaping dead agent {}", agent);
+      try {
+        masterModel.deregisterHost(agent);
+      } catch (Exception e) {
+        log.error("Failed to reap dead agent {}", agent, e);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static List<String> getDeadAgents(final MasterModel masterModel, final long timeoutMillis,
+                                    final Clock clock) {
+    final List<String> deadAgents = Lists.newArrayList();
+    final List<String> agents = masterModel.listHosts();
+
+    for (final String agent : agents) {
+      try {
+        final HostStatus hostStatus = masterModel.getHostStatus(agent);
+        if (hostStatus == null || hostStatus.getStatus() != HostStatus.Status.DOWN) {
+          // Hot not found or host not DOWN -- nothing to do, move on to the next host
+          continue;
+        }
+
+        final AgentInfo agentInfo = hostStatus.getAgentInfo();
+        if (agentInfo == null) {
+          continue;
+        }
+
+        final long downSince = agentInfo.getStartTime() + agentInfo.getUptime();
+        final long downDurationMillis = clock.now().getMillis() - downSince;
+
+        if (downDurationMillis >= timeoutMillis) {
+          deadAgents.add(agent);
+        }
+      } catch (Exception e) {
+        log.warn("Failed to determine if agent '{}' should be reaped", agent, e);
+      }
+    }
+
+    return deadAgents;
+  }
+
+  @Override
+  protected ScheduledFuture<?> schedule(final Runnable runnable,
+                                        final ScheduledExecutorService executorService) {
+    return executorService.scheduleWithFixedDelay(runnable, 0, INTERVAL, INTERVAL_TIME_UNIT);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
@@ -52,6 +52,7 @@ public class MasterConfig extends Configuration {
   private String zooKeeperAclAgentDigest;
   private String zookeeperAclMasterUser;
   private String zooKeeperAclMasterPassword;
+  private long agentReapingTimeout;
 
   public String getDomain() {
     return domain;
@@ -249,5 +250,14 @@ public class MasterConfig extends Configuration {
   public MasterConfig setZookeeperAclAgentUser(final String zookeeperAclAgentUser) {
     this.zookeeperAclAgentUser = zookeeperAclAgentUser;
     return this;
+  }
+
+  public MasterConfig setAgentReapingTimeout(final long agentReapingTimeout) {
+    this.agentReapingTimeout = agentReapingTimeout;
+    return this;
+  }
+
+  public long getAgentReapingTimeout() {
+    return agentReapingTimeout;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -25,6 +25,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Parses command-line arguments to produce the {@link MasterConfig}.
@@ -39,6 +40,7 @@ public class MasterParser extends ServiceParser {
   private Argument adminArg;
   private Argument zkAclAgentDigest;
   private Argument zkAclMasterPassword;
+  private Argument agentReapingTimeout;
 
   public MasterParser(final String... args) throws ArgumentParserException {
     super("helios-master", "Spotify Helios Master", args);
@@ -73,7 +75,8 @@ public class MasterParser extends ServiceParser {
         .setAdminPort(options.getInt(adminArg.getDest()))
         .setHttpEndpoint(httpAddress)
         .setKafkaBrokers(getKafkaBrokers())
-        .setStateDirectory(getStateDirectory());
+        .setStateDirectory(getStateDirectory())
+        .setAgentReapingTimeout(options.getInt(agentReapingTimeout.getDest()));
 
     this.masterConfig = config;
   }
@@ -97,6 +100,12 @@ public class MasterParser extends ServiceParser {
         .help("ZooKeeper master password (for ZooKeeper ACLs). If the "
               + ZK_MASTER_PASSWORD_ENVVAR
               + " environment variable is present this argument is ignored.");
+
+    agentReapingTimeout = parser.addArgument("--agent-reaping-timeout")
+        .type(Integer.class)
+        .setDefault(TimeUnit.DAYS.toHours(14))
+        .help("In hours. Agents will be automatically de-registered if they are DOWN for more " +
+              "than the specified timeout.");
   }
 
   public MasterConfig getMasterConfig() {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -105,7 +105,7 @@ public class MasterParser extends ServiceParser {
         .type(Integer.class)
         .setDefault(TimeUnit.DAYS.toHours(14))
         .help("In hours. Agents will be automatically de-registered if they are DOWN for more " +
-              "than the specified timeout.");
+              "than the specified timeout. To disable reaping, set to 0.");
   }
 
   public MasterConfig getMasterConfig() {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -76,7 +76,7 @@ public class MasterParser extends ServiceParser {
         .setHttpEndpoint(httpAddress)
         .setKafkaBrokers(getKafkaBrokers())
         .setStateDirectory(getStateDirectory())
-        .setAgentReapingTimeout(options.getInt(agentReapingTimeout.getDest()));
+        .setAgentReapingTimeout(options.getLong(agentReapingTimeout.getDest()));
 
     this.masterConfig = config;
   }
@@ -102,7 +102,7 @@ public class MasterParser extends ServiceParser {
               + " environment variable is present this argument is ignored.");
 
     agentReapingTimeout = parser.addArgument("--agent-reaping-timeout")
-        .type(Integer.class)
+        .type(Long.class)
         .setDefault(TimeUnit.DAYS.toHours(14))
         .help("In hours. Agents will be automatically de-registered if they are DOWN for more " +
               "than the specified timeout. To disable reaping, set to 0.");

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -202,10 +202,9 @@ public class MasterService extends AbstractIdleService {
     final ReactorFactory reactorFactory = new ReactorFactory();
     this.rollingUpdateService = new RollingUpdateService(model, reactorFactory);
 
-    // Set up agent reaper (de-registering hosts that have been DOWN for more than X time)
+    // Set up agent reaper (de-registering hosts that have been DOWN for more than X hours)
     if (config.getAgentReapingTimeout() > 0) {
-      this.agentReaper = new DeadAgentReaper(
-          model, config.getAgentReapingTimeout(), TimeUnit.HOURS);
+      this.agentReaper = new DeadAgentReaper(model, config.getAgentReapingTimeout());
     } else {
       log.info("Reaping of dead agents disabled");
       this.agentReaper = null;

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -115,6 +115,7 @@ public class MasterService extends AbstractIdleService {
   private final CuratorClientFactory curatorClientFactory;
   private final RollingUpdateService rollingUpdateService;
   private final Map<String, String> environmentVariables;
+  private final DeadAgentReaper agentReaper;
 
   private ZooKeeperRegistrarService zkRegistrar;
 
@@ -200,6 +201,9 @@ public class MasterService extends AbstractIdleService {
     // Set up rolling update service
     final ReactorFactory reactorFactory = new ReactorFactory();
     this.rollingUpdateService = new RollingUpdateService(model, reactorFactory);
+
+    // Set up agent reaper (de-registering hosts that have been DOWN for more than X time)
+    this.agentReaper = new DeadAgentReaper(model, config.getAgentReapingTimeout(), TimeUnit.HOURS);
 
     // Set up http server
     environment.servlets()

--- a/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
@@ -105,11 +105,11 @@ public class DeadAgentReaperTest {
         masterModel, TIMEOUT_HOURS, clock);
     reaper.startAsync().awaitRunning();
 
-    verify(masterModel, timeout(5000)).listHosts();
+    verify(masterModel, timeout(5000).atLeastOnce()).listHosts();
 
     for (final Datapoint datapoint : datapoints) {
       if (datapoint.expectReap) {
-        verify(masterModel).deregisterHost(datapoint.host);
+        verify(masterModel, timeout(500)).deregisterHost(datapoint.host);
       }
     }
   }

--- a/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import com.spotify.helios.common.Clock;
+import com.spotify.helios.common.descriptors.AgentInfo;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.TaskStatus;
+
+import org.joda.time.Instant;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DeadAgentReaperTest {
+
+  private static  final long TIMEOUT_MILLIS = 1000;
+
+  private static class Datapoint {
+
+    private final String host;
+    private final long startTime;
+    private final long uptime;
+    private final HostStatus.Status status;
+    private final boolean expectReap;
+
+    private Datapoint(final String host, final long startTime, final long uptime,
+                      final HostStatus.Status status, final boolean expectReap) {
+      this.host = host;
+      this.startTime = startTime;
+      this.uptime = uptime;
+      this.status = status;
+      this.expectReap = expectReap;
+    }
+  }
+
+  @Test
+  public void testDeadAgentReaper() throws Exception {
+    final MasterModel masterModel = mock(MasterModel.class);
+    final Clock clock = mock(Clock.class);
+    // Current time is 2000 (ms)
+    when(clock.now()).thenReturn(new Instant(2000));
+
+    final List<Datapoint> datapoints = Lists.newArrayList(
+        new Datapoint("host1", 0, TIMEOUT_MILLIS - 1, HostStatus.Status.DOWN, true),
+        new Datapoint("host2", 0, TIMEOUT_MILLIS + 1, HostStatus.Status.DOWN, false),
+        new Datapoint("host3", 1000, 1000, HostStatus.Status.UP, false),
+        new Datapoint("host4", 500, 300, HostStatus.Status.DOWN, true),
+        new Datapoint("host5", 5000, 0, HostStatus.Status.DOWN, false),
+        new Datapoint("host6", 0, 0, HostStatus.Status.UP, false)
+    );
+
+    when(masterModel.listHosts()).thenReturn(Lists.newArrayList(
+        Iterables.transform(datapoints, new Function<Datapoint, String>() {
+          @Override
+          public String apply(final Datapoint input) {
+            return input.host;
+          }
+        })));
+
+    for (final Datapoint datapoint : datapoints) {
+      when(masterModel.getHostStatus(datapoint.host)).thenReturn(
+          HostStatus.newBuilder()
+              .setStatus(datapoint.status)
+              .setAgentInfo(AgentInfo.newBuilder()
+                                .setStartTime(datapoint.startTime)
+                                .setUptime(datapoint.uptime)
+                                .build())
+              .setJobs(Collections.<JobId, Deployment>emptyMap())
+              .setStatuses(Collections.<JobId, TaskStatus>emptyMap())
+              .build());
+    }
+
+    final List<String> expected = FluentIterable.from(datapoints)
+        .filter(new Predicate<Datapoint>() {
+          @Override
+          public boolean apply(final Datapoint input) {
+            return input.expectReap;
+          }
+        })
+        .transform(new Function<Datapoint, String>() {
+          @Override
+          public String apply(final Datapoint input) {
+            return input.host;
+          }
+        })
+        .toList();
+
+    assertThat(
+        DeadAgentReaper.getDeadAgents(masterModel, TIMEOUT_MILLIS, clock),
+        containsInAnyOrder(expected.toArray()));
+  }
+}


### PR DESCRIPTION
I.e. if agent A has job J deployed to it, and is then replaced by agent B
under the same name the B will also automatically get J deployed to it.

Previously, the automatic re-registration would fail if there were any
deployed jobs on the host being replaced -- which was the case almost all
of the time. With this in place, the automatic re-registration should
actually work. (History of any existing jobs will also be preserved.)