### PR TITLE
Add OldJobReaper

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/DeadAgentReaper.java
@@ -55,9 +55,9 @@ public class DeadAgentReaper extends InterruptingScheduledService {
     this(masterModel, timeoutHours, SYSTEM_CLOCK);
   }
 
-  public DeadAgentReaper(final MasterModel masterModel,
-                         final long timeoutHours,
-                         final Clock clock) {
+  DeadAgentReaper(final MasterModel masterModel,
+                  final long timeoutHours,
+                  final Clock clock) {
     this.masterModel = masterModel;
     checkArgument(timeoutHours > 0);
     this.timeoutMillis = TimeUnit.HOURS.toMillis(timeoutHours);

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
@@ -55,6 +55,7 @@ public class MasterConfig extends Configuration {
   private String zookeeperAclMasterUser;
   private String zooKeeperAclMasterPassword;
   private long agentReapingTimeout;
+  private long jobRetention;
   private FastForwardConfig fastForwardConfig;
 
   public String getDomain() {
@@ -262,6 +263,15 @@ public class MasterConfig extends Configuration {
 
   public long getAgentReapingTimeout() {
     return agentReapingTimeout;
+  }
+
+  public MasterConfig setJobRetention(final long jobRetention) {
+    this.jobRetention = jobRetention;
+    return this;
+  }
+
+  public long getJobRetention() {
+    return jobRetention;
   }
 
   public FastForwardConfig getFfwdConfig() {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -41,6 +41,7 @@ public class MasterParser extends ServiceParser {
   private Argument zkAclAgentDigest;
   private Argument zkAclMasterPassword;
   private Argument agentReapingTimeout;
+  private Argument jobRetention;
 
   public MasterParser(final String... args) throws ArgumentParserException {
     super("helios-master", "Spotify Helios Master", args);
@@ -79,6 +80,7 @@ public class MasterParser extends ServiceParser {
         .setKafkaBrokers(getKafkaBrokers())
         .setStateDirectory(getStateDirectory())
         .setAgentReapingTimeout(options.getLong(agentReapingTimeout.getDest()))
+        .setJobRetention(options.getLong(jobRetention.getDest()))
         .setFfwdConfig(ffwdConfig(options));
 
     this.masterConfig = config;
@@ -108,6 +110,13 @@ public class MasterParser extends ServiceParser {
         .setDefault(TimeUnit.DAYS.toHours(14))
         .help("In hours. Agents will be automatically de-registered if they are DOWN for more " +
               "than the specified timeout. To disable reaping, set to 0.");
+
+    jobRetention = parser.addArgument("--job-retention")
+        .type(Long.class)
+        .setDefault(-1L)
+        .help("In days. Jobs not deployed anywhere and with a job history showing they were last " +
+              "used before the specified retention time will be removed. " +
+              "This is disabled by default by setting it to a sentinel value of -1.");
   }
 
   public MasterConfig getMasterConfig() {

--- a/helios-services/src/main/java/com/spotify/helios/master/OldJobReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/OldJobReaper.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.spotify.helios.agent.InterruptingScheduledService;
+import com.spotify.helios.common.Clock;
+import com.spotify.helios.common.SystemClock;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.JobStatus;
+import com.spotify.helios.common.descriptors.TaskStatusEvent;
+
+import org.apache.commons.lang.time.DurationFormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Removes old jobs that haven't been deployed for a while.
+ */
+public class OldJobReaper extends InterruptingScheduledService {
+
+  private static final Clock SYSTEM_CLOCK = new SystemClock();
+  private static final long INTERVAL = 1;
+  private static final TimeUnit INTERVAL_TIME_UNIT = TimeUnit.DAYS;
+
+  private static final Logger log = LoggerFactory.getLogger(OldJobReaper.class);
+
+  private final MasterModel masterModel;
+  private final long retentionMillis;
+  private final Clock clock;
+
+  public OldJobReaper(final MasterModel masterModel, final long retentionDays) {
+    this(masterModel, retentionDays, SYSTEM_CLOCK);
+  }
+
+  OldJobReaper(final MasterModel masterModel,
+               final long retentionDays,
+               final Clock clock) {
+    this.masterModel = masterModel;
+    checkArgument(retentionDays > 0);
+    this.retentionMillis = TimeUnit.DAYS.toMillis(retentionDays);
+    this.clock = clock;
+  }
+
+  @Override
+  protected void runOneIteration() {
+    log.debug("Reaping old jobs.");
+
+    final Map<JobId, Job> jobs = masterModel.getJobs();
+    for (final Map.Entry<JobId, Job> jobEntry : jobs.entrySet()) {
+      final JobId jobId = jobEntry.getKey();
+
+      try {
+        final List<TaskStatusEvent> events = masterModel.getJobHistory(jobId);
+        final int numEvents = events.size();
+
+        //noinspection StatementWithEmptyBody
+        if (numEvents == 0) {
+          // Don't reap. We're being conservative here in case the agent couldn't write the
+          // history or the reaper happens to be running right in between the time the job is
+          // created and when it's deployed.
+        } else {
+          // Get the last event which is the most recent
+          final TaskStatusEvent event = events.get(numEvents - 1);
+          // Calculate the amount of time in milliseconds that has elapsed since the last event
+          final long unusedDurationMillis = clock.now().getMillis() - event.getTimestamp();
+
+          if (unusedDurationMillis > retentionMillis) {
+            // Check the job isn't deployed anywhere
+            final JobStatus jobStatus = masterModel.getJobStatus(jobId);
+            final Map<String, Deployment> deployments = jobStatus.getDeployments();
+            if (deployments.size() == 0) {
+              try {
+                log.info("Reaping old job '{}' (unused for {} days)", jobId,
+                         DurationFormatUtils.formatDuration(unusedDurationMillis, "DD H:mm"));
+                masterModel.removeJob(jobId, jobEntry.getValue().getToken());
+              } catch (Exception e) {
+                log.warn("Failed to reap old job '{}'", jobId, e);
+              }
+            }
+          }
+        }
+      } catch (Exception e) {
+        log.warn("Failed to determine if job '{}' should be reaped", jobId, e);
+      }
+    }
+  }
+
+  @Override
+  protected ScheduledFuture<?> schedule(final Runnable runnable,
+                                        final ScheduledExecutorService executorService) {
+    return executorService.scheduleWithFixedDelay(runnable, 0, INTERVAL, INTERVAL_TIME_UNIT);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/OldJobReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/OldJobReaper.java
@@ -76,16 +76,15 @@ public class OldJobReaper extends InterruptingScheduledService {
 
       try {
         final List<TaskStatusEvent> events = masterModel.getJobHistory(jobId);
-        final int numEvents = events.size();
 
         //noinspection StatementWithEmptyBody
-        if (numEvents == 0) {
+        if (events.isEmpty()) {
           // Don't reap. We're being conservative here in case the agent couldn't write the
           // history or the reaper happens to be running right in between the time the job is
           // created and when it's deployed.
         } else {
           // Get the last event which is the most recent
-          final TaskStatusEvent event = events.get(numEvents - 1);
+          final TaskStatusEvent event = events.get(events.size() - 1);
           // Calculate the amount of time in milliseconds that has elapsed since the last event
           final long unusedDurationMillis = clock.now().getMillis() - event.getTimestamp();
 

--- a/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
 
 public class DeadAgentReaperTest {
 
-  private static  final long TIMEOUT_HOURS = 1000;
+  private static final long TIMEOUT_HOURS = 1000;
 
   private static class Datapoint {
 

--- a/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeadAgentReaperTest.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.master;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import com.spotify.helios.common.Clock;
@@ -33,9 +31,11 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -81,12 +81,7 @@ public class DeadAgentReaperTest {
     );
 
     when(masterModel.listHosts()).thenReturn(Lists.newArrayList(
-        Iterables.transform(datapoints, new Function<Datapoint, String>() {
-          @Override
-          public String apply(final Datapoint input) {
-            return input.host;
-          }
-        })));
+        datapoints.stream().map(input -> input.host).collect(Collectors.toList())));
 
     for (final Datapoint datapoint : datapoints) {
       when(masterModel.getHostStatus(datapoint.host)).thenReturn(
@@ -101,15 +96,14 @@ public class DeadAgentReaperTest {
               .build());
     }
 
-    final DeadAgentReaper reaper = new DeadAgentReaper(
-        masterModel, TIMEOUT_HOURS, clock);
+    final DeadAgentReaper reaper = new DeadAgentReaper(masterModel, TIMEOUT_HOURS, clock);
     reaper.startAsync().awaitRunning();
-
-    verify(masterModel, timeout(5000).atLeastOnce()).listHosts();
 
     for (final Datapoint datapoint : datapoints) {
       if (datapoint.expectReap) {
         verify(masterModel, timeout(500)).deregisterHost(datapoint.host);
+      } else {
+        verify(masterModel, never()).deregisterHost(datapoint.host);
       }
     }
   }


### PR DESCRIPTION
This reaper, disabled by default, runs in the master and will remove
jobs that are not deployed anywhere and have a job history whose latest
event is older than the specified retention.