### PR TITLE
fix logging of exception when loading AgentProxy

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -615,7 +615,7 @@ public class HeliosClient implements Closeable {
         // the user likely doesn't have ssh-agent setup. This may not matter at all if the masters
         // do not require authentication, so we delay reporting any sort of error to the user until
         // the servers return 401 Unauthorized.
-        log.debug("{}", e);
+        log.debug("Exception (possibly benign) while loading AgentProxy", e);
       }
 
       // set up the ClientCertificatePath, giving precedence to any values set


### PR DESCRIPTION
The current log message ends up logged as:

```
15:45:51.632 [main] DEBUG c.spotify.helios.client.HeliosClient - {}
java.lang.RuntimeException: The environment variable SSH_AUTH_SOCK is not set. Please configure your ssh-agent.
    at com.spotify.sshagentproxy.AgentProxies$DefaultAgentProxy.fromEnvironmentVariable(AgentProxies.java:61) ~[ssh-agent-proxy-0.1.4.jar:na]
```

When the last argument is a Throwable, slf4j doesn't treat it as a
parameter in the message so `{}` is logged by itself.