### PR TITLE
Make `helios create` support add/drop capabiltiies

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -32,6 +32,7 @@ import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.common.descriptors.TcpHealthCheck;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -71,10 +72,25 @@ public class JobValidator {
   private final boolean shouldValidateAddCapabilities;
   private final Set<String> whitelistedCapabilities;
 
-  public JobValidator(final Builder builder) {
-    this.shouldValidateJobHash = builder.shouldValidateJobHash;
-    this.shouldValidateAddCapabilities = builder.shouldValidateAddCapabilities;
-    this.whitelistedCapabilities = builder.whitelistedCapabilities;
+  public JobValidator() {
+    this(true);
+  }
+
+  public JobValidator(final boolean shouldValidateJobHash) {
+    this(shouldValidateJobHash, false);
+  }
+
+  public JobValidator(final boolean shouldValidateJobHash,
+                      final boolean shouldValidateAddCapabilities) {
+    this(shouldValidateJobHash, shouldValidateAddCapabilities, Collections.<String>emptySet());
+  }
+
+  public JobValidator(final boolean shouldValidateJobHash,
+                      final boolean shouldValidateAddCapabilities,
+                      final Set<String> whitelistedCapabilities) {
+    this.shouldValidateJobHash = shouldValidateJobHash;
+    this.shouldValidateAddCapabilities = shouldValidateAddCapabilities;
+    this.whitelistedCapabilities = whitelistedCapabilities;
   }
 
   public Set<String> validate(final Job job) {
@@ -522,35 +538,5 @@ public class JobValidator {
 
   private boolean legalPort(final int port) {
     return port >= 0 && port <= 65535;
-  }
-
-  public static Builder newBuilder() {
-    return new Builder();
-  }
-
-  public static class Builder {
-
-    private boolean shouldValidateJobHash = true;
-    private boolean shouldValidateAddCapabilities = false;
-    private Set<String> whitelistedCapabilities = emptySet();
-
-    public Builder setShouldValidateJobHash(final boolean shouldValidateJobHash) {
-      this.shouldValidateJobHash = shouldValidateJobHash;
-      return this;
-    }
-
-    public Builder setShouldValidateAddCapabilities(final boolean shouldValidateAddCapabilities) {
-      this.shouldValidateAddCapabilities = shouldValidateAddCapabilities;
-      return this;
-    }
-
-    public Builder setWhitelistedCapabilities(final Set<String> whitelistedCapabilities) {
-      this.whitelistedCapabilities = whitelistedCapabilities;
-      return this;
-    }
-
-    public JobValidator build() {
-      return new JobValidator(this);
-    }
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -676,12 +677,12 @@ public class Job extends Descriptor implements Comparable<Job> {
       return this;
     }
 
-    public Builder setAddCapabilities(final Set<String> addCapabilities) {
+    public Builder setAddCapabilities(final Collection<String> addCapabilities) {
       p.addCapabilities = ImmutableSet.copyOf(addCapabilities);
       return this;
     }
 
-    public Builder setDropCapabilities(final Set<String> dropCapabilities) {
+    public Builder setDropCapabilities(final Collection<String> dropCapabilities) {
       p.dropCapabilities = ImmutableSet.copyOf(dropCapabilities);
       return this;
     }

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -76,7 +76,9 @@ public class JobValidatorTest {
       .setHealthCheck(HEALTH_CHECK)
       .build();
 
-  final JobValidator validator = new JobValidator();
+  final JobValidator validator = JobValidator.newBuilder()
+      .setShouldValidateAddCapabilities(true)
+      .build();
 
   @Test
   public void testValidJobPasses() {
@@ -433,7 +435,10 @@ public class JobValidatorTest {
 
   @Test
   public void testWhitelistedCapabilities_withWhitelist() throws Exception {
-    final JobValidator validator = new JobValidator(true, ImmutableSet.of("cap1"));
+    final JobValidator validator = JobValidator.newBuilder()
+        .setShouldValidateAddCapabilities(true)
+        .setWhitelistedCapabilities(ImmutableSet.of("cap1"))
+        .build();
     final Job job = Job.newBuilder()
         .setName("foo")
         .setVersion("1")
@@ -446,7 +451,10 @@ public class JobValidatorTest {
         "The following Linux capabilities aren't allowed by the Helios master: 'cap2'. "
         + "The allowed capabilities are: 'cap1'."));
 
-    final JobValidator validator2 = new JobValidator(true, ImmutableSet.of("cap1", "cap2"));
+    final JobValidator validator2 = JobValidator.newBuilder()
+        .setShouldValidateJobHash(false)
+        .setWhitelistedCapabilities(ImmutableSet.of("cap1", "cap2"))
+        .build();
     final Set<String> errors2 = validator2.validate(job);
     assertEquals(0, errors2.size());
   }

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -76,9 +76,7 @@ public class JobValidatorTest {
       .setHealthCheck(HEALTH_CHECK)
       .build();
 
-  final JobValidator validator = JobValidator.newBuilder()
-      .setShouldValidateAddCapabilities(true)
-      .build();
+  final JobValidator validator = new JobValidator(true, true);
 
   @Test
   public void testValidJobPasses() {
@@ -435,10 +433,7 @@ public class JobValidatorTest {
 
   @Test
   public void testWhitelistedCapabilities_withWhitelist() throws Exception {
-    final JobValidator validator = JobValidator.newBuilder()
-        .setShouldValidateAddCapabilities(true)
-        .setWhitelistedCapabilities(ImmutableSet.of("cap1"))
-        .build();
+    final JobValidator validator = new JobValidator(true, true, ImmutableSet.of("cap1"));
     final Job job = Job.newBuilder()
         .setName("foo")
         .setVersion("1")
@@ -451,10 +446,7 @@ public class JobValidatorTest {
         "The following Linux capabilities aren't allowed by the Helios master: 'cap2'. "
         + "The allowed capabilities are: 'cap1'."));
 
-    final JobValidator validator2 = JobValidator.newBuilder()
-        .setShouldValidateJobHash(false)
-        .setWhitelistedCapabilities(ImmutableSet.of("cap1", "cap2"))
-        .build();
+    final JobValidator validator2 = new JobValidator(true, true, ImmutableSet.of("cap1", "cap2"));
     final Set<String> errors2 = validator2.validate(job);
     assertEquals(0, errors2.size());
   }

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
@@ -78,9 +78,7 @@ public class JobsResource {
                       final Set<String> whitelistedCapabilities) {
     this.model = model;
     this.metrics = metrics;
-    this.jobValidator = JobValidator.newBuilder()
-        .setWhitelistedCapabilities(whitelistedCapabilities)
-        .build();
+    this.jobValidator = new JobValidator(true, true, whitelistedCapabilities);
   }
 
   /**

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/JobsResource.java
@@ -78,7 +78,9 @@ public class JobsResource {
                       final Set<String> whitelistedCapabilities) {
     this.model = model;
     this.metrics = metrics;
-    this.jobValidator = new JobValidator(true, whitelistedCapabilities);
+    this.jobValidator = JobValidator.newBuilder()
+        .setWhitelistedCapabilities(whitelistedCapabilities)
+        .build();
   }
 
   /**

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -22,7 +22,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -57,7 +56,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,9 +75,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 public class JobCreateCommand extends ControlCommand {
 
-  private static final JobValidator JOB_VALIDATOR = JobValidator.newBuilder()
-      .setShouldValidateJobHash(false)
-      .build();
+  private static final JobValidator JOB_VALIDATOR = new JobValidator(false);
 
   /**
    * If any of the keys of this map are set as environment variables (i.e. an environment variable
@@ -550,16 +546,8 @@ public class JobCreateCommand extends ControlCommand {
       builder.setToken(token);
     }
 
-    final Set<String> addCapabilities = ImmutableSet.copyOf(
-        options.<String>getList(addCapabilityArg.getDest()));
-    if (!addCapabilities.isEmpty()) {
-      builder.setAddCapabilities(addCapabilities);
-    }
-    final Set<String> dropCapabilities = ImmutableSet.copyOf(
-        options.<String>getList(dropCapabilityArg.getDest()));
-    if (!dropCapabilities.isEmpty()) {
-      builder.setDropCapabilities(dropCapabilities);
-    }
+    builder.setAddCapabilities(options.<String>getList(addCapabilityArg.getDest()));
+    builder.setDropCapabilities(options.<String>getList(dropCapabilityArg.getDest()));
 
     // We build without a hash here because we want the hash to be calculated server-side.
     // This allows different CLI versions to be cross-compatible with different master versions

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
@@ -151,6 +151,8 @@ public class JobInspectCommand extends WildcardJobCommand {
       out.printf("Network mode: %s%n", job.getNetworkMode());
       out.printf("Token: %s%n", job.getToken());
       printVolumes(out, job.getVolumes());
+      out.printf("Add capabilities: %s%n", Joiner.on(", ").join(job.getAddCapabilities()));
+      out.printf("Drop capabilities: %s%n", Joiner.on(", ").join(job.getDropCapabilities()));
     }
 
     return 0;

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
@@ -113,6 +113,8 @@ public class JobCreateCommandTest {
     doReturn(SECURITY_OPT).when(options).getList("security_opt");
     when(options.getString("network_mode")).thenReturn(NETWORK_MODE);
     when(options.getList("metadata")).thenReturn(Lists.<Object>newArrayList("a=1", "b=2"));
+    doReturn(ImmutableList.of("cap1", "cap2")).when(options).getList("add_capability");
+    doReturn(ImmutableList.of("cap3", "cap4")).when(options).getList("drop_capability");
 
     final int ret = command.run(options, client, out, false, null);
 
@@ -129,6 +131,8 @@ public class JobCreateCommandTest {
     assertThat(output, containsString("\"securityOpt\":[\"label:user:dxia\",\"apparmor:foo\"]"));
     assertThat(output, containsString("\"networkMode\":\"host\""));
     assertThat(output, containsString("\"expires\":null"));
+    assertThat(output, containsString("\"addCapabilities\":[\"cap1\",\"cap2\"]"));
+    assertThat(output, containsString("\"dropCapabilities\":[\"cap3\",\"cap4\"]"));
   }
 
   @Test

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobInspectCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobInspectCommandTest.java
@@ -18,6 +18,7 @@
 package com.spotify.helios.cli.command;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 
 import com.spotify.helios.client.HeliosClient;
@@ -56,6 +57,8 @@ public class JobInspectCommandTest {
       .setVersion(JOB_VERSION)
       .setCreated((long) 0)
       .setExpires(new Date(0))
+      .setAddCapabilities(ImmutableSet.of("cap1", "cap2"))
+      .setDropCapabilities(ImmutableSet.of("cap3", "cap4"))
       .build();
 
   private final Namespace options = mock(Namespace.class);
@@ -88,6 +91,8 @@ public class JobInspectCommandTest {
     final String output = baos.toString();
     assertThat(output, containsString("Created: Thu, 1 Jan 1970 00:00:00 +0000"));
     assertThat(output, containsString("Expires: Thu, 1 Jan 1970 00:00:00 +0000"));
+    assertThat(output, containsString("Add capabilities: cap1, cap2"));
+    assertThat(output, containsString("Drop capabilities: cap3, cap4"));
   }
 
   @Test


### PR DESCRIPTION
Disable capablity validation for JobValidator when it's
being run by the CLI.