### PR TITLE
Fix SkyDNS setup for helios-solo

### DIFF
--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -8,7 +8,7 @@ etcd $ETCD_OPTS &
 
 NAMESERVERS=$(cat /etc/resolv.conf | grep nameserver |
               python -c "import json, sys; ns=['%s:53' % (l.strip().split()[1], ) for l in sys.stdin]; print json.dumps(ns or ['8.8.8.8:53', '8.8.4.4:53']);")
-SKYDNS_PATH=$(echo $HELIOS_NAME|python -c "import sys;h=sys.stdin.read().strip().split('.');h.reverse();print '/'.join(h)")
+SKYDNS_PATH=$(echo $HELIOS_NAME|python -c "import sys;h=sys.stdin.read().strip().rstrip('.').split('.');h.reverse();print '/'.join(h)")
 
 # Write skydns configuration and retry for 30 seconds until successful
 for i in {1..30}; do


### PR DESCRIPTION
In the default case of HELIOS_NAME being set to helios.solo. the
SkyDNS curl tried to access

    http://127.0.0.1:4001/v2/keys/skydns//solo/helios

and got back a 301 Moved Permanently. Since curl doesn't follow that
automatically the DNS entry was never set.

Also SkyDNS was only set to be the authorative source
for "local." domain and in the default case the domain is "solo.".

The new approach should set things up correctly in the default case
and force a "local." domain in case the HELIOS_NAME is set without a
domain.