### PR TITLE
fix occasional NullPointerException in DefaultDeployer

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
@@ -24,6 +24,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 
 import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.HostStatus.Status;
 import com.spotify.helios.common.descriptors.Job;
 
@@ -107,7 +108,8 @@ public class DefaultDeployer implements Deployer {
     while (true) {
       final String candidateHost = hostPicker.pickHost(mutatedList);
       try {
-        if (Status.UP == client.hostStatus(candidateHost).get().getStatus()) {
+        final HostStatus hostStatus = client.hostStatus(candidateHost).get();
+        if (hostStatus != null && Status.UP == hostStatus.getStatus()) {
           return candidateHost;
         } 
         mutatedList.remove(candidateHost);


### PR DESCRIPTION
For currently unknown reasons, occasionally
`client.hostStatus(candidateHost)` will return a completed
ListenableFuture with a `null` value when called by DefaultDeployer
(which HeliosClient does when the host doesn't exist). It's not clear
why the host would have `null` status when a few lines earlier the host
was retrieved from `client.hosts()`.

But in any case, this fixes the NPE that occurs when this happens.