### PR TITLE
Pull newer version of base images before building

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -66,6 +66,7 @@
                   <labels>
                     <label>com.spotify.helios.version="${project.version}"</label>
                   </labels>
+                  <pullOnBuild>true</pullOnBuild>
                 </configuration>
               </execution>
               <execution>
@@ -94,6 +95,7 @@
                   <labels>
                     <label>com.spotify.helios.version="${project.version}"</label>
                   </labels>
+                  <pullOnBuild>true</pullOnBuild>
                 </configuration>
               </execution>
             </executions>
@@ -114,6 +116,7 @@
               <labels>
                 <label>com.spotify.helios.version="${project.version}"</label>
               </labels>
+              <pullOnBuild>true</pullOnBuild>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
For cases where we need to update our base image without needing to
remember to manually run `docker pull` on the build agent first.