### PR TITLE
avoid use of MoreObjects.toStringHelper

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -299,6 +299,11 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="severity" value="warning"/>
     </module>
 
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="MoreObjects\.toStringHelper"/>
+      <property name="message" value="Avoid using MoreObjects.toStringHelper as it places an unnecessary dependency on very recent versions of Guava" />
+    </module>
+
   </module>
 </module>
 

--- a/helios-client/src/main/java/com/spotify/helios/client/ClientCertificatePath.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/ClientCertificatePath.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.client;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 import java.nio.file.Path;
@@ -75,9 +74,9 @@ public class ClientCertificatePath {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("certificatePath", certificatePath)
-        .add("keyPath", keyPath)
-        .toString();
+    return "ClientCertificatePath{" +
+           "certificatePath=" + certificatePath +
+           ", keyPath=" + keyPath +
+           '}';
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/client/Endpoints.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/Endpoints.java
@@ -18,7 +18,6 @@
 package com.spotify.helios.client;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
@@ -162,10 +161,10 @@ public class Endpoints {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("uri", uri)
-          .add("ip", ip)
-          .toString();
+      return "DefaultEndpoint{" +
+             "ip=" + ip +
+             ", uri=" + uri +
+             '}';
     }
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Deployment.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Deployment.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -123,13 +121,13 @@ public class Deployment extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("jobId", jobId)
-        .add("goal", goal)
-        .add("deployerUser", deployerUser)
-        .add("deployerMaster", deployerMaster)
-        .add("deploymentGroupName", deploymentGroupName)
-        .toString();
+    return "Deployment{" +
+           "jobId=" + jobId +
+           ", goal=" + goal +
+           ", deployerUser='" + deployerUser + '\'' +
+           ", deployerMaster='" + deployerMaster + '\'' +
+           ", deploymentGroupName='" + deploymentGroupName + '\'' +
+           "} " + super.toString();
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupStatus.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -99,10 +97,10 @@ public class DeploymentGroupStatus extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("state", state)
-        .add("error", error)
-        .toString();
+    return "DeploymentGroupStatus{" +
+           "state=" + state +
+           ", error='" + error + '\'' +
+           "} " + super.toString();
   }
 
   public static class Builder {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupTasks.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupTasks.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -108,11 +106,11 @@ public class DeploymentGroupTasks extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("rolloutTasks", rolloutTasks)
-        .add("taskIndex", taskIndex)
-        .add("deploymentGroup", deploymentGroup)
-        .toString();
+    return "DeploymentGroupTasks{" +
+           "rolloutTasks=" + rolloutTasks +
+           ", taskIndex=" + taskIndex +
+           ", deploymentGroup=" + deploymentGroup +
+           "} " + super.toString();
   }
 
   public static class Builder {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DockerVersion.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DockerVersion.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -164,15 +162,15 @@ public class DockerVersion {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("apiVersion", apiVersion)
-        .add("arch", arch)
-        .add("gitCommit", gitCommit)
-        .add("goVersion", goVersion)
-        .add("kernelVersion", kernelVersion)
-        .add("os", os)
-        .add("version", version)
-        .toString();
+    return "DockerVersion{" +
+           "apiVersion='" + apiVersion + '\'' +
+           ", arch='" + arch + '\'' +
+           ", gitCommit='" + gitCommit + '\'' +
+           ", goVersion='" + goVersion + '\'' +
+           ", kernelVersion='" + kernelVersion + '\'' +
+           ", os='" + os + '\'' +
+           ", version='" + version + '\'' +
+           '}';
   }
 
   public static Builder builder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ExecHealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ExecHealthCheck.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Arrays;
@@ -75,9 +73,9 @@ public class ExecHealthCheck extends HealthCheck {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("command", command)
-        .toString();
+    return "ExecHealthCheck{" +
+           "command=" + command +
+           "} " + super.toString();
   }
 
   static Builder newBuilder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -288,22 +286,22 @@ public class HostInfo extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("hostname", hostname)
-        .add("uname", uname)
-        .add("architecture", architecture)
-        .add("osName", osName)
-        .add("osVersion", osVersion)
-        .add("cpus", cpus)
-        .add("loadAvg", loadAvg)
-        .add("memoryTotalBytes", memoryTotalBytes)
-        .add("memoryFreeBytes", memoryFreeBytes)
-        .add("swapTotalBytes", swapTotalBytes)
-        .add("swapFreeBytes", swapFreeBytes)
-        .add("dockerVersion", dockerVersion)
-        .add("dockerHost", dockerHost)
-        .add("dockerCertPath", dockerCertPath)
-        .toString();
+    return "HostInfo{" +
+           "hostname='" + hostname + '\'' +
+           ", uname='" + uname + '\'' +
+           ", architecture='" + architecture + '\'' +
+           ", osName='" + osName + '\'' +
+           ", osVersion='" + osVersion + '\'' +
+           ", cpus=" + cpus +
+           ", loadAvg=" + loadAvg +
+           ", memoryTotalBytes=" + memoryTotalBytes +
+           ", memoryFreeBytes=" + memoryFreeBytes +
+           ", swapTotalBytes=" + swapTotalBytes +
+           ", swapFreeBytes=" + swapFreeBytes +
+           ", dockerVersion=" + dockerVersion +
+           ", dockerHost='" + dockerHost + '\'' +
+           ", dockerCertPath='" + dockerCertPath + '\'' +
+           "} " + super.toString();
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HttpHealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HttpHealthCheck.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -88,10 +86,10 @@ public class HttpHealthCheck extends HealthCheck {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("path", path)
-        .add("port", port)
-        .toString();
+    return "HttpHealthCheck{" +
+           "path='" + path + '\'' +
+           ", port='" + port + '\'' +
+           "} " + super.toString();
   }
 
   static Builder newBuilder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -17,17 +17,16 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -423,26 +422,27 @@ public class Job extends Descriptor implements Comparable<Job> {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("id", id)
-        .add("image", image)
-        .add("hostname", hostname)
-        .add("created", created)
-        .add("command", command)
-        .add("env", env)
-        .add("resources", resources)
-        .add("ports", ports)
-        .add("registration", registration)
-        .add("gracePeriod", gracePeriod)
-        .add("expires", expires)
-        .add("registrationDomain", registrationDomain)
-        .add("creatingUser", creatingUser)
-        .add("token", token)
-        .add("healthCheck", healthCheck)
-        .add("securityOpt", securityOpt)
-        .add("networkMode", networkMode)
-        .add("metadata", metadata)
-        .toString();
+    return "Job{" +
+           "id=" + id +
+           ", image='" + image + '\'' +
+           ", hostname='" + hostname + '\'' +
+           ", created=" + created +
+           ", command=" + command +
+           ", env=" + env +
+           ", resources=" + resources +
+           ", ports=" + ports +
+           ", registration=" + registration +
+           ", gracePeriod=" + gracePeriod +
+           ", volumes=" + volumes +
+           ", expires=" + expires +
+           ", registrationDomain='" + registrationDomain + '\'' +
+           ", creatingUser='" + creatingUser + '\'' +
+           ", token='" + token + '\'' +
+           ", healthCheck=" + healthCheck +
+           ", securityOpt=" + securityOpt +
+           ", networkMode='" + networkMode + '\'' +
+           ", metadata=" + metadata +
+           "} " + super.toString();
   }
 
   public Builder toBuilder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobStatus.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -126,11 +124,11 @@ public class JobStatus {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("job", job)
-        .add("taskStatuses", taskStatuses)
-        .add("deployments", deployments)
-        .toString();
+    return "JobStatus{" +
+           "job=" + job +
+           ", taskStatuses=" + taskStatuses +
+           ", deployments=" + deployments +
+           '}';
   }
 
   public static Builder newBuilder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -141,10 +140,10 @@ public class PortMapping extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("internalPort", internalPort)
-        .add("externalPort", externalPort)
-        .add("protocol", protocol)
-        .toString();
+    return "PortMapping{" +
+           "internalPort=" + internalPort +
+           ", externalPort=" + externalPort +
+           ", protocol='" + protocol + '\'' +
+           "} " + super.toString();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Resources.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Resources.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -111,11 +109,11 @@ public class Resources extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("memory", memory)
-        .add("memorySwap", memorySwap)
-        .add("cpuShares", cpuShares)
-        .add("cpuset", cpuset)
-        .toString();
+    return "Resources{" +
+           "memory=" + memory +
+           ", memorySwap=" + memorySwap +
+           ", cpuShares=" + cpuShares +
+           ", cpuset='" + cpuset + '\'' +
+           "} " + super.toString();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutTask.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutTask.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -65,10 +63,10 @@ public class RolloutTask extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("action", action)
-        .add("target", target)
-        .toString();
+    return "RolloutTask{" +
+           "action=" + action +
+           ", target='" + target + '\'' +
+           "} " + super.toString();
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -92,8 +90,8 @@ public class ServicePortParameters extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("tags", tags)
-        .toString();
+    return "ServicePortParameters{" +
+           "tags=" + tags +
+           "} " + super.toString();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -76,9 +75,9 @@ public class ServicePorts extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("ports", ports)
-        .toString();
+    return "ServicePorts{" +
+           "ports=" + ports +
+           "} " + super.toString();
   }
 
   public static ServicePorts of(final String... ports) {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Task.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Task.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -117,12 +115,12 @@ public class Task extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("job", job)
-        .add("goal", goal)
-        .add("deployerUser", deployerUser)
-        .add("deployerMaster", deployerMaster)
-        .add("deploymentGroupName", deploymentGroupName)
-        .toString();
+    return "Task{" +
+           "job=" + job +
+           ", goal=" + goal +
+           ", deployerUser='" + deployerUser + '\'' +
+           ", deployerMaster='" + deployerMaster + '\'' +
+           ", deploymentGroupName='" + deploymentGroupName + '\'' +
+           "} " + super.toString();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 
@@ -178,16 +177,16 @@ public class TaskStatus extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-            .add("job", job)
-            .add("goal", goal)
-            .add("state", state)
-            .add("containerId", containerId)
-            .add("throttled", throttled)
-            .add("ports", ports)
-            .add("containerError", containerError)
-            .add("env", env)
-            .toString();
+    return "TaskStatus{" +
+           "job=" + job +
+           ", goal=" + goal +
+           ", state=" + state +
+           ", containerId='" + containerId + '\'' +
+           ", throttled=" + throttled +
+           ", ports=" + ports +
+           ", env=" + env +
+           ", containerError='" + containerError + '\'' +
+           "} " + super.toString();
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -72,10 +70,10 @@ public class TaskStatusEvent extends Descriptor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(TaskStatusEvent.class)
-        .add("timestamp", timestamp)
-        .add("host", host)
-        .add("status", status)
-        .toString();
+    return "TaskStatusEvent{" +
+           "status=" + status +
+           ", timestamp=" + timestamp +
+           ", host='" + host + '\'' +
+           "} " + super.toString();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TcpHealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TcpHealthCheck.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.base.MoreObjects;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -72,9 +70,9 @@ public class TcpHealthCheck extends HealthCheck {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("port", port)
-        .toString();
+    return "TcpHealthCheck{" +
+           "port='" + port + '\'' +
+           "} " + super.toString();
   }
 
   static Builder newBuilder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/CreateDeploymentGroupResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/CreateDeploymentGroupResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class CreateDeploymentGroupResponse {
 
@@ -42,9 +41,9 @@ public class CreateDeploymentGroupResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .toString();
+    return "CreateDeploymentGroupResponse{" +
+           "status=" + status +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/CreateJobResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/CreateJobResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 import java.util.List;
 
@@ -61,11 +60,11 @@ public class CreateJobResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("errors", errors)
-        .add("id", id)
-        .toString();
+    return "CreateJobResponse{" +
+           "status=" + status +
+           ", errors=" + errors +
+           ", id='" + id + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
@@ -17,14 +17,13 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -139,13 +138,13 @@ public class DeploymentGroupStatusResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("deploymentGroup", deploymentGroup)
-        .add("status", status)
-        .add("error", error)
-        .add("hostStatuses", hostStatuses)
-        .add("deploymentGroupStatus", deploymentGroupStatus)
-        .toString();
+    return "DeploymentGroupStatusResponse{" +
+           "deploymentGroup=" + deploymentGroup +
+           ", status=" + status +
+           ", error='" + error + '\'' +
+           ", hostStatuses=" + hostStatuses +
+           ", deploymentGroupStatus=" + deploymentGroupStatus +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/HostDeregisterResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/HostDeregisterResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class HostDeregisterResponse {
 
@@ -45,10 +44,10 @@ public class HostDeregisterResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("host", host)
-        .toString();
+    return "HostDeregisterResponse{" +
+           "status=" + status +
+           ", host='" + host + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/HostRegisterResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/HostRegisterResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class HostRegisterResponse {
 
@@ -45,10 +44,10 @@ public class HostRegisterResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("host", host)
-        .toString();
+    return "HostRegisterResponse{" +
+           "status=" + status +
+           ", host='" + host + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/JobDeleteResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/JobDeleteResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class JobDeleteResponse {
   public enum Status { OK, STILL_IN_USE, JOB_NOT_FOUND, FORBIDDEN }
@@ -37,9 +36,9 @@ public class JobDeleteResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .toString();
+    return "JobDeleteResponse{" +
+           "status=" + status +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/JobDeployResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/JobDeployResponse.java
@@ -17,11 +17,10 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.JobId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JobDeployResponse {
 
@@ -63,11 +62,11 @@ public class JobDeployResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("host", host)
-        .add("job", job)
-        .toString();
+    return "JobDeployResponse{" +
+           "status=" + status +
+           ", job=" + job +
+           ", host='" + host + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/JobUndeployResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/JobUndeployResponse.java
@@ -17,11 +17,10 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.JobId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class JobUndeployResponse {
 
@@ -59,11 +58,11 @@ public class JobUndeployResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("host", host)
-        .add("job", job)
-        .toString();
+    return "JobUndeployResponse{" +
+           "status=" + status +
+           ", job=" + job +
+           ", host='" + host + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/RemoveDeploymentGroupResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/RemoveDeploymentGroupResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class RemoveDeploymentGroupResponse {
 
@@ -41,9 +40,9 @@ public class RemoveDeploymentGroupResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .toString();
+    return "RemoveDeploymentGroupResponse{" +
+           "status=" + status +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/RollingUpdateRequest.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/RollingUpdateRequest.java
@@ -17,12 +17,11 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -47,10 +46,10 @@ public class RollingUpdateRequest {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("job", job)
-        .add("rolloutOptions", rolloutOptions)
-        .toString();
+    return "RollingUpdateRequest{" +
+           "job=" + job +
+           ", rolloutOptions=" + rolloutOptions +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/RollingUpdateResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/RollingUpdateResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class RollingUpdateResponse {
 
@@ -42,9 +41,9 @@ public class RollingUpdateResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .toString();
+    return "RollingUpdateResponse{" +
+           "status=" + status +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/SetGoalResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/SetGoalResponse.java
@@ -17,11 +17,10 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.JobId;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SetGoalResponse {
 
@@ -61,11 +60,11 @@ public class SetGoalResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("host", host)
-        .add("job", job)
-        .toString();
+    return "SetGoalResponse{" +
+           "status=" + status +
+           ", job=" + job +
+           ", host='" + host + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/TaskStatusEvents.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/TaskStatusEvents.java
@@ -17,11 +17,10 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.TaskStatusEvent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
@@ -47,10 +46,10 @@ public class TaskStatusEvents {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("events", events)
-        .toString();
+    return "TaskStatusEvents{" +
+           "events=" + events +
+           ", status=" + status +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/VersionResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/VersionResponse.java
@@ -17,10 +17,9 @@
 
 package com.spotify.helios.common.protocol;
 
-import com.google.common.base.MoreObjects;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.spotify.helios.common.Json;
 
 public class VersionResponse {
 
@@ -43,10 +42,10 @@ public class VersionResponse {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("clientVersion", clientVersion)
-        .add("masterVersion", masterVersion)
-        .toString();
+    return "VersionResponse{" +
+           "clientVersion='" + clientVersion + '\'' +
+           ", masterVersion='" + masterVersion + '\'' +
+           '}';
   }
 
   public String toJsonString() {

--- a/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
+++ b/helios-service-registration/src/main/java/com/spotify/helios/serviceregistration/ServiceRegistration.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.serviceregistration;
 
-import com.google.common.base.MoreObjects;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -146,15 +144,15 @@ public class ServiceRegistration {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("name", name)
-          .add("protocol", protocol)
-          .add("port", port)
-          .add("domain", domain)
-          .add("host", host)
-          .add("tags", tags)
-          .add("healthCheck", healthCheck)
-          .toString();
+      return "Endpoint{" +
+             "name='" + name + '\'' +
+             ", protocol='" + protocol + '\'' +
+             ", port=" + port +
+             ", domain='" + domain + '\'' +
+             ", host='" + host + '\'' +
+             ", tags=" + tags +
+             ", healthCheck=" + healthCheck +
+             '}';
     }
   }
 
@@ -188,10 +186,10 @@ public class ServiceRegistration {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("type", type)
-          .add("path", path)
-          .toString();
+      return "EndpointHealthCheck{" +
+             "type='" + type + '\'' +
+             ", path='" + path + '\'' +
+             '}';
     }
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.agent;
 
-import com.google.common.base.MoreObjects;
-
 import com.spotify.docker.client.ContainerNotFoundException;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
@@ -439,11 +437,11 @@ public class Supervisor {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("job", job)
-        .add("currentCommand", currentCommand)
-        .add("performedCommand", performedCommand)
-        .toString();
+    return "Supervisor{" +
+           "job=" + job +
+           ", currentCommand=" + currentCommand +
+           ", performedCommand=" + performedCommand +
+           '}';
   }
 
   private class TaskListener extends TaskRunner.NopListener {

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -17,15 +17,6 @@
 
 package com.spotify.helios.agent;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.ImageInfo;
@@ -40,6 +31,14 @@ import com.spotify.helios.common.descriptors.ServicePortParameters;
 import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.common.descriptors.TcpHealthCheck;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -416,15 +415,16 @@ public class TaskConfig {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("job", job)
-        .add("host", host)
-        .add("ports", ports)
-        .add("envVars", envVars)
-        .add("containerDecorators", containerDecorators)
-        .add("defaultRegistrationDomain", defaultRegistrationDomain)
-        .add("dns", dns)
-        .toString();
+    return "TaskConfig{" +
+           "host='" + host + '\'' +
+           ", ports=" + ports +
+           ", job=" + job +
+           ", envVars=" + envVars +
+           ", containerDecorators=" + containerDecorators +
+           ", namespace='" + namespace + '\'' +
+           ", defaultRegistrationDomain='" + defaultRegistrationDomain + '\'' +
+           ", dns=" + dns +
+           '}';
   }
 }
 

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
@@ -17,13 +17,12 @@
 
 package com.spotify.helios.servicescommon;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
+import com.spotify.helios.common.Json;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
-import com.spotify.helios.common.Json;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -162,8 +161,8 @@ public class PersistentAtomicReference<T> {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("filename", filename)
-        .toString();
+    return "PersistentAtomicReference{" +
+           "filename=" + filename +
+           '}';
   }
 }

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCacheTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCacheTest.java
@@ -17,17 +17,16 @@
 
 package com.spotify.helios.servicescommon.coordination;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.SettableFuture;
-
 import com.spotify.helios.Parallelized;
 import com.spotify.helios.Polling;
 import com.spotify.helios.ZooKeeperTestManager;
 import com.spotify.helios.ZooKeeperTestingServerManager;
 import com.spotify.helios.common.Json;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.SettableFuture;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.curator.framework.state.ConnectionState;
@@ -105,15 +104,6 @@ public class PersistentPathChildrenCacheTest {
       result = 31 * result + bar;
       result = 31 * result + (baz != null ? baz.hashCode() : 0);
       return result;
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("name", name)
-          .add("bar", bar)
-          .add("baz", baz)
-          .toString();
     }
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -17,19 +17,6 @@
 
 package com.spotify.helios.testing;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.FutureFallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificateException;
 import com.spotify.docker.client.DockerClient;
@@ -49,6 +36,18 @@ import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.common.protocol.JobUndeployResponse;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.FutureFallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 
@@ -550,11 +549,11 @@ public class HeliosSoloDeployment implements HeliosDeployment {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("deploymentAddress", deploymentAddress)
-        .add("dockerHost", dockerHost)
-        .add("heliosContainerId", heliosContainerId)
-        .toString();
+    return "HeliosSoloDeployment{" +
+           "deploymentAddress=" + deploymentAddress +
+           ", dockerHost=" + dockerHost +
+           ", heliosContainerId=" + heliosContainerId +
+           '}';
   }
 
   public static class Builder {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/descriptors/TemporaryJobEvent.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/descriptors/TemporaryJobEvent.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.testing.descriptors;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -93,14 +92,14 @@ public class TemporaryJobEvent {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("timestamp", timestamp)
-        .add("duration", duration)
-        .add("testClassName", testClassName)
-        .add("testName", testName)
-        .add("step", step)
-        .add("success", success)
-        .add("tags", tags)
-        .toString();
+    return "TemporaryJobEvent{" +
+           "timestamp=" + timestamp +
+           ", duration=" + duration +
+           ", testClassName='" + testClassName + '\'' +
+           ", testName='" + testName + '\'' +
+           ", step='" + step + '\'' +
+           ", success=" + success +
+           ", tags=" + tags +
+           '}';
   }
 }


### PR DESCRIPTION
Users of `helios-testing` that are stuck on previous versions of Guava
(for example, if building something that needs to use Hadoop, and using
TemporaryJobs within the test of that thing) fail to load `MoreObjects`
from the classpath as this was only introduced in Guava v18.

Since the functionality used here to implement `toString()` is so tiny,
it feels unnecessary to rely on an external library for it (which
creates the potential for conflicting dependency library problems).
Therefore just implement `toString()` with simple String concatenation
(which the compiler will replaced with StringBuilder for us).