### PR TITLE
Make HeliosSoloDeployment clean up leftover jobs

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -405,6 +405,13 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   /**
+   * @return The container ID of the Helios Solo container.
+   */
+  public String heliosContainerId() {
+    return heliosContainerId;
+  }
+
+  /**
    * Undeploy (shut down) this HeliosSoloDeployment.
    */
   public void close() {
@@ -457,7 +464,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
         }
       }
     } catch (Exception e) {
-      log.warn("Something went wrong.", e);
+      log.warn("Exception occurred when trying to clean up leftover temp jobs.", e);
     }
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -444,11 +444,12 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   @VisibleForTesting
   protected void undeployLeftoverJobs() {
     try {
-      // List all jobs. TemporaryJobs should delete jobs in addition to undeploying them.
+      // List all jobs. If we are using TemporaryJobs, that class should've deleted them at this
+      // point in addition to undeploying them.
       // So any jobs found at this point have only been partially cleaned up.
       final Map<JobId, Job> jobs = heliosClient.jobs().get();
       if (jobs.size() > 0) {
-        log.info("There are jobs in helios-solo left over by TemporaryJobs. " +
+        log.info("There are leftover jobs deployed by helios-solo. " +
                  "Undeploying and deleting them now. Jobs: {}", jobs.keySet());
       }
 
@@ -477,7 +478,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
         }
       }
     } catch (Exception e) {
-      log.warn("Exception occurred when trying to clean up leftover temp jobs.", e);
+      log.warn("Exception occurred when trying to clean up leftover jobs.", e);
     }
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
@@ -27,8 +27,8 @@ import static java.lang.System.nanoTime;
 
 class Polling {
 
-  private static <T> T await(final long timeout, final TimeUnit timeUnit,
-                             final Callable<T> callable) throws Exception {
+  static <T> T await(final long timeout, final TimeUnit timeUnit,
+                     final Callable<T> callable) throws Exception {
     final long deadline = nanoTime() + timeUnit.toNanos(timeout);
     while (nanoTime() < deadline) {
       final T value = callable.call();

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -22,6 +22,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.SettableFuture;
 
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
@@ -37,7 +38,15 @@ import com.spotify.docker.client.messages.ImageInfo;
 import com.spotify.docker.client.messages.Info;
 import com.spotify.docker.client.messages.NetworkSettings;
 import com.spotify.docker.client.messages.PortBinding;
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Goal;
+import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.JobStatus;
 import com.spotify.helios.common.descriptors.TaskStatus;
+import com.spotify.helios.common.protocol.JobUndeployResponse;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -45,7 +54,9 @@ import com.typesafe.config.ConfigValueFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,16 +76,41 @@ public class HeliosSoloDeploymentTest {
 
   private static final String CONTAINER_ID = "abc123";
   private static final String BUSYBOX = "busybox:latest";
-  public static final List<String> IDLE_COMMAND = asList(
+  private static final List<String> IDLE_COMMAND = asList(
       "sh", "-c", "trap 'exit 0' SIGINT SIGTERM; while :; do sleep 1; done");
+  private static final String HOST1 = "host1";
+  private static final String HOST2 = "host2";
+  private static final Job JOB1 = Job.newBuilder()
+      .setCommand(ImmutableList.of("BOGUS1"))
+      .setImage("IMAGE")
+      .setName("NAME")
+      .setVersion("VERSION")
+      .build();
+  private static final Job JOB2 = Job.newBuilder()
+      .setCommand(ImmutableList.of("BOGUS2"))
+      .setImage("IMAGE")
+      .setName("NAME")
+      .setVersion("VERSION")
+      .build();
+  private static final TaskStatus TASK_STATUS1 = TaskStatus.newBuilder()
+      .setJob(JOB1)
+      .setGoal(Goal.START)
+      .setState(TaskStatus.State.RUNNING)
+      .build();
+  private static final TaskStatus TASK_STATUS2 = TaskStatus.newBuilder()
+      .setJob(JOB2)
+      .setGoal(Goal.START)
+      .setState(TaskStatus.State.RUNNING)
+      .build();
 
   private DockerClient dockerClient;
+  private HeliosClient heliosClient;
   private ArgumentCaptor<ContainerConfig> containerConfig;
-  private ContainerCreation creation;
 
   @Before
   public void setup() throws Exception {
     this.dockerClient = mock(DockerClient.class);
+    this.heliosClient = mock(HeliosClient.class);
 
     // the anonymous classes to override a method are to workaround the docker-client "messages"
     // having no mutators, fun
@@ -88,11 +124,11 @@ public class HeliosSoloDeploymentTest {
     // mock the call to dockerClient.createContainer so we can test the arguments passed to it
     this.containerConfig = ArgumentCaptor.forClass(ContainerConfig.class);
 
-    this.creation = mock(ContainerCreation.class);
-    when(this.creation.id()).thenReturn(CONTAINER_ID);
+    final ContainerCreation creation = mock(ContainerCreation.class);
+    when(creation.id()).thenReturn(CONTAINER_ID);
 
     when(this.dockerClient.createContainer(
-        this.containerConfig.capture(), anyString())).thenReturn(this.creation);
+        this.containerConfig.capture(), anyString())).thenReturn(creation);
 
     // we have to mock out several other calls to get the HeliosSoloDeployment ctor
     // to return non-exceptionally. the anonymous classes to override a method are to workaround
@@ -194,6 +230,77 @@ public class HeliosSoloDeploymentTest {
         .build();
 
     verify(this.dockerClient).pull(HeliosSoloDeployment.PROBE_IMAGE);
+  }
+
+  @Test
+  public void testUndeployLeftoverJobs() throws Exception {
+    final HeliosSoloDeployment solo = (HeliosSoloDeployment) HeliosSoloDeployment.builder()
+        .dockerClient(dockerClient)
+        .heliosClient(heliosClient)
+        .build();
+
+    final SettableFuture<Map<JobId, Job>> jobsFuture = SettableFuture.create();
+    jobsFuture.set(ImmutableMap.of(JOB1.getId(), JOB1, JOB2.getId(), JOB2));
+    when(heliosClient.jobs()).thenReturn(jobsFuture);
+
+    final SettableFuture<JobStatus> statusFuture1 = SettableFuture.create();
+    statusFuture1.set(JobStatus.newBuilder().setTaskStatuses(ImmutableMap.of(
+        HOST1, TASK_STATUS1
+    )).build());
+    final SettableFuture<JobStatus> statusFuture2 = SettableFuture.create();
+    statusFuture2.set(JobStatus.newBuilder().setTaskStatuses(ImmutableMap.of(
+        HOST2, TASK_STATUS2
+    )).build());
+    when(heliosClient.jobStatus(JOB1.getId())).thenReturn(statusFuture1);
+    when(heliosClient.jobStatus(JOB2.getId())).thenReturn(statusFuture2);
+
+    final SettableFuture<JobUndeployResponse> undeployFuture1 = SettableFuture.create();
+    undeployFuture1.set(new JobUndeployResponse(
+        JobUndeployResponse.Status.OK, HOST1, JOB1.getId()));
+    final SettableFuture<JobUndeployResponse> undeployFuture2 = SettableFuture.create();
+    undeployFuture2.set(new JobUndeployResponse(
+        JobUndeployResponse.Status.OK, HOST2, JOB1.getId()));
+    when(heliosClient.undeploy(JOB1.getId(), HOST1)).thenReturn(undeployFuture1);
+    when(heliosClient.undeploy(JOB2.getId(), HOST2)).thenReturn(undeployFuture2);
+
+    final SettableFuture<HostStatus> hostStatusFuture1 = SettableFuture.create();
+    hostStatusFuture1.set(HostStatus.newBuilder()
+                              .setStatus(HostStatus.Status.UP)
+                              .setStatuses(Collections.<JobId, TaskStatus>emptyMap())
+                              .setJobs(ImmutableMap.of(JOB1.getId(),
+                                                       Deployment.of(JOB1.getId(), Goal.START)))
+                              .build());
+    final SettableFuture<HostStatus> hostStatusFuture2 = SettableFuture.create();
+    hostStatusFuture2.set(HostStatus.newBuilder()
+                              .setStatus(HostStatus.Status.UP)
+                              .setStatuses(Collections.<JobId, TaskStatus>emptyMap())
+                              .setJobs(ImmutableMap.of(JOB2.getId(),
+                                                       Deployment.of(JOB2.getId(), Goal.START)))
+                              .build());
+    when(heliosClient.hostStatus(HOST1)).thenReturn(hostStatusFuture1);
+    when(heliosClient.hostStatus(HOST2)).thenReturn(hostStatusFuture2);
+
+    solo.undeployLeftoverJobs();
+
+    verify(heliosClient).undeploy(JOB1.getId(), HOST1);
+    verify(heliosClient).undeploy(JOB2.getId(), HOST2);
+  }
+
+  @Test
+  public void testUndeployLeftoverJobs_noLeftoverJobs() throws Exception {
+    final HeliosSoloDeployment solo = (HeliosSoloDeployment) HeliosSoloDeployment.builder()
+        .dockerClient(dockerClient)
+        .heliosClient(heliosClient)
+        .build();
+
+    final SettableFuture<Map<JobId, Job>> jobsFuture = SettableFuture.create();
+    jobsFuture.set(Collections.<JobId, Job>emptyMap());
+    when(heliosClient.jobs()).thenReturn(jobsFuture);
+
+    solo.undeployLeftoverJobs();
+
+    // There should be no more calls to any HeliosClient methods.
+    verify(heliosClient, never()).jobStatus(Matchers.any(JobId.class));
   }
 
   @Test


### PR DESCRIPTION
Sometimes TemporaryJobs doesn't undeploy its jobs.
This might be due to a race condition between tearing down
of TemporaryJobs and HeliosSoloDeployment.

Make HeliosSoloDeployment undeploy and remove leftover
temp jobs.