### PR TITLE
fix small errors in healthcheck section

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -330,9 +330,13 @@ code of 2xx or 3xx as successful. HTTP health checks are specified in the form `
 where `port_name` is the **name** of the exposed port (as set in the `--port` argument), and `path`
 is the path portion of the URL. Requests have a connect timeout of 500ms and a read timeout of 10s.
 
-    helios create --http-check http:health -p http=8080 ...
+To specify a HTTP healthcheck in the CLI arguments:
 
-In your Helios job config file:
+```bash
+$ helios create --http-check http:/healthcheck -p http=8080 ...
+```
+
+or instead to specify the healthcheck in your Helios job config file:
 
 ```json
 "healthCheck" : {
@@ -346,9 +350,13 @@ In your Helios job config file:
 This health check succeeds if it is able to connect to the specified port. You must specify the
 **name** of the port as set in the `--port` argument. Each request will timeout after 500ms.
 
-    helios create --tcp-check http-admin -p http-admin=4229 ...
+To specify a TCP healthcheck in the CLI arguments:
 
-In your Helios job config file:
+```bash
+$ helios create --tcp-check http-admin -p http-admin=4229 ...
+```
+
+or instead to specify the healthcheck in your Helios job config file:
 
 ```json
 "healthCheck" : {
@@ -363,9 +371,11 @@ This health check runs `docker exec` with the provided command. The service will
 in service discovery until the command executes successfully in the container, i.e. exits with
 status code 0.
 
-    helios create --exec-check "ping google.com" ...
+```bash
+$ helios create --exec-check "ping google.com" ...
+```
 
-In your Helios job config file:
+or instead to specify the healthcheck in your Helios job config file:
 
 ```json
 "healthCheck" : {


### PR DESCRIPTION
When using `--http-check` on command line, the argument for path needs to start with a `/`. Also update the path in the example to match the JSON example, and clarify that only one of the two (CLI args or json) needs to be specified.