### PR TITLE
helios-solo: use bridge interface for http healthchecks

### DIFF
--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloHealthchecksIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloHealthchecksIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios;
+
+import com.spotify.helios.testing.HeliosDeploymentResource;
+import com.spotify.helios.testing.HeliosSoloDeployment;
+import com.spotify.helios.testing.TemporaryJobBuilder;
+import com.spotify.helios.testing.TemporaryJobs;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests that jobs with http and tcp healthchecks can be successfully deployed to helios-solo.
+ */
+public class HeliosSoloHealthchecksIT {
+
+  @Rule
+  public HeliosDeploymentResource solo = new HeliosDeploymentResource(
+      HeliosSoloDeployment.fromEnv()
+          .heliosSoloImage(Utils.soloImage())
+          .checkForNewImages(false)
+          .removeHeliosSoloOnExit(false)
+          .build()
+  );
+
+  @Rule
+  public TemporaryJobs jobs = TemporaryJobs.builder()
+      .client(solo.client())
+      .deployTimeoutMillis(TimeUnit.MINUTES.toMillis(1))
+      .build();
+
+  private final TemporaryJobBuilder nginx = jobs.job()
+      .image("nginx:1.9.9")
+      .port("http", 80);
+
+  @Test
+  public void testHttpHealthcheck() {
+    nginx.httpHealthCheck("http", "/")
+        .deploy();
+  }
+
+  @Test
+  public void testTcpHealthcheck() {
+    nginx.tcpHealthCheck("http")
+        .deploy();
+  }
+}

--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.net.HostAndPort;
 
