### PR TITLE
Fix race btw HostInfoReporter + ZKRegistrarService

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -251,6 +251,7 @@ public class AgentService extends AbstractIdleService implements Managed {
                                                                           dockerClient);
 
     this.hostInfoReporter = HostInfoReporter.newBuilder()
+        .setZKRegistrationSignal(zkRegistrationSignal)
         .setNodeUpdaterFactory(nodeUpdaterFactory)
         .setOperatingSystemMXBean((OperatingSystemMXBean) getOperatingSystemMXBean())
         .setHost(config.getName())

--- a/helios-services/src/main/java/com/spotify/helios/agent/EnvironmentVariableReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/EnvironmentVariableReporter.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -46,12 +47,14 @@ public class EnvironmentVariableReporter extends InterruptingScheduledService {
                                      final CountDownLatch zkRegistrationSignal) {
     this.envVars = envVars;
     this.nodeUpdater = nodeUpdaterFactory.create(Paths.statusHostEnvVars(host));
-    this.zkRegistrationSignal = zkRegistrationSignal;
+    this.zkRegistrationSignal = checkNotNull(zkRegistrationSignal, "zkRegistrationSignal");
   }
 
 
   @Override
   protected void runOneIteration() throws InterruptedException {
+    // Wait for the agent to register itself with ZooKeeper to prevent this reporter from winning a
+    // race and then having its data erased.
     zkRegistrationSignal.await();
     final boolean succesful = nodeUpdater.update(Json.asBytesUnchecked(envVars));
     if (succesful) {


### PR DESCRIPTION
Wait for the agent to register itself with ZooKeeper to
prevent HostInfoReporter from winning a race in updating the
ZooKeeper node /status/hosts/<hostname>/hostinfo.

The ZooKeeperRegistrarService run by the agent checks the mtime
of the above znode and only tries to re-register if that znode
has been stale for a while (defaults to 10 minutes).

If we don't make HostInfoReporter wait, the agent will never
re-register itself in ZK.