### PR TITLE
Fix the default Prober to support UDP probing as well as TCP

### DIFF
--- a/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
@@ -25,6 +25,7 @@ import com.spotify.helios.cli.CliMain;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.testing.Prober;
 
 import java.io.ByteArrayOutputStream;
@@ -115,7 +116,7 @@ public class Utils {
     }
 
     @Override
-    public boolean probe(String host, int port) {
+    public boolean probe(String host, PortMapping portMapping) {
       try {
         final HostStatus hostStatus = client.hostStatus(hostName).get(10, TimeUnit.SECONDS);
         return hostStatus != null && hostStatus.getStatus() == HostStatus.Status.UP;

--- a/helios-testing/src/main/java/com/spotify/helios/testing/DefaultProber.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DefaultProber.java
@@ -47,7 +47,7 @@ class DefaultProber implements Prober {
       return probeUdpPort(host, portMapping);
     }
 
-    throw new IllegalArgumentException("Unsupported protocol "+portMapping.getProtocol());
+    throw new IllegalArgumentException("Unsupported protocol " + portMapping.getProtocol());
   }
 
   private boolean probeUdpPort(String host, PortMapping portMapping) {
@@ -57,7 +57,8 @@ class DefaultProber implements Prober {
     try {
       // Let's send a PING
       // A UDP service should ignore any messages that do not conform to its protocol
-      // If it does then you probably should implement your own Prober or skip the probing by using a Dummy prober
+      // If it does then you probably should implement your own Prober or
+      // skip the probing by using a Dummy prober
       byte[] pingData = "PING".getBytes("UTF-8");
 
       // Use ephemeral port number
@@ -81,7 +82,8 @@ class DefaultProber implements Prober {
       // OK we got a timeout. That means that the UDP port is up and listening
       return true;
     } catch (PortUnreachableException e) {
-      // The port is unreachable which of course means that there is no-one listening to the UDP port
+      // The port is unreachable which of course means that
+      // there is no-one listening to the UDP port
       return false;
     } catch (SocketException e) {
       LOG.warn(e.getMessage(), e);

--- a/helios-testing/src/main/java/com/spotify/helios/testing/DefaultProber.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DefaultProber.java
@@ -17,13 +17,84 @@
 
 package com.spotify.helios.testing;
 
+import com.spotify.helios.common.descriptors.PortMapping;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
 import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 
 class DefaultProber implements Prober {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultProber.class);
+
   @Override
-  public boolean probe(final String host, final int port) {
+  public boolean probe(final String host, final PortMapping portMapping) {
+    String protocol = portMapping.getProtocol();
+
+    if (PortMapping.TCP.equals(protocol)) {
+      return probeTcpPort(host, portMapping);
+    } else if (PortMapping.UDP.equals(protocol)) {
+      return probeUdpPort(host, portMapping);
+    }
+
+    throw new IllegalArgumentException("Unsupported protocol "+portMapping.getProtocol());
+  }
+
+  private boolean probeUdpPort(String host, PortMapping portMapping) {
+
+    Integer port = portMapping.getExternalPort();
+
+    try {
+      // Let's send a PING
+      // A UDP service should ignore any messages that do not conform to its protocol
+      // If it does then you probably should implement your own Prober or skip the probing by using a Dummy prober
+      byte[] pingData = "PING".getBytes("UTF-8");
+
+      // Use ephemeral port number
+      DatagramSocket serverSocket = new DatagramSocket(0);
+      SocketAddress socketAddr = new InetSocketAddress(host, port);
+      serverSocket.connect(socketAddr);
+
+      InetAddress address = InetAddress.getByName(host);
+      DatagramPacket sendPacket =
+          new DatagramPacket(pingData, pingData.length, address, port);
+      serverSocket.send(sendPacket);
+
+      // Wait for a response: This will cause either a timeout (OK) or a port not reachable (NOT OK)
+      byte[] receiveData = new byte[8];
+      DatagramPacket receivePacket =
+          new DatagramPacket(receiveData, receiveData.length);
+      serverSocket.setSoTimeout(200);
+      serverSocket.receive(receivePacket);
+
+    } catch (SocketTimeoutException e) {
+      // OK we got a timeout. That means that the UDP port is up and listening
+      return true;
+    } catch (PortUnreachableException e) {
+      // The port is unreachable which of course means that there is no-one listening to the UDP port
+      return false;
+    } catch (SocketException e) {
+      LOG.warn(e.getMessage(), e);
+      return false;
+    } catch (IOException e) {
+      LOG.warn(e.getMessage(), e);
+      return false;
+    }
+    return false;
+  }
+
+  private boolean probeTcpPort(String host, PortMapping portMapping) {
+    Integer port = portMapping.getExternalPort();
     try (final Socket ignored = new Socket(host, port)) {
       return true;
     } catch (IOException e) {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Jobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Jobs.java
@@ -68,8 +68,8 @@ class Jobs {
    * @return the list of errors
    */
   static List<AssertionError> undeploy(final HeliosClient client, final Job job,
-                                              final List<String> hosts,
-                                              final List<AssertionError> errors) {
+                                       final List<String> hosts,
+                                       final List<AssertionError> errors) {
     final JobId id = job.getId();
     for (String host : hosts) {
       log.info("Undeploying {} from {}", getJobDescription(job), host);

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Prober.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Prober.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.testing;
 
+import com.spotify.helios.common.descriptors.PortMapping;
+
 public interface Prober {
-  boolean probe(String host, int port);
+  boolean probe(String host, PortMapping portMapping);
 }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
@@ -230,7 +230,7 @@ public class TemporaryJob {
 
   /**
    * Undeploys and removes this TemporaryJob from the Helios cluster. This is normally done
-   * automatically by TemporaryJObs at the end of the test run. Use this method if you need to
+   * automatically by TemporaryJobs at the end of the test run. Use this method if you need to
    * manually undeploy a job prior to the end of the test run.
    */
   public void undeploy() {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
@@ -339,13 +339,14 @@ public class TemporaryJob {
     final String endpoint = endpointFromHost(host);
     final TaskStatus taskStatus = statuses.get(host);
     assert taskStatus != null;
-    final Integer externalPort = taskStatus.getPorts().get(port).getExternalPort();
+    final PortMapping portMapping = taskStatus.getPorts().get(port);
+    final Integer externalPort = portMapping.getExternalPort();
     assert externalPort != null;
     Polling.awaitUnchecked(TIMEOUT_MILLIS, MILLISECONDS, new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
-        log.info("Probing: {} @ {}:{}", port, endpoint, externalPort);
-        final boolean up = prober.probe(endpoint, externalPort);
+        log.info("Probing: {} @ {}:{}", port, endpoint, portMapping);
+        final boolean up = prober.probe(endpoint, portMapping);
         if (up) {
           log.info("Up: {} @ {}:{}", port, endpoint, externalPort);
           return true;

--- a/helios-testing/src/test/java/com/spotify/helios/testing/ProberTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/ProberTest.java
@@ -19,6 +19,8 @@ package com.spotify.helios.testing;
 
 import com.google.common.base.Optional;
 
+import com.spotify.helios.common.descriptors.PortMapping;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,7 +41,7 @@ public class ProberTest extends TemporaryJobsTestBase {
     private boolean probed;
 
     @Override
-    public boolean probe(String host, int port) {
+    public boolean probe(String host, PortMapping port) {
       return probed = true;
     }
 

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTestBase.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTestBase.java
@@ -18,6 +18,7 @@
 package com.spotify.helios.testing;
 
 import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.system.SystemTestBase;
 
 import org.junit.Before;
@@ -47,10 +48,10 @@ public abstract class TemporaryJobsTestBase extends SystemTestBase {
   protected static final class TestProber extends DefaultProber {
 
     @Override
-    public boolean probe(final String host, final int port) {
+    public boolean probe(final String host, final PortMapping portMapping) {
       // Probe for ports where docker is running instead of on the mock testHost address
       assertEquals(testHost1, host);
-      return super.probe(DOCKER_HOST.address(), port);
+      return super.probe(DOCKER_HOST.address(), portMapping);
     }
   }
 

--- a/helios-testing/src/test/java/com/spotify/helios/testing/UdpProberTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/UdpProberTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.experimental.results.ResultMatchers.isSuccessful;
+
+/**
+ * Tests that a UDP port in a TemporaryJob can be probed.
+ */
+public class UdpProberTest extends TemporaryJobsTestBase {
+
+  @Test
+  public void test() throws Exception {
+    assertThat(testResult(UdpProberTestImpl.class), isSuccessful());
+  }
+
+  public static class UdpProberTestImpl {
+
+    private TemporaryJob job;
+
+    @Rule
+    public final TemporaryJobs temporaryJobs = temporaryJobsBuilder()
+        .client(client)
+        .prober(new TestProber())
+        .build();
+
+    @Before
+    public void setup() {
+      job = temporaryJobs.job()
+          .image(ALPINE)
+          .command(asList("nc", "-p", "4711", "-lu"))
+          .port("default", 4711, "udp")
+          .deploy(testHost1);
+    }
+
+    @After
+    public void tearDown() {
+      // The TemporaryJobs Rule above doesn't undeploy the job for some reason...
+      job.undeploy();
+    }
+
+    @Test
+    public void test() throws Exception {
+      final Map<JobId, Job> jobs = client.jobs().get(15, SECONDS);
+      assertEquals("wrong number of jobs running", 1, jobs.size());
+      for (final Job job : jobs.values()) {
+        assertEquals("wrong job running", ALPINE, job.getImage());
+      }
+    }
+  }
+}


### PR DESCRIPTION
I made a suggested change to the DefaultProber to support UDP ports as well as TCP
The current implementation will hang when probing UDP ports.
This implementation mimics the nmap behavior by sending a "PING" message to the port and wait for timeout (OK) or port not reachable (NOT OK)