### PR TITLE
allow alternate java installation in startup scripts

### DIFF
--- a/bin/helios-agent
+++ b/bin/helios-agent
@@ -34,7 +34,14 @@ if [ $JMXPORT ]; then
           -Dcom.sun.management.jmxremote.authenticate=false )
 fi
 
-exec java \
+# Allow the path to the java installation to be specified in the JAVA environment variable.
+# This can be useful if you want to run helios-agent using a different version of Java than the
+# default version on the host (possibly set up through update-alternatives)
+if [ -z $JAVA ]; then
+    JAVA=java
+fi
+
+exec $JAVA \
     $HELIOS_AGENT_JVM_OPTS \
     "${args[@]}" \
     -Djava.net.preferIPv4Stack=true \

--- a/bin/helios-master
+++ b/bin/helios-master
@@ -34,7 +34,14 @@ if [ $JMXPORT ]; then
           -Dcom.sun.management.jmxremote.authenticate=false )
 fi
 
-exec java \
+# Allow the path to the java installation to be specified in the JAVA environment variable.
+# This can be useful if you want to run helios-agent using a different version of Java than the
+# default version on the host (possibly set up through update-alternatives)
+if [ -z $JAVA ]; then
+    JAVA=java
+fi
+
+exec $JAVA \
     $HELIOS_MASTER_JVM_OPTS \
     "${args[@]}" \
     -Djava.net.preferIPv4Stack=true \


### PR DESCRIPTION
Changes `bin/helios-agent` and `bin/helios-master` to respect a `$JAVA`
environment variable which contains the path to the java command to run
the helios process with.

If the environment variable is not set, then the scripts fall back to (the
prior behavior of) a simple `java` command.

This can be useful for environments where the helios agent and/or master
should be run with a version of Java that is not the default version on
the host.