### PR TITLE
Fix race in ZooKeeperAclTest

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperAclTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ZooKeeperAclTest.java
@@ -65,7 +65,7 @@ public class ZooKeeperAclTest extends SystemTestBase {
 
     final CuratorFramework curator = zk().curatorWithSuperAuth();
 
-    final String path = Paths.statusHostUp(TEST_HOST);
+    final String path = Paths.configHost(TEST_HOST);
     final List<ACL> acls = curator.getACL().forPath(path);
     assertEquals(
         Sets.newHashSet(aclProvider.getAclForPath(path)),


### PR DESCRIPTION
testAgentCreatedNodesHaveAcls(). Check for znode at
/config/hosts/<hostname> instead of /status/hosts/<hostname>/up.
We call awaitHostRegistered() before this, but the up znode
may not have been written yet as that happens after the
agent writes the other znodes. See AgentZooKeeperRegistrar.tryToRegister().