### PR TITLE
fix race conditions when registering agents

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentInfoReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentInfoReporter.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * Report various Agent runtime information via ZK so it can be visible to clients of Helios.
@@ -43,12 +42,13 @@ public class AgentInfoReporter extends SignalAwaitingService {
   private final int interval;
   private final TimeUnit timeUnit;
 
-  AgentInfoReporter(final Builder builder) {
-    super(checkNotNull(builder.latch));
-    this.runtimeMXBean = checkNotNull(builder.runtimeMXBean);
-    this.nodeUpdater = builder.nodeUpdaterFactory.create(Paths.statusHostAgentInfo(builder.host));
-    this.interval = builder.interval;
-    this.timeUnit = checkNotNull(builder.timeUnit);
+  AgentInfoReporter(RuntimeMXBean runtimeMXBean, NodeUpdaterFactory nodeUpdaterFactory, String host,
+                    int interval, TimeUnit timeUnit, CountDownLatch latch) {
+    super(checkNotNull(latch));
+    this.runtimeMXBean = checkNotNull(runtimeMXBean);
+    this.nodeUpdater = nodeUpdaterFactory.create(Paths.statusHostAgentInfo(host));
+    this.interval = interval;
+    this.timeUnit = checkNotNull(timeUnit);
   }
 
   @Override
@@ -74,57 +74,5 @@ public class AgentInfoReporter extends SignalAwaitingService {
   protected ScheduledFuture<?> schedule(final Runnable runnable,
                                         final ScheduledExecutorService executorService) {
     return executorService.scheduleWithFixedDelay(runnable, 0, interval, timeUnit);
-  }
-
-  public static Builder newBuilder() {
-    return new Builder();
-  }
-
-  public static class Builder {
-
-    Builder() {
-    }
-
-    private NodeUpdaterFactory nodeUpdaterFactory;
-    private RuntimeMXBean runtimeMXBean;
-    private String host;
-    private int interval = 1;
-    private TimeUnit timeUnit = MINUTES;
-    private CountDownLatch latch;
-
-    public Builder setNodeUpdaterFactory(final NodeUpdaterFactory nodeUpdaterFactory) {
-      this.nodeUpdaterFactory = nodeUpdaterFactory;
-      return this;
-    }
-
-    public Builder setRuntimeMXBean(
-        final RuntimeMXBean runtimeMXBean) {
-      this.runtimeMXBean = runtimeMXBean;
-      return this;
-    }
-
-    public Builder setHost(final String host) {
-      this.host = host;
-      return this;
-    }
-
-    public Builder setInterval(final int interval) {
-      this.interval = interval;
-      return this;
-    }
-
-    public Builder setTimeUnit(final TimeUnit timeUnit) {
-      this.timeUnit = timeUnit;
-      return this;
-    }
-
-    public Builder setLatch(CountDownLatch latch) {
-      this.latch = latch;
-      return this;
-    }
-
-    public AgentInfoReporter build() {
-      return new AgentInfoReporter(this);
-    }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentInfoReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentInfoReporter.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Report various Agent runtime information via ZK so it can be visible to clients of Helios.
@@ -44,11 +44,11 @@ public class AgentInfoReporter extends SignalAwaitingService {
 
   AgentInfoReporter(RuntimeMXBean runtimeMXBean, NodeUpdaterFactory nodeUpdaterFactory, String host,
                     int interval, TimeUnit timeUnit, CountDownLatch latch) {
-    super(checkNotNull(latch));
-    this.runtimeMXBean = checkNotNull(runtimeMXBean);
+    super(latch);
+    this.runtimeMXBean = requireNonNull(runtimeMXBean);
     this.nodeUpdater = nodeUpdaterFactory.create(Paths.statusHostAgentInfo(host));
     this.interval = interval;
-    this.timeUnit = checkNotNull(timeUnit);
+    this.timeUnit = requireNonNull(timeUnit);
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -256,12 +256,14 @@ public class AgentService extends AbstractIdleService implements Managed {
         .setHost(config.getName())
         .setDockerClient(dockerClient)
         .setDockerHost(config.getDockerHost())
+        .setLatch(zkRegistrationSignal)
         .build();
 
     this.agentInfoReporter = AgentInfoReporter.newBuilder()
         .setNodeUpdaterFactory(nodeUpdaterFactory)
         .setRuntimeMXBean(getRuntimeMXBean())
         .setHost(config.getName())
+        .setLatch(zkRegistrationSignal)
         .build();
 
     this.environmentVariableReporter = new EnvironmentVariableReporter(

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -251,21 +251,14 @@ public class AgentService extends AbstractIdleService implements Managed {
     final DockerClient monitoredDockerClient = MonitoredDockerClient.wrap(riemannFacade,
                                                                           dockerClient);
 
-    this.hostInfoReporter = HostInfoReporter.newBuilder()
-        .setNodeUpdaterFactory(nodeUpdaterFactory)
-        .setOperatingSystemMXBean((OperatingSystemMXBean) getOperatingSystemMXBean())
-        .setHost(config.getName())
-        .setDockerClient(dockerClient)
-        .setDockerHost(config.getDockerHost())
-        .setLatch(zkRegistrationSignal)
-        .build();
+    this.hostInfoReporter =
+        new HostInfoReporter((OperatingSystemMXBean) getOperatingSystemMXBean(), nodeUpdaterFactory,
+                             config.getName(), dockerClient, config.getDockerHost(),
+                             1, TimeUnit.MINUTES, zkRegistrationSignal);
 
-    this.agentInfoReporter = AgentInfoReporter.newBuilder()
-        .setNodeUpdaterFactory(nodeUpdaterFactory)
-        .setRuntimeMXBean(getRuntimeMXBean())
-        .setHost(config.getName())
-        .setLatch(zkRegistrationSignal)
-        .build();
+    this.agentInfoReporter =
+        new AgentInfoReporter(getRuntimeMXBean(), nodeUpdaterFactory, config.getName(),
+                              1, TimeUnit.MINUTES, zkRegistrationSignal);
 
     this.environmentVariableReporter = new EnvironmentVariableReporter(
         config.getName(), config.getEnvVars(), nodeUpdaterFactory, zkRegistrationSignal);

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -402,7 +402,7 @@ public class AgentService extends AbstractIdleService implements Managed {
 
     // Register the agent
     final AgentZooKeeperRegistrar agentZooKeeperRegistrar = new AgentZooKeeperRegistrar(
-        this, config.getName(), id, config.getZooKeeperRegistrationTtlMinutes());
+        config.getName(), id, config.getZooKeeperRegistrationTtlMinutes());
     zkRegistrar = ZooKeeperRegistrarService.newBuilder()
         .setZooKeeperClient(client)
         .setZooKeeperRegistrar(agentZooKeeperRegistrar)

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -30,6 +30,7 @@ import com.spotify.docker.client.DockerCertificateException;
 import com.spotify.docker.client.DockerCertificates;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.helios.common.HeliosRuntimeException;
+import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.master.metrics.HealthCheckGauge;
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
@@ -404,7 +405,7 @@ public class AgentService extends AbstractIdleService implements Managed {
 
     // Register the agent
     final AgentZooKeeperRegistrar agentZooKeeperRegistrar = new AgentZooKeeperRegistrar(
-        config.getName(), id, config.getZooKeeperRegistrationTtlMinutes());
+        config.getName(), id, config.getZooKeeperRegistrationTtlMinutes(), new SystemClock());
     zkRegistrar = ZooKeeperRegistrarService.newBuilder()
         .setZooKeeperClient(client)
         .setZooKeeperRegistrar(agentZooKeeperRegistrar)

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.agent;
 
-import com.google.common.util.concurrent.Service;
-
 import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.master.HostNotFoundException;
@@ -104,7 +102,6 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
             final String message = format("Another agent already registered as '%s' " +
                                           "(local=%s remote=%s).", name, id, existingId);
             log.error(message);
-            // signal to the caller if registration was successful or not
             return false;
           }
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
@@ -50,7 +50,6 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
 
   private static final byte[] EMPTY_BYTES = new byte[]{};
 
-  private final Service agentService;
   private final String name;
   private final String id;
   private final long zooKeeperRegistrationTtlMillis;
@@ -58,9 +57,8 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
 
   private PersistentEphemeralNode upNode;
 
-  public AgentZooKeeperRegistrar(final Service agentService, final String name, final String id,
+  public AgentZooKeeperRegistrar(final String name, final String id,
                                  final int zooKeeperRegistrationTtlMinutes) {
-    this.agentService = agentService;
     this.name = name;
     this.id = id;
     this.zooKeeperRegistrationTtlMillis =
@@ -86,7 +84,7 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
   }
 
   @Override
-  public void tryToRegister(ZooKeeperClient client)
+  public boolean tryToRegister(ZooKeeperClient client)
       throws KeeperException, HostNotFoundException {
     final String idPath = Paths.configHostId(name);
     final String hostInfoPath = Paths.statusHostInfo(name);
@@ -106,8 +104,8 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
             final String message = format("Another agent already registered as '%s' " +
                                           "(local=%s remote=%s).", name, id, existingId);
             log.error(message);
-            agentService.stopAsync();
-            return;
+            // signal to the caller if registration was successful or not
+            return false;
           }
 
           log.info("Another agent has already registered as '{}', but its ID node was last " +
@@ -135,6 +133,7 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
     }
 
     log.info("ZooKeeper registration complete");
+    return true;
   }
 
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentZooKeeperRegistrar.java
@@ -18,7 +18,6 @@
 package com.spotify.helios.agent;
 
 import com.spotify.helios.common.Clock;
-import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.master.HostNotFoundException;
 import com.spotify.helios.servicescommon.ZooKeeperRegistrar;
 import com.spotify.helios.servicescommon.ZooKeeperRegistrarUtil;
@@ -56,12 +55,12 @@ public class AgentZooKeeperRegistrar implements ZooKeeperRegistrar {
   private PersistentEphemeralNode upNode;
 
   public AgentZooKeeperRegistrar(final String name, final String id,
-                                 final int zooKeeperRegistrationTtlMinutes) {
+                                 final int zooKeeperRegistrationTtlMinutes, final Clock clock) {
     this.name = name;
     this.id = id;
     this.zooKeeperRegistrationTtlMillis =
         TimeUnit.MILLISECONDS.convert(zooKeeperRegistrationTtlMinutes, TimeUnit.MINUTES);
-    this.clock = new SystemClock();
+    this.clock = clock;
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/agent/EnvironmentVariableReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/EnvironmentVariableReporter.java
@@ -33,28 +33,26 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * Puts the environment variables the Agent has been configured to set in all child containers
  * into ZK so they can be visible to the master and via the API.
  */
-public class EnvironmentVariableReporter extends InterruptingScheduledService {
+public class EnvironmentVariableReporter extends SignalAwaitingService {
 
   private static final int RETRY_INTERVAL_MILLIS = 1000;
 
   private final Map<String, String> envVars;
   private final ZooKeeperNodeUpdater nodeUpdater;
-  private final CountDownLatch zkRegistrationSignal;
 
   public EnvironmentVariableReporter(final String host, final Map<String, String> envVars,
                                      final NodeUpdaterFactory nodeUpdaterFactory,
                                      final CountDownLatch zkRegistrationSignal) {
+    super(zkRegistrationSignal);
     this.envVars = envVars;
     this.nodeUpdater = nodeUpdaterFactory.create(Paths.statusHostEnvVars(host));
-    this.zkRegistrationSignal = zkRegistrationSignal;
   }
 
 
   @Override
   protected void runOneIteration() throws InterruptedException {
-    zkRegistrationSignal.await();
-    final boolean succesful = nodeUpdater.update(Json.asBytesUnchecked(envVars));
-    if (succesful) {
+    final boolean successful = nodeUpdater.update(Json.asBytesUnchecked(envVars));
+    if (successful) {
       stopAsync();
     }
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/HostInfoReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/HostInfoReporter.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.propagate;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Reports various bits of system information to ZK so it can be viewed via the the API.
@@ -57,13 +57,14 @@ public class HostInfoReporter extends SignalAwaitingService {
                    NodeUpdaterFactory nodeUpdaterFactory, String host, DockerClient dockerClient,
                    DockerHost dockerHost, int interval, TimeUnit timeUnit, CountDownLatch latch) {
 
-    super(checkNotNull(latch));
-    this.operatingSystemMXBean = checkNotNull(operatingSystemMXBean, "operatingSystemMXBean");
-    this.nodeUpdater = nodeUpdaterFactory.create(Paths.statusHostInfo(checkNotNull(host, "host")));
-    this.dockerClient = checkNotNull(dockerClient, "dockerClient");
-    this.dockerHost = checkNotNull(dockerHost, "dockerHost");
+    super(latch);
+    this.operatingSystemMXBean = requireNonNull(operatingSystemMXBean, "operatingSystemMXBean");
+    final String hostInfoPath = Paths.statusHostInfo(requireNonNull(host, "host"));
+    this.nodeUpdater = nodeUpdaterFactory.create(hostInfoPath);
+    this.dockerClient = requireNonNull(dockerClient, "dockerClient");
+    this.dockerHost = requireNonNull(dockerHost, "dockerHost");
     this.interval = interval;
-    this.timeUnit = checkNotNull(timeUnit, "timeUnit");
+    this.timeUnit = requireNonNull(timeUnit, "timeUnit");
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/agent/SignalAwaitingService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SignalAwaitingService.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -35,7 +36,7 @@ public abstract class SignalAwaitingService extends InterruptingScheduledService
   private final CountDownLatch signal;
 
   public SignalAwaitingService(final CountDownLatch signal) {
-    this.signal = signal;
+    this.signal = Objects.requireNonNull(signal);
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/agent/SignalAwaitingService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SignalAwaitingService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * An InterruptingScheduledService which awaits on a CountDownLatch prior to
+ * {@link #runOneIteration()}. This can be used to have the Service fully enter the RUNNING state
+ * and schedule it's periodic task, but block the actual execution of the task until some condition
+ * is met by another thread.
+ * <p>
+ * Implementation note: await() is called in the thread running the "periodic task" as it is
+ * easier to interrupt that thread when the Service is shut down; blocking on the latch in the
+ * startUp() method caused the Service to never exit (and prevent the JVM from exiting normally
+ * on SIGINT).</p>
+ */
+public abstract class SignalAwaitingService extends InterruptingScheduledService {
+
+  private final CountDownLatch signal;
+
+  public SignalAwaitingService(final CountDownLatch signal) {
+    this.signal = signal;
+  }
+
+  @Override
+  protected void beforeIteration() throws InterruptedException {
+    signal.await();
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterZooKeeperRegistrar.java
@@ -64,7 +64,7 @@ public class MasterZooKeeperRegistrar implements ZooKeeperRegistrar {
   }
 
   @Override
-  public void tryToRegister(final ZooKeeperClient client) throws KeeperException {
+  public boolean tryToRegister(final ZooKeeperClient client) throws KeeperException {
 
     client.ensurePath(Paths.configHosts());
     client.ensurePath(Paths.configJobs());
@@ -83,5 +83,6 @@ public class MasterZooKeeperRegistrar implements ZooKeeperRegistrar {
     }
 
     log.info("ZooKeeper registration complete");
+    return true;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/ZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/ZooKeeperRegistrar.java
@@ -42,9 +42,10 @@ public interface ZooKeeperRegistrar {
    * Called when ZK client connects. Handler should attempt to do on connection initialization here.
    *
    * @param client The zookeeper client.
+   * @return if registration was successful
    * @throws KeeperException If an unexpected zookeeper error occurs.
    * @throws HostNotFoundException If the hostname we are trying to re-register as doesn't exist.
    */
-  void tryToRegister(final ZooKeeperClient client)
+  boolean tryToRegister(final ZooKeeperClient client)
       throws KeeperException, HostNotFoundException;
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/ZooKeeperRegistrarService.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/ZooKeeperRegistrarService.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.util.concurrent.Service.State.STOPPING;
@@ -175,7 +176,8 @@ public class ZooKeeperRegistrarService extends AbstractIdleService {
           zkRegistrationSignal.ifPresent(CountDownLatch::countDown);
           return;
         } else {
-          log.info("registration not successful, sleeping for {} ms", sleep);
+          log.warn("registration not successful, sleeping for {} seconds",
+                   TimeUnit.MILLISECONDS.toSeconds(sleep));
           sleeper.sleep(sleep);
         }
       }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Check.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Check.java
@@ -38,4 +38,24 @@ public class Check implements ZooKeeperOperation {
            "path='" + path + '\'' +
            '}';
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final Check check = (Check) o;
+
+    return path != null ? path.equals(check.path) : check.path == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    return path != null ? path.hashCode() : 0;
+  }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CheckWithVersion.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CheckWithVersion.java
@@ -41,4 +41,29 @@ public class CheckWithVersion implements ZooKeeperOperation {
            ", version=" + version +
            '}';
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CheckWithVersion that = (CheckWithVersion) o;
+
+    if (version != that.version) {
+      return false;
+    }
+    return path != null ? path.equals(that.path) : that.path == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = path != null ? path.hashCode() : 0;
+    result = 31 * result + version;
+    return result;
+  }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateMany.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateMany.java
@@ -42,4 +42,24 @@ public class CreateMany implements ZooKeeperOperation {
            "nodes=" + nodes.keySet() +
            '}';
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CreateMany that = (CreateMany) o;
+
+    return nodes != null ? nodes.equals(that.nodes) : that.nodes == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    return nodes != null ? nodes.hashCode() : 0;
+  }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateWithData.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateWithData.java
@@ -19,6 +19,8 @@ package com.spotify.helios.servicescommon.coordination;
 
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 
+import java.util.Arrays;
+
 class CreateWithData implements ZooKeeperOperation {
 
   private final String path;
@@ -39,5 +41,30 @@ class CreateWithData implements ZooKeeperOperation {
     return "CreateWithData{" +
            "path='" + path + '\'' +
            '}';
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CreateWithData that = (CreateWithData) o;
+
+    if (path != null ? !path.equals(that.path) : that.path != null) {
+      return false;
+    }
+    return Arrays.equals(data, that.data);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = path != null ? path.hashCode() : 0;
+    result = 31 * result + Arrays.hashCode(data);
+    return result;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateWithDataAndVersion.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/CreateWithDataAndVersion.java
@@ -19,6 +19,8 @@ package com.spotify.helios.servicescommon.coordination;
 
 import org.apache.curator.framework.api.transaction.CuratorTransaction;
 
+import java.util.Arrays;
+
 class CreateWithDataAndVersion implements ZooKeeperOperation {
 
   private final String path;
@@ -44,5 +46,34 @@ class CreateWithDataAndVersion implements ZooKeeperOperation {
            "path='" + path + '\'' +
            ", version=" + version +
            '}';
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final CreateWithDataAndVersion that = (CreateWithDataAndVersion) o;
+
+    if (version != that.version) {
+      return false;
+    }
+    if (path != null ? !path.equals(that.path) : that.path != null) {
+      return false;
+    }
+    return Arrays.equals(data, that.data);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = path != null ? path.hashCode() : 0;
+    result = 31 * result + Arrays.hashCode(data);
+    result = 31 * result + version;
+    return result;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/DeleteMany.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/DeleteMany.java
@@ -42,4 +42,24 @@ public class DeleteMany implements ZooKeeperOperation {
            "paths=" + paths +
            '}';
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final DeleteMany that = (DeleteMany) o;
+
+    return paths != null ? paths.equals(that.paths) : that.paths == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    return paths != null ? paths.hashCode() : 0;
+  }
 }

--- a/helios-services/src/test/java/com/spotify/helios/agent/AgentZooKeeperRegistrarTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AgentZooKeeperRegistrarTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.spotify.helios.common.Clock;
+import com.spotify.helios.servicescommon.coordination.Paths;
+import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
+import com.spotify.helios.servicescommon.coordination.ZooKeeperOperation;
+import com.spotify.helios.servicescommon.coordination.ZooKeeperOperations;
+
+import org.apache.curator.framework.recipes.nodes.PersistentEphemeralNode;
+import org.apache.zookeeper.data.Stat;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AgentZooKeeperRegistrarTest {
+
+  private final ZooKeeperClient client = mock(ZooKeeperClient.class);
+
+  private final String agentName = "agent";
+  private final String hostId = "1234";
+  private final int registrationTTL = 2;
+
+  // a clock that always returns the same time
+  private final Instant now = Instant.now();
+  private final Clock clock = () -> now;
+
+  private final AgentZooKeeperRegistrar registrar =
+      new AgentZooKeeperRegistrar(agentName, hostId, registrationTTL, clock);
+
+  private final String hostPath = Paths.statusHostInfo(agentName);
+  private final String upPath = Paths.statusHostUp(agentName);
+  private final String idPath = Paths.configHostId(agentName);
+
+  @Before
+  public void setUp() throws Exception {
+    registrar.startUp();
+
+    final PersistentEphemeralNode ephemeralNode = mock(PersistentEphemeralNode.class);
+    when(client.persistentEphemeralNode(upPath,
+                                        PersistentEphemeralNode.Mode.EPHEMERAL,
+                                        new byte[]{}))
+        .thenReturn(ephemeralNode);
+
+    // default behavior for checking ID of the host registered in zookeeper - it is this host
+    when(client.exists(idPath)).thenReturn(new Stat());
+    when(client.getData(idPath)).thenReturn(hostId.getBytes());
+  }
+
+  @Test
+  public void newRegistration() throws Exception {
+    // stat = null means path does not exist
+    when(client.exists(idPath)).thenReturn(null);
+    when(client.stat(hostPath)).thenReturn(null);
+
+    final boolean success = registrar.tryToRegister(client);
+    assertTrue(success);
+
+    // verify the id was claimed in zookeeper
+    verify(client).createAndSetData(idPath, hostId.getBytes());
+  }
+
+  @Test
+  public void alreadyRegistered_SameHostId() throws Exception {
+    final boolean success = registrar.tryToRegister(client);
+    assertTrue(success);
+
+    // no need to re-write the id path
+    verify(client, never()).createAndSetData(idPath, hostId.getBytes());
+  }
+
+  @Test
+  public void recentRegistrationExists_DifferentHostId() throws Exception {
+    // hostInfo has been updated for this host name very recently...
+    final Stat hostInfo = new Stat();
+    hostInfo.setMtime(clock.now().getMillis());
+    when(client.stat(hostPath)).thenReturn(hostInfo);
+
+    // ... and the name is claimed by a different ID
+    when(client.getData(idPath)).thenReturn("a different host".getBytes());
+
+    final boolean success = registrar.tryToRegister(client);
+    assertFalse(success);
+
+    verify(client, never()).createAndSetData(idPath, hostId.getBytes());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void oldRegistrationExists_DifferentHostId() throws Exception {
+    // the hostname is claimed by a different ID...
+    when(client.getData(idPath)).thenReturn("a different host".getBytes());
+
+    // ... but the hostInfo was last updated more than TTL minutes ago
+    final Stat hostInfo = new Stat();
+    hostInfo.setMtime(clock.now().minus(Duration.standardMinutes(registrationTTL * 2)).getMillis());
+    when(client.stat(hostPath)).thenReturn(hostInfo);
+
+    // expect the old host to be deregistered and this registration to succeed
+    final boolean success = registrar.tryToRegister(client);
+    assertTrue(success);
+
+    // expect a transaction containing a delete of the idpath followed by a create
+    // // TODO (mbrown): this should really be in a test of ZooKeeperRegistrarUtil, and
+    // AgentZooKeeperRegistrar should not call a static method to do this
+    ArgumentCaptor<List> opsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(client).transaction(opsCaptor.capture());
+
+    // note that we are not testing full equality of the list, just that it contains
+    // a few notable items
+    final List<ZooKeeperOperation> actual = opsCaptor.getValue();
+    assertThat(actual, hasItems(ZooKeeperOperations.delete(idPath),
+                                ZooKeeperOperations.create(idPath, hostId.getBytes())));
+  }
+}


### PR DESCRIPTION
There are two race conditions in the logic around registering agents that occurs if the host being registered has a different ID than what is already stored in ZooKeeper. 

Combined, these can cause newly-reinstalled hosts (e.g. the host has been reformatted and had it's OS reinstalled) to get stuck in a loop where they will never be able to register if the reinstall process took less than the `zkRegistrationTTL` (which defaults to 10 minutes).

race condition one
------------------
This race condition occurs when an agent with a hostname collision (it has the hostname of an agent already registered in Zookeeper but it's `id` does not match) attempts to register itself.

If the automatic-deregistration logic does not kick in, AgentZooKeeperRegistrar attempts to shut down the AgentService and therefore the agent itself.

However the HostInfoReporter and AgentInfoReporter have already been started asynchronously by the AgentService. The HostInfoReporter in particular overwrites the existing data at `/status/hosts/<hostname>/hostinfo` with the HostInfo of the hostname with the collision (and which is about to be shut down).

Overwriting the `/status/hosts/<hostname>/hostinfo` path causes it's `mtime` to be updated. This is the same exact `mtime` that AgentZooKeeperRegistrar uses to decide if enough time has passed to do the automatic deregistration of the old node.

This can cause the new agent (for instance, after reinstalling the operating system) to get stuck in a loop where it tries to register, fails, shuts down, and is restarted by Upstart. This loop will never end because of the race condition that will bump the mtime of the Znode (which seems to win the race at least once every few iterations).

To fix this, introduce a new type of InterruptingScheduledService that awaits on a CountDownLatch before executing it's task. This class is then extended by HostInfoReporter, LabelReporter, etc. This avoids having to add code to each of these Reporters to block on the latch before executing their task. LabelReporter and EnvironmentReporter already have this behavior.

race condition two
------------------
If the AgentZooKeeperRegistrar cannot register the agent because of a hostname conflict, it attempts to shut down the AgentService and exits itself; however, the ZooKeeperRegistrarService counts down on the "registration signal" latch anyway, unblocking any reporters waiting on it.

This PR changes ZooKeeperRegistrar so that it has to return if it was able to register or not. When registration is not successful, ZooKeeperRegistrarService backs off and retries later (as it already does for Zookeeper exceptions). The registration signal is only counted-down on an actual successful registration, preventing possible race conditions with any threads that might be waiting on that signal to do work in Zookeeper that should only proceed when registration is successful.

This causes the agent registration to be retried after some delay, according to ZooKeeperRegistrarService's retry policy, so that it can eventually succeed (or at least keep trying). The AgentService (and the agent itself) is no longer terminated when registration collisions occur.