### PR TITLE
add --add-host argument to agents

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AddExtraHostContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AddExtraHostContainerDecorator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.InetAddresses;
+
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.ImageInfo;
+import com.spotify.helios.common.descriptors.Job;
+
+import java.util.List;
+
+/** ContainerDecorator that adds to {@link HostConfig#extraHosts}. */
+public class AddExtraHostContainerDecorator implements ContainerDecorator {
+
+  private final List<String> extraHosts;
+
+  public AddExtraHostContainerDecorator(final List<String> extraHosts) {
+    this.extraHosts = ImmutableList.copyOf(extraHosts);
+  }
+
+  @Override
+  public void decorateHostConfig(final HostConfig.Builder hostConfig) {
+    hostConfig.extraHosts(this.extraHosts);
+  }
+
+  @Override
+  public void decorateContainerConfig(final Job job, final ImageInfo imageInfo,
+                                      final ContainerConfig.Builder containerConfig) {
+    //do nothing
+  }
+
+  /**
+   * Validates that the argument has form "host:ip-address". Does not validate the form of the
+   * hostname argument, but checks that the second half is valid via {@link
+   * InetAddresses#isInetAddress}.
+   */
+  public static boolean isValidArg(String arg) {
+    final String[] args = arg.split(":");
+    if (args.length != 2) {
+      return false;
+    }
+
+    final String ip = args[1];
+    return InetAddresses.isInetAddress(ip);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -65,6 +65,7 @@ public class AgentConfig extends Configuration {
   private String zookeeperAclAgentUser;
   private String zooKeeperAclAgentPassword;
   private FastForwardConfig fastForwardConfig;
+  private List<String> extraHosts;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -355,6 +356,15 @@ public class AgentConfig extends Configuration {
 
   public AgentConfig setFfwdConfig(FastForwardConfig config) {
     this.fastForwardConfig = config;
+    return this;
+  }
+
+  public List<String> getExtraHosts() {
+    return extraHosts;
+  }
+
+  public AgentConfig setExtraHosts(final List<String> extraHosts) {
+    this.extraHosts = extraHosts;
     return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.net.InetAddresses;
 
@@ -172,11 +173,12 @@ public class AgentParser extends ServiceParser {
    * Verifies that all entries in the Collection satisfy the predicate. If any do not, throw an
    * IllegalArgumentException with the specified message for the first invalid entry.
    */
-  private static <T> List<T> validateArgument(List<T> list, Predicate<T> predicate,
+  @VisibleForTesting
+  protected static <T> List<T> validateArgument(List<T> list, Predicate<T> predicate,
                                               Function<T, String> msgFn) {
 
     final Optional<T> firstInvalid = list.stream()
-        .filter(predicate)
+        .filter(predicate.negate())
         .findAny();
 
     if (firstInvalid.isPresent()) {

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -282,6 +282,10 @@ public class AgentService extends AbstractIdleService implements Managed {
       decorators.add(new BindVolumeContainerDecorator(config.getBinds()));
     }
 
+    if (!config.getExtraHosts().isEmpty()) {
+      decorators.add(new AddExtraHostContainerDecorator(config.getExtraHosts()));
+    }
+
     final SupervisorFactory supervisorFactory = new SupervisorFactory(
         model, monitoredDockerClient,
         config.getEnvVars(), serviceRegistrar,

--- a/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.google.common.collect.ImmutableList;
+
+import com.spotify.docker.client.messages.HostConfig;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.spotify.helios.agent.AddExtraHostContainerDecorator.isValidArg;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AddExtraHostContainerDecoratorTest {
+
+  @Test
+  public void simpleTest() {
+    final List<String> hosts = ImmutableList.of("one", "two");
+    final AddExtraHostContainerDecorator decorator = new AddExtraHostContainerDecorator(hosts);
+
+    final HostConfig.Builder hostBuilder = HostConfig.builder();
+    decorator.decorateHostConfig(hostBuilder);
+
+    final HostConfig config = hostBuilder.build();
+    assertThat(config.extraHosts(), equalTo(hosts));
+  }
+
+  @Test
+  public void invalidArgument() {
+    assertThat(isValidArg("abcdefg"), is(false));
+  }
+
+  @Test
+  public void invalidArguments() {
+    assertThat(isValidArg("abc:def:gh"), is(false));
+  }
+
+  @Test
+  public void testValidArgument() {
+    assertThat(isValidArg("foo:169.254.169.254"), is(true));
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/agent/AgentParserTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AgentParserTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+public class AgentParserTest {
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testValidateArgument() {
+    final Predicate<Integer> isOdd = num -> num % 2 == 1;
+
+    UnaryOperator<List<Integer>> testFn =
+        nums -> AgentParser.validateArgument(nums, isOdd, n -> n + " is expected to be odd");
+
+    testFn.apply(ImmutableList.of(1, 3, 5, 7));
+
+    exception.expect(IllegalArgumentException.class);
+    testFn.apply(ImmutableList.of(1, 3, 5, 7, 8));
+  }
+}


### PR DESCRIPTION
This argument allows for specifying entries to be added to the
`/etc/hosts` file of the containers created by the Agent, mirroring the
functionality of the [`--add-host` argument to `docker run`][docker] or `docker
create`.

It is implemented within the Agent by passing the `host:ip` pairs in the
`HostConfig.ExtraHosts` field when [creating the container][remote-api].

[docker]: https://docs.docker.com/engine/reference/commandline/run/#add-host-device-to-container-device
[remote-api]: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.18/#create-a-container