### PR TITLE
add a FastForward metrics reporter

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -234,10 +234,6 @@
       <version>4.1.1</version>
     </dependency>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
       <version>3.8.0.Final</version>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -229,6 +229,11 @@
       <version>4.5.1</version>
     </dependency>
     <dependency>
+      <groupId>eu.toolchain.ffwd</groupId>
+      <artifactId>ffwd-client</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>net.kencochrane.raven</groupId>
       <artifactId>raven-logback</artifactId>
       <version>4.1.1</version>

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -18,6 +18,7 @@
 package com.spotify.helios.agent;
 
 import com.spotify.docker.client.DockerHost;
+import com.spotify.helios.servicescommon.FastForwardConfig;
 
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
@@ -63,6 +64,7 @@ public class AgentConfig extends Configuration {
   private String zooKeeperAclMasterDigest;
   private String zookeeperAclAgentUser;
   private String zooKeeperAclAgentPassword;
+  private FastForwardConfig fastForwardConfig;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -344,6 +346,15 @@ public class AgentConfig extends Configuration {
 
   public AgentConfig setZookeeperAclAgentUser(final String zookeeperAclAgentUser) {
     this.zookeeperAclAgentUser = zookeeperAclAgentUser;
+    return this;
+  }
+
+  public FastForwardConfig getFfwdConfig() {
+    return this.fastForwardConfig;
+  }
+
+  public AgentConfig setFfwdConfig(FastForwardConfig config) {
+    this.fastForwardConfig = config;
     return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -135,7 +135,8 @@ public class AgentParser extends ServiceParser {
         .setHttpEndpoint(httpAddress)
         .setNoHttp(options.getBoolean(noHttpArg.getDest()))
         .setKafkaBrokers(getKafkaBrokers())
-        .setLabels(labels);
+        .setLabels(labels)
+        .setFfwdConfig(ffwdConfig(options));
 
     final String explicitId = options.getString(agentIdArg.getDest());
     if (explicitId != null) {

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -178,7 +178,7 @@ public class AgentService extends AbstractIdleService implements Managed {
       metrics = new NoopMetrics();
     } else {
       log.info("Starting metrics");
-      metrics = new MetricsImpl(metricsRegistry);
+      metrics = new MetricsImpl(metricsRegistry, MetricsImpl.Type.AGENT);
       environment.lifecycle().manage(riemannSupport);
       if (!Strings.isNullOrEmpty(config.getStatsdHostPort())) {
         environment.lifecycle().manage(new ManagedStatsdReporter(config.getStatsdHostPort(),

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -176,9 +177,11 @@ public class AgentService extends AbstractIdleService implements Managed {
     } else {
       log.info("Starting metrics");
       metrics = new MetricsImpl(metricsRegistry);
-      environment.lifecycle().manage(new ManagedStatsdReporter(config.getStatsdHostPort(),
-          "helios-agent", metricsRegistry));
       environment.lifecycle().manage(riemannSupport);
+      if (!Strings.isNullOrEmpty(config.getStatsdHostPort())) {
+        environment.lifecycle().manage(new ManagedStatsdReporter(config.getStatsdHostPort(),
+                                                                 metricsRegistry));
+      }
     }
 
     // This CountDownLatch will signal EnvironmentVariableReporter and LabelReporter when to report

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -169,7 +169,7 @@ public class AgentService extends AbstractIdleService implements Managed {
     }
 
     // Configure metrics
-    final MetricRegistry metricsRegistry = new MetricRegistry();
+    final MetricRegistry metricsRegistry = environment.metrics();
     RiemannSupport riemannSupport = new RiemannSupport(metricsRegistry, config.getRiemannHostPort(),
                                                        config.getName(), "helios-agent");
     final RiemannFacade riemannFacade = riemannSupport.getFacade();

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.master;
 
+import com.spotify.helios.servicescommon.FastForwardConfig;
+
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.List;
@@ -53,6 +55,7 @@ public class MasterConfig extends Configuration {
   private String zookeeperAclMasterUser;
   private String zooKeeperAclMasterPassword;
   private long agentReapingTimeout;
+  private FastForwardConfig fastForwardConfig;
 
   public String getDomain() {
     return domain;
@@ -259,5 +262,14 @@ public class MasterConfig extends Configuration {
 
   public long getAgentReapingTimeout() {
     return agentReapingTimeout;
+  }
+
+  public FastForwardConfig getFfwdConfig() {
+    return this.fastForwardConfig;
+  }
+
+  public MasterConfig setFfwdConfig(FastForwardConfig config) {
+    this.fastForwardConfig = config;
+    return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -76,7 +76,8 @@ public class MasterParser extends ServiceParser {
         .setHttpEndpoint(httpAddress)
         .setKafkaBrokers(getKafkaBrokers())
         .setStateDirectory(getStateDirectory())
-        .setAgentReapingTimeout(options.getLong(agentReapingTimeout.getDest()));
+        .setAgentReapingTimeout(options.getLong(agentReapingTimeout.getDest()))
+        .setFfwdConfig(ffwdConfig(options));
 
     this.masterConfig = config;
   }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -140,8 +140,7 @@ public class MasterService extends AbstractIdleService {
     this.environmentVariables = environmentVariables;
 
     // Configure metrics
-    // TODO (dano): do something with the riemann facade
-    final MetricRegistry metricsRegistry = new MetricRegistry();
+    final MetricRegistry metricsRegistry = environment.metrics();
     final RiemannSupport riemannSupport = new RiemannSupport(metricsRegistry,
         config.getRiemannHostPort(), config.getName(), "helios-master");
     final RiemannFacade riemannFacade = riemannSupport.getFacade();

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -39,6 +39,7 @@ import com.spotify.helios.master.resources.VersionResource;
 import com.spotify.helios.rollingupdate.RollingUpdateService;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
+import com.spotify.helios.servicescommon.FastForwardConfig;
 import com.spotify.helios.servicescommon.KafkaClientProvider;
 import com.spotify.helios.servicescommon.KafkaSender;
 import com.spotify.helios.servicescommon.ManagedStatsdReporter;
@@ -55,6 +56,7 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperHealthChecker;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperModelReporter;
+import com.spotify.helios.servicescommon.statistics.FastForwardReporter;
 import com.spotify.helios.servicescommon.statistics.Metrics;
 import com.spotify.helios.servicescommon.statistics.MetricsImpl;
 import com.spotify.helios.servicescommon.statistics.NoopMetrics;
@@ -154,6 +156,16 @@ public class MasterService extends AbstractIdleService {
       if (!Strings.isNullOrEmpty(config.getStatsdHostPort())) {
         environment.lifecycle().manage(new ManagedStatsdReporter(config.getStatsdHostPort(),
                                                                  metricsRegistry));
+      }
+
+      final FastForwardConfig ffwdConfig = config.getFfwdConfig();
+      if (ffwdConfig != null) {
+        environment.lifecycle().manage(FastForwardReporter.create(
+            metricsRegistry,
+            ffwdConfig.getAddress(),
+            ffwdConfig.getMetricKey(),
+            ffwdConfig.getReportingIntervalSeconds())
+        );
       }
     }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.master;
 
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -150,8 +151,10 @@ public class MasterService extends AbstractIdleService {
       metrics = new MetricsImpl(metricsRegistry);
       metrics.start();
       environment.lifecycle().manage(riemannSupport);
-      environment.lifecycle().manage(new ManagedStatsdReporter(config.getStatsdHostPort(),
-          "helios-master", metricsRegistry));
+      if (!Strings.isNullOrEmpty(config.getStatsdHostPort())) {
+        environment.lifecycle().manage(new ManagedStatsdReporter(config.getStatsdHostPort(),
+                                                                 metricsRegistry));
+      }
     }
 
     // Set up the master model

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -150,7 +150,7 @@ public class MasterService extends AbstractIdleService {
     if (config.isInhibitMetrics()) {
       metrics = new NoopMetrics();
     } else {
-      metrics = new MetricsImpl(metricsRegistry);
+      metrics = new MetricsImpl(metricsRegistry, MetricsImpl.Type.MASTER);
       metrics.start();
       environment.lifecycle().manage(riemannSupport);
       if (!Strings.isNullOrEmpty(config.getStatsdHostPort())) {

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/FastForwardConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/FastForwardConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.servicescommon;
+
+import com.google.common.net.HostAndPort;
+
+import java.util.Optional;
+
+public class FastForwardConfig {
+
+  private final Optional<HostAndPort> address;
+  private final int intervalSeconds;
+  private final String key;
+
+  public FastForwardConfig(Optional<String> address, int intervalSeconds, String key) {
+    this.address = address.map(HostAndPort::fromString);
+    this.intervalSeconds = intervalSeconds;
+    this.key = key;
+  }
+
+  /** connection address, empty means use default */
+  public Optional<HostAndPort> getAddress() {
+    return address;
+  }
+
+  public int getReportingIntervalSeconds() {
+    return intervalSeconds;
+  }
+
+  public String getMetricKey() {
+    return key;
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/ManagedStatsdReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/ManagedStatsdReporter.java
@@ -17,16 +17,16 @@
 
 package com.spotify.helios.servicescommon;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 
+import com.codahale.metrics.MetricRegistry;
 import com.readytalk.metrics.StatsDReporter;
 
-import io.dropwizard.lifecycle.Managed;
-
-import com.codahale.metrics.MetricRegistry;
-
 import java.util.List;
+
+import io.dropwizard.lifecycle.Managed;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -37,12 +37,9 @@ public class ManagedStatsdReporter implements Managed {
 
   private final StatsDReporter statsdReporter;
 
-  public ManagedStatsdReporter(final String endpoint, final String name,
-                               final MetricRegistry registry) {
-    if (Strings.isNullOrEmpty(endpoint)) {
-      statsdReporter = null;
-      return;
-    }
+  public ManagedStatsdReporter(final String endpoint, final MetricRegistry registry) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(endpoint));
+
     final List<String> parts = Splitter.on(":").splitToList(endpoint);
     checkArgument(parts.size() == 2, "Specification of statsd host port has wrong number of " +
                                      "parts. Should be host:port");
@@ -53,15 +50,11 @@ public class ManagedStatsdReporter implements Managed {
 
   @Override
   public void start() throws Exception {
-    if (statsdReporter != null) {
-      statsdReporter.start(POLL_INTERVAL_SECONDS, SECONDS);
-    }
+    statsdReporter.start(POLL_INTERVAL_SECONDS, SECONDS);
   }
 
   @Override
   public void stop() throws Exception {
-    if (statsdReporter != null) {
-      statsdReporter.close();
-    }
+    statsdReporter.close();
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
@@ -28,6 +28,7 @@ import com.codahale.metrics.Metered;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
+import com.spotify.helios.common.Version;
 
 import eu.toolchain.ffwd.FastForward;
 import eu.toolchain.ffwd.Metric;
@@ -99,8 +100,8 @@ public class FastForwardReporter implements Managed {
   private final TimeUnit intervalTimeUnit;
 
   FastForwardReporter(FastForward fastForward, MetricRegistry metricRegistry,
-                             ScheduledExecutorService executor, String key,
-                             long interval, TimeUnit intervalTimeUnit) {
+                      ScheduledExecutorService executor, String key,
+                      long interval, TimeUnit intervalTimeUnit) {
     this.fastForward = fastForward;
     this.metricRegistry = metricRegistry;
     this.executor = executor;
@@ -192,8 +193,9 @@ public class FastForwardReporter implements Managed {
 
   private Metric createMetric(String metricName, String metricType) {
     return FastForward.metric(key)
-        .attribute("what", metricName)
-        .attribute("metric_type", metricType);
+        .attribute("helios_version", Version.POM_VERSION)
+        .attribute("metric_type", metricType)
+        .attribute("what", metricName);
   }
 
   private double convert(Object value) {

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.servicescommon.statistics;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -118,7 +119,7 @@ public class FastForwardReporter implements Managed {
     // wrap the runnable in a try-catch as uncaught exceptions will prevent subsequent executions
     executor.scheduleAtFixedRate(() -> {
       try {
-        report();
+        reportOnce();
       } catch (Exception e) {
         log.error("Exception in reporting loop", e);
       }
@@ -130,7 +131,8 @@ public class FastForwardReporter implements Managed {
     executor.shutdown();
   }
 
-  private void report() {
+  @VisibleForTesting
+  void reportOnce() {
     metricRegistry.getGauges().forEach(this::reportGauge);
 
     metricRegistry.getCounters().forEach(this::reportCounter);

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.servicescommon.statistics;
+
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+import eu.toolchain.ffwd.FastForward;
+import eu.toolchain.ffwd.Metric;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import io.dropwizard.lifecycle.Managed;
+
+/**
+ * Sends the metrics in a v3 MetricRegistry to
+ * <a href="https://github.com/spotify/ffwd">FastForward</a>.
+ *
+ * <p>The String "name" of the Metric is sent as the 'what' attribute in the FastForward metric. No
+ * translation of the (possibly long, Java classname-ish) name is done. The type of metric is
+ * included in the 'metric_type' attribute.</p>
+ *
+ * <p>For meters, timers, and histograms, the various component values of the
+ * com.codahale.metrics.Metric (m1/m5/m15, p50, p99 etc) are sent as individual {@link Metric}
+ * instances. The 'stat' attribute is filled out with the corresponding statistic. </p>
+ *
+ * <p>Note that not every statistic from Meters/Timers/Histograms is sent to FastForward in order
+ * to limit the amount of data being sent and needing to be stored downstream. For Metered
+ * instances, only 1m and 5m is sent. For Histograms, just median, p75 and p99 (plus
+ * min/max/mean/stddev).
+ * </p>
+ */
+public class FastForwardReporter implements Managed {
+
+  private static final Logger log = LoggerFactory.getLogger(FastForwardReporter.class);
+
+  public static FastForwardReporter create(MetricRegistry registry, Optional<HostAndPort> address,
+                                           String metricKey, int intervalSeconds)
+      throws SocketException, UnknownHostException {
+
+    final FastForward ff;
+    if (address.isPresent()) {
+      ff = FastForward.setup(address.get().getHostText(), address.get().getPort());
+    } else {
+      ff = FastForward.setup();
+    }
+
+    final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setDaemon(true)
+        .setNameFormat("fast-forward-reporter-%d")
+        .build();
+
+    final ScheduledExecutorService executorService =
+        Executors.newSingleThreadScheduledExecutor(threadFactory);
+
+    return new FastForwardReporter(ff, registry, executorService, metricKey, intervalSeconds,
+                                   TimeUnit.SECONDS);
+  }
+
+  private final FastForward fastForward;
+  private final MetricRegistry metricRegistry;
+  private final ScheduledExecutorService executor;
+  private final String key;
+  private final long interval;
+  private final TimeUnit intervalTimeUnit;
+
+  public FastForwardReporter(FastForward fastForward, MetricRegistry metricRegistry,
+                             ScheduledExecutorService executor, String key,
+                             long interval, TimeUnit intervalTimeUnit) {
+    this.fastForward = fastForward;
+    this.metricRegistry = metricRegistry;
+    this.executor = executor;
+    this.key = key;
+    this.interval = interval;
+    this.intervalTimeUnit = intervalTimeUnit;
+  }
+
+  @Override
+  public void start() throws Exception {
+    log.info("Scheduling reporting of metrics every {} {}",
+             interval, intervalTimeUnit.name().toLowerCase());
+
+    // wrap the runnable in a try-catch as uncaught exceptions will prevent subsequent executions
+    executor.scheduleAtFixedRate(() -> {
+      try {
+        report();
+      } catch (Exception e) {
+        log.error("Exception in reporting loop", e);
+      }
+    }, interval, interval, intervalTimeUnit);
+  }
+
+  @Override
+  public void stop() throws Exception {
+    executor.shutdown();
+  }
+
+  private void report() {
+    metricRegistry.getGauges().forEach(this::reportGauge);
+
+    metricRegistry.getCounters().forEach(this::reportCounter);
+
+    metricRegistry.getMeters().forEach(this::reportMeter);
+
+    metricRegistry.getHistograms().forEach(this::reportHistogram);
+
+    metricRegistry.getTimers().forEach(this::reportTimer);
+  }
+
+  private void reportGauge(String name, Gauge gauge) {
+    final Metric metric = createMetric(name, "gauge")
+        .value(convert(gauge.getValue()));
+    send(metric);
+  }
+
+  private void reportCounter(String name, Counter counter) {
+    final Metric metric = createMetric(name, "counter")
+        .value(counter.getCount());
+    send(metric);
+  }
+
+  private void reportMeter(String name, Meter meter) {
+    final Metric metric = createMetric(name, "meter")
+        .attribute("unit", "n/s");
+
+    reportMetered(metric, meter);
+  }
+
+  private void reportMetered(Metric metric, Metered metered) {
+    //purposefully don't emit 15m as it is not very useful
+    send(metric.attribute("stat", "1m").value(metered.getOneMinuteRate()));
+    send(metric.attribute("stat", "5m").value(metered.getOneMinuteRate()));
+  }
+
+  private void reportHistogram(String name, Histogram histogram) {
+    final Metric metric = createMetric(name, "histogram");
+    reportHistogram(metric, histogram.getSnapshot());
+  }
+
+  private void reportHistogram(Metric metric, Snapshot snapshot) {
+    send(metric.attribute("stat", "min").value(snapshot.getMin()));
+    send(metric.attribute("stat", "max").value(snapshot.getMax()));
+    send(metric.attribute("stat", "mean").value(snapshot.getMean()));
+    send(metric.attribute("stat", "stddev").value(snapshot.getStdDev()));
+
+    send(metric.attribute("stat", "median").value(snapshot.getMedian()));
+    send(metric.attribute("stat", "p75").value(snapshot.get75thPercentile()));
+    send(metric.attribute("stat", "p99").value(snapshot.get99thPercentile()));
+  }
+
+  private void reportTimer(String name, Timer timer) {
+    final Metric metric = createMetric(name, "timer")
+        .attribute("unit", "ns");
+
+    reportHistogram(metric, timer.getSnapshot());
+    reportMetered(metric, timer);
+  }
+
+  private Metric createMetric(String metricName, String metricType) {
+    return FastForward.metric(key)
+        .attribute("what", metricName)
+        .attribute("metric_type", metricType);
+  }
+
+  private double convert(Object value) {
+    if (value instanceof Number) {
+      return Number.class.cast(value).doubleValue();
+    }
+
+    if (value instanceof Boolean) {
+      return (Boolean) value ? 1 : 0;
+    }
+
+    return 0;
+  }
+
+  private void send(Metric metric) {
+    try {
+      fastForward.send(metric);
+    } catch (IOException e) {
+      log.error("Error sending metric to FastForward", e);
+    }
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
@@ -98,7 +98,7 @@ public class FastForwardReporter implements Managed {
   private final long interval;
   private final TimeUnit intervalTimeUnit;
 
-  public FastForwardReporter(FastForward fastForward, MetricRegistry metricRegistry,
+  FastForwardReporter(FastForward fastForward, MetricRegistry metricRegistry,
                              ScheduledExecutorService executor, String key,
                              long interval, TimeUnit intervalTimeUnit) {
     this.fastForward = fastForward;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/MetricsImpl.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/MetricsImpl.java
@@ -22,6 +22,10 @@ import com.codahale.metrics.MetricRegistry;
 
 public class MetricsImpl implements Metrics {
 
+  public enum Type {
+    MASTER, AGENT
+  }
+
   private static final String GROUP = "helios";
 
   private final SupervisorMetrics supervisorMetrics;
@@ -29,9 +33,14 @@ public class MetricsImpl implements Metrics {
   private final ZooKeeperMetrics zooKeeperMetrics;
   private final JmxReporter jmxReporter;
 
-  public MetricsImpl(final MetricRegistry registry) {
-    this.masterMetrics = new MasterMetricsImpl(GROUP, registry);
-    this.supervisorMetrics = new SupervisorMetricsImpl(GROUP, registry);
+  public MetricsImpl(final MetricRegistry registry, final Type type) {
+    // MasterMetrics is only for masters, and SupervisorMetrics only for agents
+    this.masterMetrics = type == Type.MASTER ? new MasterMetricsImpl(GROUP, registry)
+                                             : new NoopMasterMetrics();
+
+    this.supervisorMetrics = type == Type.AGENT ? new SupervisorMetricsImpl(GROUP, registry)
+                                                : new NoopSupervisorMetrics();
+
     this.zooKeeperMetrics = new ZooKeeperMetricsImpl(GROUP, registry);
     this.jmxReporter = JmxReporter.forRegistry(registry).build();
   }

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/statistics/FastForwardReporterTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/statistics/FastForwardReporterTest.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
+import com.spotify.helios.common.Version;
 
 import eu.toolchain.ffwd.FastForward;
 import eu.toolchain.ffwd.Metric;
@@ -211,5 +212,14 @@ public class FastForwardReporterTest {
 
     verifyHistogramStats("blah-timer", "timer");
     verifyMeterStats("blah-timer", "timer");
+  }
+
+  @Test
+  public void testAttributesIncludeHeliosVersion() throws Exception {
+    metricRegistry.register("something", (Gauge<Integer>) () -> 1);
+
+    reporter.start();
+
+    verify().send(argThat(containsAttributes("helios_version", Version.POM_VERSION)));
   }
 }

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/statistics/FastForwardReporterTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/statistics/FastForwardReporterTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.servicescommon.statistics;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+
+import eu.toolchain.ffwd.FastForward;
+import eu.toolchain.ffwd.Metric;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+
+public class FastForwardReporterTest {
+
+  private static final int REPORTING_INTERVAL_MILLIS = 10;
+  private static final int VERIFY_TIMEOUT = REPORTING_INTERVAL_MILLIS * 2;
+
+  private final FastForward ffwd = mock(FastForward.class);
+  private final MetricRegistry metricRegistry = new MetricRegistry();
+
+  private FastForwardReporter reporter;
+
+  @Before
+  public void setUp() throws Exception {
+    final ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true).build();
+
+    final ScheduledExecutorService executor =
+        Executors.newSingleThreadScheduledExecutor(threadFactory);
+
+    this.reporter = new FastForwardReporter(ffwd, metricRegistry, executor, "helios.test",
+                                            REPORTING_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    reporter.stop();
+  }
+
+  // shortcut to Mockito.verify(ffwd, timeout(..).times(..))...
+  private FastForward verify() {
+    return Mockito.verify(ffwd, timeout(VERIFY_TIMEOUT).atLeastOnce());
+  }
+
+  /**
+   * A matcher that matches when the actual object contains all of the given attributes
+   * (note that the reverse isn't necessarily true; this is a partial matcher).
+   */
+  private static CustomTypeSafeMatcher<Metric> containsAttributes(Map<String, String> attributes) {
+
+    final String description = String.format("a metric containing attributes=%s", attributes);
+
+    return new CustomTypeSafeMatcher<Metric>(description) {
+      @Override
+      protected boolean matchesSafely(final Metric item) {
+        return item.getAttributes().entrySet().containsAll(attributes.entrySet());
+      }
+    };
+  }
+
+  private static CustomTypeSafeMatcher<Metric> containsAttributes(String... strings) {
+    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    for (int i = 0; i < strings.length; i += 2) {
+      builder.put(strings[i], strings[i + 1]);
+    }
+    return containsAttributes(builder.build());
+  }
+
+  private static CustomTypeSafeMatcher<Metric> hasValue(double value) {
+    return new CustomTypeSafeMatcher<Metric>("a metric with value=" + value) {
+      @Override
+      protected boolean matchesSafely(final Metric item) {
+        return item.getValue() == value;
+      }
+    };
+  }
+
+  private static CustomTypeSafeMatcher<Metric> hasKey(String key) {
+    return new CustomTypeSafeMatcher<Metric>("a metric with key=" + key) {
+      @Override
+      protected boolean matchesSafely(final Metric item) {
+        return item.getKey().equals(key);
+      }
+    };
+  }
+
+  // The compiler has a very hard time inferring the type of an expression like
+  // argThat(allOf(foo(), bar())) as being Matcher<Metric>, so we define the method here
+  // to help out poor confused javac.
+  @SafeVarargs
+  private static Matcher<Metric> allOf(Matcher<Metric>... matchers) {
+    return CoreMatchers.allOf(matchers);
+  }
+
+  @Test
+  public void testGauges() throws Exception {
+    metricRegistry.register("some.gauge1", (Gauge<Integer>) () -> 1);
+    metricRegistry.register("some.gauge2", (Gauge<Integer>) () -> 2);
+
+    reporter.start();
+
+    verify().send(argThat(allOf(
+        hasKey("helios.test"),
+        containsAttributes("what", "some.gauge1", "metric_type", "gauge"),
+        hasValue(1)
+    )));
+
+    verify().send(argThat(allOf(
+        hasKey("helios.test"),
+        containsAttributes("what", "some.gauge2", "metric_type", "gauge"),
+        hasValue(2)
+    )));
+  }
+
+  @Test
+  public void testCounter() throws Exception {
+    metricRegistry.counter("counting.is.fun")
+        .inc(7982);
+
+    reporter.start();
+
+    verify().send(argThat(allOf(
+        hasKey("helios.test"),
+        containsAttributes("what", "counting.is.fun", "metric_type", "counter"),
+        hasValue(7982)
+    )));
+  }
+
+  @Test
+  public void testMeter() throws Exception {
+    metricRegistry.meter("the-meter");
+
+    reporter.start();
+
+    verifyMeterStats("the-meter", "meter");
+  }
+
+  private void verifyMeterStats(String what, String type) throws Exception {
+    for (String stat : new String[]{"1m", "5m"}) {
+      verify().send(argThat(allOf(
+          hasKey("helios.test"),
+          containsAttributes("what", what, "metric_type", type, "stat", stat),
+          hasValue(0)
+      )));
+    }
+  }
+
+  @Test
+  public void testHistogram() throws Exception {
+    final Histogram h = metricRegistry.histogram("histo.gram");
+    IntStream.range(1, 10).forEach(h::update);
+
+    reporter.start();
+
+    verifyHistogramStats("histo.gram", "histogram");
+  }
+
+  private void verifyHistogramStats(String what, String type) throws Exception {
+    final Set<String> expectedStats =
+        ImmutableSet.of("median", "p75", "p99", "mean", "min", "max", "stddev");
+
+    for (String stat : expectedStats) {
+      verify().send(argThat(allOf(
+          hasKey("helios.test"),
+          containsAttributes("what", what, "metric_type", type, "stat", stat))));
+    }
+  }
+
+  @Test
+  public void testTimer() throws Exception {
+    metricRegistry.timer("blah-timer");
+
+    reporter.start();
+
+    verifyHistogramStats("blah-timer", "timer");
+    verifyMeterStats("blah-timer", "timer");
+  }
+}

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -86,10 +86,6 @@
       <version>4.1.1</version>
     </dependency>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
       <version>3.8.0.Final</version>

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/LoggingTestWatcher.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/LoggingTestWatcher.java
@@ -121,7 +121,6 @@ final class LoggingTestWatcher extends TestWatcher {
     configureLogger("org.eclipse.jetty", Level.ERROR);
     configureLogger("org.apache.curator", Level.ERROR);
     configureLogger("org.apache.zookeeper", Level.ERROR);
-    configureLogger("com.yammer.metrics", Level.ERROR);
     configureLogger("com.spotify.helios", Level.DEBUG);
   }
 

--- a/helios-testing-common/src/main/resources/logback-test.xml
+++ b/helios-testing-common/src/main/resources/logback-test.xml
@@ -46,9 +46,6 @@
   <logger name="org.eclipse.jetty" level="${externalLoggingLevel:-ERROR}">
     <appender-ref ref="EXTERNAL_STDERR"/>
   </logger>
-  <logger name="com.yammer.metrics" level="${externalLoggingLevel:-ERROR}">
-    <appender-ref ref="EXTERNAL_STDERR"/>
-  </logger>
 
   <logger name="com.spotify.helios" level="${heliosLoggingLevel:-DEBUG}"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,11 +241,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.yammer.metrics</groupId>
-        <artifactId>metrics-core</artifactId>
-        <version>2.2.0</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>2.0.3</version>


### PR DESCRIPTION
Reports metrics from the MetricsRegistry to [ffwd][].

The String "name" of the Metric is sent as the `what` attribute in the FastForward metric. No translation of the (possibly long, Java classname-ish) name is done.

The type of metric is included in the `metric_type` attribute. For meters, timers, and histograms, the various component values of the com.codahale.metrics.Metric (m1/m5/m15, p50, p99 etc) are sent as individual Metric instances. The `stat` attribute is filled out with the corresponding statistic.

Note that not every statistic from Meters/Timers/Histograms is sent to FastForward in order to limit the amount of data being sent and needing to be stored downstream. For Metered instances, only 1m and 5m is sent. For Histograms, just median, p75 and p99 (plus min/max/mean/stddev).

This implementation is heavily inspired by our internal implementation which does the same basic work to send data to FastForward but for a non-`com.codahale.metrics.MetricRegistry` registry.

Along the way I also simplified a little bit of the ManagedStatsdReporter, removed no-longer-used dependencies on the v2 com.yammer.metrics library, and added a TODO (which I'll fix later in this PR) about reducing the volume of empty metrics sent by the master and agent.

[ffwd]: https://github.com/spotify/ffwd