### PR TITLE
add CLI arguments for request timeouts

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -265,8 +265,6 @@ public class CliParser {
     private final Argument verbose;
     private final Argument noLogSetup;
     private final Argument jsonArg;
-    private final Argument insecureHttps;
-
     private final ArgumentGroup globalArgs;
     private final boolean topLevel;
 
@@ -311,13 +309,28 @@ public class CliParser {
           .action(storeTrue())
           .help(SUPPRESS);
 
-      insecureHttps = addArgument("-k", "--insecure")
+      // note: because of the way the HeliosClient is constructed, these next arguments are
+      // read indirectly in cli/Utils.java:
+
+      addArgument("-k", "--insecure")
           .action(storeTrue())
           .help("Disables hostname verification of HTTPS connections. "
                 + "Similar to 'curl -k'. "
                 + "Useful when using -z flag to connect directly to a master using HTTPS which "
                 + "presents a certificate whose subject does not match the actual hostname."
           );
+
+      addArgument("--http-timeout")
+          .type(Integer.class)
+          .setDefault(10)
+          .help("Timeout (in seconds) for each HTTP/S request to the master.");
+
+      addArgument("--retry-timeout")
+          .type(Integer.class)
+          .setDefault(60)
+          .help("Total timeout (in seconds) for all of the requests that helios makes to the "
+                + "master. If an individual request fails, helios will retry the request again "
+                + "until successful or until this timeout elapses.");
     }
 
     private Argument addArgument(final String... nameOrFlags) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -41,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 
@@ -71,6 +72,9 @@ public class Utils {
 
     return HeliosClient.newBuilder()
         .setEndpointSupplier(Endpoints.of(target.getEndpointSupplier()))
+        //argparse4j converts names like "--http-timeout" to dests of "http_timeout"
+        .setHttpTimeout(options.getInt("http_timeout"), TimeUnit.SECONDS)
+        .setRetryTimeout(options.getInt("retry_timeout"), TimeUnit.SECONDS)
         .setSslHostnameVerification(!options.getBoolean("insecure"))
         .setUser(username)
         .build();


### PR DESCRIPTION
Allows for customization of the individual HTTP request timeout (previously hardcoded to 10 seconds on socket connect/reads) and the total amount of time to spend retrying requests.

Can be useful if sending a command to a Helios master that has thousands of jobs in the output or if the master is otherwise slow.