@@ -80,6 +81,7 @@ public class HeliosSoloIT {
         .hostStatus(probe.hosts().get(0)).get();
     final Map<String, String> hostEnvironment = hostStatus.getEnvironment();
     final HostInfo hostInfo = hostStatus.getHostInfo();
+    Preconditions.checkNotNull(hostInfo);
     probe.undeploy();
 
     // get values from the agent environment
@@ -138,7 +140,7 @@ public class HeliosSoloIT {
       solo.volume("/var/run/docker.sock", dockerHost.replace("unix://", ""));
     }
 
-    // deploy the helios-solo job and create a Helios client for talking to it
+    // create a Helios client for talking to helios-solo
     final String masterEndpoint = "http://" + solo.deploy().address("helios").toString();
     soloClient = HeliosClient.newBuilder()
         .setEndpoints(masterEndpoint)

--- a/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
@@ -70,27 +70,32 @@ public class Utils {
     return out;
   }
 
-  public static String masterImage() throws IOException {
+  public static String masterImage() {
     final String path = System.getProperty("masterImage",
                                            DEFAULT_IMAGE_INFO_PATH + "master-image.json");
     return imageInfo(path);
   }
 
-  public static String agentImage() throws IOException {
+  public static String agentImage() {
     final String path = System.getProperty("agentImage",
                                            DEFAULT_IMAGE_INFO_PATH + "agent-image.json");
     return imageInfo(path);
   }
 
-  public static String soloImage() throws IOException {
+  public static String soloImage() {
     final String path = System.getProperty("soloImage",
                                            DEFAULT_IMAGE_INFO_PATH + "solo-image.json");
     return imageInfo(path);
   }
 
-  private static String imageInfo(final String path) throws IOException {
-    final String json = new String(Files.readAllBytes(Paths.get(path)));
-    final JsonNode node = Json.readTree(json);
+  private static String imageInfo(final String path) {
+    final JsonNode node;
+    try {
+      final String json = new String(Files.readAllBytes(Paths.get(path)));
+      node = Json.readTree(json);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
     final JsonNode imageNode = node.get("image");
     return (imageNode == null || imageNode.getNodeType() != STRING) ? null : imageNode.asText();
   }

--- a/helios-integration-tests/src/test/resources/Dockerfile
+++ b/helios-integration-tests/src/test/resources/Dockerfile
@@ -1,5 +1,0 @@
-# This generates an image which is used by TemporaryJobsITCase. The test needs dig and
-# netcat-traditional, so this will install the dnsutils and netcat-traditional packages.
-
-FROM ubuntu:14.04
-RUN apt-get update && apt-get install -y dnsutils netcat-traditional && update-alternatives --set nc /bin/nc.traditional

--- a/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
@@ -57,12 +57,16 @@ public final class HealthCheckerFactory {
     } else if (healthCheck instanceof ExecHealthCheck) {
       return new ExecHealthChecker((ExecHealthCheck) healthCheck, docker);
     } else if (healthCheck instanceof HttpHealthCheck) {
-      return new HttpHealthChecker((HttpHealthCheck) healthCheck, taskConfig, dockerHost);
+      return new HttpHealthChecker((HttpHealthCheck) healthCheck, taskConfig, docker, dockerHost);
     } else if (healthCheck instanceof TcpHealthCheck) {
       return new TcpHealthChecker((TcpHealthCheck) healthCheck, taskConfig, docker, dockerHost);
     }
 
     throw new IllegalArgumentException("Unknown healthCheck type");
+  }
+
+  private static boolean isHeliosSolo() {
+    return "true".equals(System.getProperty("helios.solo"));
   }
 
   static class ExecHealthChecker implements HealthChecker {
@@ -138,7 +142,20 @@ public final class HealthCheckerFactory {
     }
   }
 
-  private static class HttpHealthChecker implements HealthChecker {
+  private abstract static class NetworkHealthchecker implements HealthChecker {
+    private final DockerClient dockerClient;
+
+    protected NetworkHealthchecker(final DockerClient dockerClient) {
+      this.dockerClient = dockerClient;
+    }
+
+    protected String getBridgeAddress(String containerId)
+        throws DockerException, InterruptedException {
+      return dockerClient.inspectContainer(containerId).networkSettings().gateway();
+    }
+  }
+
+  private static class HttpHealthChecker extends NetworkHealthchecker {
 
     private static final Logger log = LoggerFactory.getLogger(HttpHealthChecker.class);
 
@@ -151,7 +168,8 @@ public final class HealthCheckerFactory {
     private final DockerHost dockerHost;
 
     private HttpHealthChecker(final HttpHealthCheck healthCheck, final TaskConfig taskConfig,
-                              final DockerHost dockerHost) {
+                              final DockerClient dockerClient, final DockerHost dockerHost) {
+      super(dockerClient);
       this.healthCheck = healthCheck;
       this.taskConfig = taskConfig;
       this.dockerHost = dockerHost;
@@ -159,11 +177,24 @@ public final class HealthCheckerFactory {
 
     @Override
     public boolean check(final String containerId) throws InterruptedException, DockerException {
-      final Integer port = taskConfig.ports().get(healthCheck.getPort()).getExternalPort();
+
+      final String host;
+      // Special case for running the agent inside helios-solo and DOCKER_HOST is a unix socket:
+      // in this case we cannot reach the job's container with "localhost" at the external port
+      // since "localhost" will refer to the agent's container and it's network namespace.
+      // The agent is only run in a container sibling to the job's container when in helios-solo.
+      if (isHeliosSolo() && dockerHost.host().startsWith("unix://")) {
+        host = getBridgeAddress(containerId);
+        log.info("Using bridge address {} for healthchecks", host);
+      } else {
+        host = dockerHost.address();
+      }
 
       final URL url;
+      // TODO (mbrown): is port always non-null? it is unconditionally unboxed on the next line
+      final Integer port = taskConfig.ports().get(healthCheck.getPort()).getExternalPort();
       try {
-        url = new URL("http", dockerHost.address(), port, healthCheck.getPath());
+        url = new URL("http", host, port, healthCheck.getPath());
       } catch (MalformedURLException e) {
         throw Throwables.propagate(e);
       }
@@ -185,9 +216,10 @@ public final class HealthCheckerFactory {
         return false;
       }
     }
+
   }
 
-  private static class TcpHealthChecker implements HealthChecker {
+  private static class TcpHealthChecker extends NetworkHealthchecker {
 
     private static final Logger log = LoggerFactory.getLogger(TcpHealthChecker.class);
 
@@ -195,15 +227,14 @@ public final class HealthCheckerFactory {
 
     private final TcpHealthCheck healthCheck;
     private final TaskConfig taskConfig;
-    private final DockerClient docker;
     private final DockerHost dockerHost;
 
 
     private TcpHealthChecker(final TcpHealthCheck healthCheck, final TaskConfig taskConfig,
                              final DockerClient docker, final DockerHost dockerHost) {
+      super(docker);
       this.healthCheck = healthCheck;
       this.taskConfig = taskConfig;
-      this.docker = docker;
       this.dockerHost = dockerHost;
     }
 
@@ -215,8 +246,7 @@ public final class HealthCheckerFactory {
       if (address.getAddress().isLoopbackAddress()) {
         // tcp connections to a container-mapped port on loopback always succeed,
         // regardless of if the container is listening or not. use the bridge address instead.
-        final String bridge = docker.inspectContainer(containerId).networkSettings().gateway();
-        address = new InetSocketAddress(bridge, port);
+        address = new InetSocketAddress(getBridgeAddress(containerId), port);
       }
 
       log.info("about to healthcheck containerId={} with address={} for task={}",

--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -32,7 +32,6 @@ cd /agent
 java -cp '/*' \
 -Xmx128m \
 -Djava.net.preferIPv4Stack=true \
--Dhelios.solo=true \
 com.spotify.helios.agent.AgentMain \
 --name ${HELIOS_NAME} \
 --service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
@@ -73,7 +72,6 @@ cd /master
 java -cp '/*' \
 -Xmx128m \
 -Djava.net.preferIPv4Stack=true \
--Dhelios.solo=true \
 com.spotify.helios.master.MasterMain \
 --service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
 --domain '' \

--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -32,6 +32,7 @@ cd /agent
 java -cp '/*' \
 -Xmx128m \
 -Djava.net.preferIPv4Stack=true \
+-Dhelios.solo=true \
 com.spotify.helios.agent.AgentMain \
 --name ${HELIOS_NAME} \
 --service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
@@ -72,6 +73,7 @@ cd /master
 java -cp '/*' \
 -Xmx128m \
 -Djava.net.preferIPv4Stack=true \
+-Dhelios.solo=true \
 com.spotify.helios.master.MasterMain \
 --service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
 --domain '' \


### PR DESCRIPTION
If the agent is using `unix://` to communicate with Docker, then the
`HttpHealthChecker` ends up using `localhost` as the host in the URL it
constructs to healthcheck the job.

When the agent is running in helios-solo (i.e. in a Docker container
itself), the agent uses the default `unix:///var/run/docker.sock` endpoint
to talk to Docker but a HTTP request to
`localhost:external-port` will not work as `localhost` refers to the
container itself.

In the scenario where the agent is running in helios-solo *and* docker.host
is using the unix protocol, this change will have the
`HttpHealthChecker` instead use the bridge address of the container to send
it's healthcheck to.

In order for the agent to know if it is running within helios-solo, added a
system property in the helios-solo startup script. This property is also
enabled for the master as well in case it is needed in the future.

This is a tweak of #828 so that the logic to use the bridge interface is only applied when using helios-solo.