### PR TITLE
use bridge interface for http healthchecks

### DIFF
--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloHealthchecksIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloHealthchecksIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios;
+
+import com.spotify.helios.testing.HeliosDeploymentResource;
+import com.spotify.helios.testing.HeliosSoloDeployment;
+import com.spotify.helios.testing.TemporaryJobBuilder;
+import com.spotify.helios.testing.TemporaryJobs;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests that jobs with http and tcp healthchecks can be successfully deployed to helios-solo.
+ */
+public class HeliosSoloHealthchecksIT {
+
+  @Rule
+  public HeliosDeploymentResource solo = new HeliosDeploymentResource(
+      HeliosSoloDeployment.fromEnv()
+          .heliosSoloImage(Utils.soloImage())
+          .checkForNewImages(false)
+          .removeHeliosSoloOnExit(false)
+          .build()
+  );
+
+  @Rule
+  public TemporaryJobs jobs = TemporaryJobs.builder()
+      .client(solo.client())
+      .deployTimeoutMillis(TimeUnit.MINUTES.toMillis(1))
+      .build();
+
+  private final TemporaryJobBuilder nginx = jobs.job()
+      .image("nginx:1.9.9")
+      .port("http", 80);
+
+  @Test
+  public void testHttpHealthcheck() {
+    nginx.httpHealthCheck("http", "/")
+        .deploy();
+  }
+
+  @Test
+  public void testTcpHealthcheck() {
+    nginx.tcpHealthCheck("http")
+        .deploy();
+  }
+}

--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
 
@@ -80,6 +81,7 @@ public class HeliosSoloIT {
         .hostStatus(probe.hosts().get(0)).get();
     final Map<String, String> hostEnvironment = hostStatus.getEnvironment();
     final HostInfo hostInfo = hostStatus.getHostInfo();
+    Preconditions.checkNotNull(hostInfo);
     probe.undeploy();
 
     // get values from the agent environment
@@ -138,7 +140,7 @@ public class HeliosSoloIT {
       solo.volume("/var/run/docker.sock", dockerHost.replace("unix://", ""));
     }
 
-    // deploy the helios-solo job and create a Helios client for talking to it
+    // create a Helios client for talking to helios-solo
     final String masterEndpoint = "http://" + solo.deploy().address("helios").toString();
     soloClient = HeliosClient.newBuilder()
         .setEndpoints(masterEndpoint)

--- a/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
@@ -70,27 +70,32 @@ public class Utils {
     return out;
   }
 
-  public static String masterImage() throws IOException {
+  public static String masterImage() {
     final String path = System.getProperty("masterImage",
                                            DEFAULT_IMAGE_INFO_PATH + "master-image.json");
     return imageInfo(path);
   }
 
-  public static String agentImage() throws IOException {
+  public static String agentImage() {
     final String path = System.getProperty("agentImage",
                                            DEFAULT_IMAGE_INFO_PATH + "agent-image.json");
     return imageInfo(path);
   }
 
-  public static String soloImage() throws IOException {
+  public static String soloImage() {
     final String path = System.getProperty("soloImage",
                                            DEFAULT_IMAGE_INFO_PATH + "solo-image.json");
     return imageInfo(path);
   }
 
-  private static String imageInfo(final String path) throws IOException {
-    final String json = new String(Files.readAllBytes(Paths.get(path)));
-    final JsonNode node = Json.readTree(json);
+  private static String imageInfo(final String path) {
+    final JsonNode node;
+    try {
+      final String json = new String(Files.readAllBytes(Paths.get(path)));
+      node = Json.readTree(json);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
     final JsonNode imageNode = node.get("image");
     return (imageNode == null || imageNode.getNodeType() != STRING) ? null : imageNode.asText();
   }

--- a/helios-integration-tests/src/test/resources/Dockerfile
+++ b/helios-integration-tests/src/test/resources/Dockerfile
@@ -1,5 +1,0 @@
-# This generates an image which is used by TemporaryJobsITCase. The test needs dig and
-# netcat-traditional, so this will install the dnsutils and netcat-traditional packages.
-
-FROM ubuntu:14.04
-RUN apt-get update && apt-get install -y dnsutils netcat-traditional && update-alternatives --set nc /bin/nc.traditional


### PR DESCRIPTION
If the agent is using `unix://` to communicate with Docker, then the
`HttpHealthChecker` ends up using `localhost` as the host in the URL it
constructs to healthcheck the job.

When the agent is running in helios-solo (i.e. in a Docker container
itself), the agent uses the default `unix:///var/run/docker.sock` endpoint
to talk to Docker but a HTTP request to
`localhost:external-port` will not work as `localhost` refers to the
container itself.

In the scenario where docker.host is using the unix protocol, this change
will have the `HttpHealthChecker` instead use the bridge address of the
container to send it's healthcheck to.