### PR TITLE
upstart: Export the ZK password env vars

### DIFF
--- a/src/deb/helios-agent/upstart
+++ b/src/deb/helios-agent/upstart
@@ -28,6 +28,8 @@ end script
 script
   [ -f $DEFAULTFILE ] && . $DEFAULTFILE
   export HELIOS_AGENT_JVM_OPTS
+  export HELIOS_ZK_AGENT_PASSWORD
+
   exec /usr/bin/helios-agent $HELIOS_AGENT_OPTS
 end script
 

--- a/src/deb/helios-master/upstart
+++ b/src/deb/helios-master/upstart
@@ -27,6 +27,8 @@ end script
 script
   [ -f $DEFAULTFILE ] && . $DEFAULTFILE
   export HELIOS_MASTER_JVM_OPTS
+  export HELIOS_ZK_MASTER_PASSWORD
+
   exec /usr/bin/helios-master $HELIOS_MASTER_OPTS
 end script
 


### PR DESCRIPTION
If the `HELIOS_ZK_MASTER_PASSWORD` or `HELIOS_ZK_AGENT_PASSWORD` are set in
the defaults file, we want to export them to the Helios process.