### PR TITLE
Remove commit hashes from Docker image tags

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -12,8 +12,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <masterImageName>helios-master:${project.version}-${gitShortCommitId}</masterImageName>
-    <agentImageName>helios-agent:${project.version}-${gitShortCommitId}</agentImageName>
+    <masterImageName>helios-master:${project.version}</masterImageName>
+    <agentImageName>helios-agent:${project.version}</agentImageName>
     <soloImageName>helios-solo:${project.version}</soloImageName>
   </properties>
 


### PR DESCRIPTION
Remove the Git commit hashes from the helios-agent and helios-master images
that we build. Instead match the behavior for helios-solo, wherein the tag
is just the same as the Helios version.

This is in preparation for pushing the images for public consumption.