### PR TITLE
ensure ports are waited on when using TemporaryJobs.jobWithConfig()

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -66,7 +66,7 @@ public class TemporaryJobBuilder {
   private final String jobNamePrefix;
   private final Map<String, String> env;
   private final TemporaryJobReports.ReportWriter reportWriter;
-  
+
   private String hostFilter;
   private Prober prober;
   private TemporaryJob job;
@@ -85,6 +85,13 @@ public class TemporaryJobBuilder {
     this.builder.setRegistrationDomain(jobNamePrefix);
     this.env = env;
     this.reportWriter = reportWriter;
+
+    // make sure waitPorts is up-to-date with ports from the Job.Builder
+    for (Map.Entry<String, PortMapping> entry : jobBuilder.getPorts().entrySet()) {
+      final String name = entry.getKey();
+      final PortMapping mapping = entry.getValue();
+      this.port(name, mapping.getInternalPort(), mapping.getExternalPort());
+    }
   }
 
   public TemporaryJobBuilder version(final String jobVersion) {

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobBuilderTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.PortMapping;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class TemporaryJobBuilderTest {
+
+  @Test
+  public void testBuildFromJob() {
+    final Job job = Job.newBuilder()
+        .setName("foo")
+        .addPort("http", PortMapping.of(8080))
+        .build();
+
+    final Deployer deployer = mock(Deployer.class);
+    final Prober prober = mock(Prober.class);
+    final Map<String, String> env = Collections.emptyMap();
+    final TemporaryJobReports.ReportWriter reportWriter =
+        mock(TemporaryJobReports.ReportWriter.class);
+
+    final TemporaryJobBuilder temporaryJobBuilder =
+        new TemporaryJobBuilder(deployer, "prefix-", prober, env, reportWriter, job.toBuilder());
+
+    final ImmutableList<String> hosts = ImmutableList.of("host1");
+
+    temporaryJobBuilder.deploy(hosts);
+
+    final ImmutableSet<String> expectedWaitPorts = ImmutableSet.of("http");
+    verify(deployer).deploy(any(Job.class), eq(hosts), eq(expectedWaitPorts),
+                            eq(prober), eq(reportWriter));
+  }
+}


### PR DESCRIPTION
If you construct a TemporaryJob like:

```java
job = temporaryJobs.jobWithConfig("helios_job_config.json")
  .imageFromBuild()
  .deploy();
```

and the job config looks like:

```json
{
  "ports": {
    "http": { "internalPort" : 8080}
  }
}
```

then TemporaryJobs does not check when deploying to see if the job's
external port can be reached in the same way that it would if the
TemporaryJob was constructed like:

```
job = temporaryJobs.job()
  .imageFromBuild()
  .port("http", 8080)
  .deploy();
```

This difference in behavior is because the `waitPorts` set in
TemporaryJobBuilder is not updated in the same way when passed a
`Job.Builder` that has ports defined as it is when
`TemporaryJobBuilder.port(..)` is called.