### PR TITLE
client: Cache generated X509 certificate

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/tls/CertificateAndPrivateKey.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/CertificateAndPrivateKey.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client.tls;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class CertificateAndPrivateKey {
+
+  private final Certificate certificate;
+  private final PrivateKey privateKey;
+
+  public CertificateAndPrivateKey(final Certificate certificate, final PrivateKey privateKey) {
+    checkNotNull(certificate, "certificate");
+    checkNotNull(privateKey, "privateKey");
+
+    this.certificate = certificate;
+    this.privateKey = privateKey;
+  }
+
+  public Certificate getCertificate() {
+    return certificate;
+  }
+
+  public PrivateKey getPrivateKey() {
+    return privateKey;
+  }
+
+  public static CertificateAndPrivateKey from(final Path certPath, final Path keyPath)
+      throws IOException, GeneralSecurityException {
+    final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+    final Certificate certificate;
+    try (final InputStream is = Files.newInputStream(certPath)) {
+      certificate = cf.generateCertificate(is);
+    }
+
+    final Object parsedPem;
+    try (final BufferedReader br = Files.newBufferedReader(keyPath, Charset.defaultCharset())) {
+      parsedPem = new PEMParser(br).readObject();
+    }
+
+    final PrivateKeyInfo keyInfo;
+    if (parsedPem instanceof PEMKeyPair) {
+      keyInfo = ((PEMKeyPair) parsedPem).getPrivateKeyInfo();
+    } else if (parsedPem instanceof PrivateKeyInfo) {
+      keyInfo = (PrivateKeyInfo) parsedPem;
+    } else {
+      throw new UnsupportedOperationException("Unable to parse x509 certificate.");
+    }
+
+    final PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyInfo.getEncoded());
+    final KeyFactory kf = KeyFactory.getInstance("RSA");
+
+    return new CertificateAndPrivateKey(certificate, kf.generatePrivate(spec));
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/client/HttpsHandlersTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HttpsHandlersTest.java
@@ -17,8 +17,8 @@
 
 package com.spotify.helios.client;
 
-import com.spotify.helios.client.HttpsHandlers.CertificateAndPrivateKey;
 import com.spotify.helios.client.HttpsHandlers.SshAgentHttpsHandler;
+import com.spotify.helios.client.tls.CertificateAndPrivateKey;
 import com.spotify.sshagentproxy.AgentProxy;
 import com.spotify.sshagentproxy.Identity;
 
@@ -27,6 +27,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.nio.file.Paths;
+import java.util.Random;
 
 import static com.google.common.io.Resources.getResource;
 import static com.spotify.helios.common.Hash.sha1digest;
@@ -55,8 +56,12 @@ public class HttpsHandlersTest {
 
   @Test
   public void testSshAgent() throws Exception {
+    final byte[] random = new byte[255];
+    new Random().nextBytes(random);
+
     final AgentProxy proxy = mock(AgentProxy.class);
     final Identity identity = mock(Identity.class);
+    when(identity.getKeyBlob()).thenReturn(random);
 
     when(proxy.sign(any(Identity.class), any(byte[].class))).thenAnswer(new Answer<byte[]>() {
       @Override

--- a/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
@@ -22,7 +22,9 @@ import com.spotify.sshagentproxy.Identity;
 
 import org.bouncycastle.util.encoders.Base64;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -32,8 +34,12 @@ import java.security.cert.X509Certificate;
 import java.security.spec.X509EncodedKeySpec;
 
 import static com.spotify.helios.common.Hash.sha1digest;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.refEq;
@@ -42,6 +48,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class X509CertificateFactoryTest {
+
+  @Rule
+  public TemporaryFolder cacheFolder = new TemporaryFolder();
 
   private static final String USERNAME = "rohan";
 
@@ -57,6 +66,8 @@ public class X509CertificateFactoryTest {
 
   private PublicKey publicKey;
 
+  private X509CertificateFactory sut;
+
   @Before
   public void setUp() throws Exception {
     X509EncodedKeySpec pubKeySpec = new X509EncodedKeySpec(Base64.decode(ROHAN_PUB_KEY));
@@ -64,6 +75,7 @@ public class X509CertificateFactoryTest {
     publicKey = keyFactory.generatePublic(pubKeySpec);
 
     when(identity.getPublicKey()).thenReturn(publicKey);
+    when(identity.getKeyBlob()).thenReturn(publicKey.getEncoded());
     when(agentProxy.sign(any(Identity.class), any(byte[].class))).thenAnswer(new Answer<byte[]>() {
       @Override
       public byte[] answer(InvocationOnMock invocation) throws Throwable {
@@ -71,20 +83,50 @@ public class X509CertificateFactoryTest {
         return sha1digest(bytesToSign);
       }
     });
+
+    sut = new X509CertificateFactory(cacheFolder.getRoot().toPath(), 500, 5000);
   }
 
   @Test
   public void testGet() throws Exception {
-    final X509CertificateFactory.CertificateAndKeyPair certificateAndKeyPair =
-        X509CertificateFactory.get(agentProxy, identity, USERNAME);
+    final CertificateAndPrivateKey certificateAndPrivateKey =
+        sut.get(agentProxy, identity, USERNAME);
 
-    assertNotNull(certificateAndKeyPair.getCertificate());
-    assertNotNull(certificateAndKeyPair.getKeyPair());
+    assertNotNull(certificateAndPrivateKey.getCertificate());
+    assertNotNull(certificateAndPrivateKey.getPrivateKey());
 
-    final X509Certificate certificate = (X509Certificate) certificateAndKeyPair.getCertificate();
+    final X509Certificate certificate = (X509Certificate) certificateAndPrivateKey.getCertificate();
 
     verify(agentProxy).sign(refEq(identity), eq(certificate.getTBSCertificate()));
     assertEquals("UID=" + USERNAME, certificate.getSubjectDN().getName());
+  }
+
+  @Test
+  public void testCache() throws Exception {
+    final CertificateAndPrivateKey original = sut.get(agentProxy, identity, USERNAME);
+
+    // repeated invocations should return the exact same cert & keypair
+    for (int i = 0; i < 5; i++) {
+      final CertificateAndPrivateKey shouldBeFromCache = sut.get(agentProxy, identity, USERNAME);
+
+      assertArrayEquals("certificate does not match original",
+                        original.getCertificate().getEncoded(),
+                        shouldBeFromCache.getCertificate().getEncoded());
+      assertArrayEquals("key does not match original",
+                        original.getPrivateKey().getEncoded(),
+                        shouldBeFromCache.getPrivateKey().getEncoded());
+    }
+
+    // sleep for long enough that the cert expires
+    Thread.sleep(5000);
+
+    final CertificateAndPrivateKey shouldBeNew = sut.get(agentProxy, identity, USERNAME);
+    assertThat("cached certificate being used past expiry",
+               shouldBeNew.getCertificate().getEncoded(),
+               not(equalTo(original.getCertificate().getEncoded())));
+    assertThat("cached key being used past expiry",
+               shouldBeNew.getPrivateKey().getEncoded(),
+               not(equalTo(original.getPrivateKey().getEncoded())));
   }
 
 }


### PR DESCRIPTION
If we generate an X509 certificate and get it signed by ssh-agent, cache
the resulting certificate and key in ~/.helios. This can reduce the time it
takes for future requests by around a second since generating new key pairs
is an expensive operation.