### PR TITLE
Add helpful error message for TempJob + solo

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJob.java
@@ -331,7 +331,10 @@ public class TemporaryJob {
       }
       throw new AssertionError(format(
           "Unexpected job state %s for job %s with image %s on host %s. Check helios agent "
-          + "logs for details.", stateString, job.getId().toShortString(), job.getImage(), host));
+          + "logs for details. If you're using HeliosSoloDeployment, set "
+          + "`HeliosSoloDeployment.fromEnv().removeHeliosSoloOnExit(false)` and check the"
+          + "logs of the helios-solo container with `docker logs <container ID>`.",
+          stateString, job.getId().toShortString(), job.getImage(), host));
     }
   }
 


### PR DESCRIPTION
to tell users how to get logs from HeliosSoloDeployment.