### PR TITLE
HeliosClient: catch EndpointIterator with no endpoints

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -604,6 +604,10 @@ public class HeliosClient implements Closeable {
     private HttpConnector createHttpConnector(final boolean sslHostnameVerification) {
 
       final EndpointIterator endpointIterator = EndpointIterator.of(endpointSupplier.get());
+      if (!endpointIterator.hasNext()) {
+        throw new IllegalStateException(
+            "no endpoints found to connect to, check your configuration");
+      }
 
       final DefaultHttpConnector connector = new DefaultHttpConnector(endpointIterator, 10000,
                                                                       sslHostnameVerification);

--- a/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.client;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+
+public class HeliosClientTest {
+
+  @Test(expected = IllegalStateException.class)
+  public void testBuildWithNoEndpoints() {
+    HeliosClient.newBuilder()
+        .setEndpoints(Collections.<URI>emptyList())
+        .build();
+  }
+}

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -119,7 +119,7 @@ public class TemporaryJobs implements TestRule {
     checkArgument(builder.deployTimeoutMillis >= 0, "deployTimeoutMillis");
 
     this.deployer = fromNullable(builder.deployer).or(
-        new DefaultDeployer(client, jobs, builder.hostPickingStrategy, 
+        new DefaultDeployer(client, jobs, builder.hostPickingStrategy,
             builder.jobDeployedMessageFormat, builder.deployTimeoutMillis));
 
     final Path prefixDirectory = Paths.get(fromNullable(builder.prefixDirectory)
@@ -508,7 +508,12 @@ public class TemporaryJobs implements TestRule {
   }
 
   static Builder builder(final String profile, final Map<String, String> env) {
-    return new Builder(profile, TemporaryJobs.loadConfig(), env);
+    return builder(profile, env, HeliosClient.newBuilder());
+  }
+
+  static Builder builder(final String profile, final Map<String, String> env,
+                         final HeliosClient.Builder clientBuilder) {
+    return new Builder(profile, TemporaryJobs.loadConfig(), env, clientBuilder);
   }
 
   public static class Builder {
@@ -519,6 +524,7 @@ public class TemporaryJobs implements TestRule {
     private Prober prober = DEFAULT_PROBER;
     private Deployer deployer;
     private String hostFilter;
+    private HeliosClient.Builder clientBuilder;
     private HeliosClient client;
     private String prefixDirectory;
     private String testReportDirectory;
@@ -527,8 +533,10 @@ public class TemporaryJobs implements TestRule {
     private HostPickingStrategy hostPickingStrategy = HostPickingStrategies.randomOneHost();
     private long deployTimeoutMillis = DEFAULT_DEPLOY_TIMEOUT_MILLIS;
 
-    Builder(String profile, Config rootConfig, Map<String, String> env) {
+    Builder(String profile, Config rootConfig, Map<String, String> env,
+            HeliosClient.Builder clientBuilder) {
       this.env = env;
+      this.clientBuilder = clientBuilder;
 
       // No profile specified so see if there is one specified in the config object.
       if (profile == null) {
@@ -663,8 +671,7 @@ public class TemporaryJobs implements TestRule {
     }
 
     public Builder domain(final String domain) {
-      return client(HeliosClient.newBuilder()
-                        .setUser(user)
+      return client(clientBuilder.setUser(user)
                         .setDomain(domain)
                         .build());
     }
@@ -674,8 +681,7 @@ public class TemporaryJobs implements TestRule {
     }
 
     public Builder endpointStrings(final List<String> endpoints) {
-      return client(HeliosClient.newBuilder()
-                        .setUser(user)
+      return client(clientBuilder.setUser(user)
                         .setEndpointStrings(endpoints)
                         .build());
     }
@@ -685,8 +691,7 @@ public class TemporaryJobs implements TestRule {
     }
 
     public Builder endpoints(final List<URI> endpoints) {
-      return client(HeliosClient.newBuilder()
-                        .setUser(user)
+      return client(clientBuilder.setUser(user)
                         .setEndpoints(endpoints)
                         .build());
     }

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTestBase.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsTestBase.java
@@ -77,8 +77,4 @@ public abstract class TemporaryJobsTestBase extends SystemTestBase {
   public static TemporaryJobs.Builder temporaryJobsBuilder() {
     return TemporaryJobs.builder(emptyEnv());
   }
-
-  public static TemporaryJobs.Builder temporaryJobsBuilder(final String profile) {
-    return TemporaryJobs.builder(profile, emptyEnv());
-  }
 }


### PR DESCRIPTION
Handle the case where the HeliosClient is configured with a list of URIs
which resolve into no actual Endpoints when EndpointIterator does it's
work.

Currently if the URI resolves into no endpoints (if there are DNS
issues, or the URI just can't be resolved), the error is only caught
when the request is made in RetryingRequestDispatcher because
EndpointIterator.next() will throw a `java.util.NoSuchElementException`,
and the RetryingRequestDispatcher will retry the doomed request many
times.