### PR TITLE
Include username in X509 cert cache key

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
@@ -62,6 +62,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.cert.X509Certificate;
@@ -70,7 +71,7 @@ import java.util.Date;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static com.spotify.helios.common.Hash.sha1digest;
+import static com.spotify.helios.common.Hash.sha1;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
 
@@ -111,8 +112,11 @@ public class X509CertificateFactory {
 
   public CertificateAndPrivateKey get(final AgentProxy agentProxy, final Identity identity,
                                       final String username) {
-    final String identityHex = HEX_ENCODING.encode(
-        sha1digest(identity.getKeyBlob())).substring(0, 8);
+    final MessageDigest identityHash = sha1();
+    identityHash.update(identity.getKeyBlob());
+    identityHash.update(username.getBytes());
+
+    final String identityHex = HEX_ENCODING.encode(identityHash.digest()).substring(0, 8);
     final Path cacheCertPath = cacheDirectory.resolve(identityHex + ".crt");
     final Path cacheKeyPath = cacheDirectory.resolve(identityHex + ".pem");
 

--- a/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/tls/X509CertificateFactoryTest.java
@@ -129,4 +129,18 @@ public class X509CertificateFactoryTest {
                not(equalTo(original.getPrivateKey().getEncoded())));
   }
 
+  @Test
+  public void testCacheWithNewUsername() throws Exception {
+    final CertificateAndPrivateKey original = sut.get(agentProxy, identity, USERNAME);
+
+    // invocation with a different username should return different cert & keypair
+    final CertificateAndPrivateKey shouldBeNew = sut.get(agentProxy, identity, USERNAME + "2");
+    assertThat("cached certificate being used with new username",
+               shouldBeNew.getCertificate().getEncoded(),
+               not(equalTo(original.getCertificate().getEncoded())));
+    assertThat("cached key being used with new username",
+               shouldBeNew.getPrivateKey().getEncoded(),
+               not(equalTo(original.getPrivateKey().getEncoded())));
+  }
+
 }


### PR DESCRIPTION
Previously, the cached certificate would be used even if the username was
different. For example, if a user ran `helios -u A` and then `helios -u B`,
the cached certificate with `/UID=A` would still be used.