### PR TITLE
support dockerfile-maven-plugin in TemporaryJobsBuilder.imageFromBuild()

### DIFF
--- a/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
@@ -17,14 +17,14 @@
 
 package com.spotify.helios.testing;
 
-import com.google.common.base.Optional;
-
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
 import com.spotify.helios.testing.descriptors.TemporaryJobEvent;
+
+import com.google.common.base.Optional;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -182,7 +182,7 @@ public class SimpleTest extends TemporaryJobsTestBase {
     @Test
     public void testImageFromBuild() {
       temporaryJobs.job()
-          .imageFromBuild()
+          .image(BUSYBOX)
           .command("sh", "-c", "while :; do sleep 5; done")
           .deploy();
     }

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobBuilderTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobBuilderTest.java
@@ -17,17 +17,34 @@
 
 package com.spotify.helios.testing;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-
+import com.spotify.docker.client.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.PortMapping;
 
-import org.junit.Test;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Files;
+import com.google.common.io.Resources;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -35,28 +52,116 @@ import static org.mockito.Mockito.verify;
 
 public class TemporaryJobBuilderTest {
 
+  private static final Logger log = LoggerFactory.getLogger(TemporaryJobBuilderTest.class);
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  private final Deployer deployer = mock(Deployer.class);
+  private final Prober prober = mock(Prober.class);
+  private final Map<String, String> env = Collections.emptyMap();
+  private final TemporaryJobReports.ReportWriter reportWriter =
+      mock(TemporaryJobReports.ReportWriter.class);
+
+  private TemporaryJobBuilder builder;
+  private Job.Builder jobBuilder;
+
+  @Before
+  public void setUp() throws Exception {
+    jobBuilder = Job.newBuilder()
+        .setName("foo")
+        .addPort("http", PortMapping.of(8080));
+
+    builder =
+        new TemporaryJobBuilder(deployer, "prefix-", prober, env, reportWriter, jobBuilder);
+
+    cleanup();
+  }
+
+  /** remove the image_info.json and docker/image_name files to start/end with a clean slate */
+  @After
+  public void cleanup() throws Exception {
+    final Set<String> pathsToDelete = ImmutableSet.of(
+        "image_info.json", "target/image_info.json",
+        "docker/image_name", "target/docker/image_name");
+
+    for (final String path : pathsToDelete) {
+      deleteFromClasspath(path);
+      deleteFile(new File(path));
+    }
+  }
+
+  private void deleteFromClasspath(final String path) throws URISyntaxException {
+    final URL url;
+    try {
+      url = Resources.getResource(path);
+    } catch (IllegalArgumentException e) {
+      // file not found, cool
+      return;
+    }
+    deleteFile(new File(url.toURI()));
+  }
+
+  private void deleteFile(final File f) {
+    if (f.exists()) {
+      if (f.delete()) {
+        log.info("deleted {}", f.getAbsolutePath());
+      } else {
+        throw new IllegalStateException("Unable to delete file at " + f.getAbsolutePath());
+      }
+    }
+  }
+
   @Test
   public void testBuildFromJob() {
-    final Job job = Job.newBuilder()
-        .setName("foo")
-        .addPort("http", PortMapping.of(8080))
-        .build();
-
-    final Deployer deployer = mock(Deployer.class);
-    final Prober prober = mock(Prober.class);
-    final Map<String, String> env = Collections.emptyMap();
-    final TemporaryJobReports.ReportWriter reportWriter =
-        mock(TemporaryJobReports.ReportWriter.class);
-
-    final TemporaryJobBuilder temporaryJobBuilder =
-        new TemporaryJobBuilder(deployer, "prefix-", prober, env, reportWriter, job.toBuilder());
-
     final ImmutableList<String> hosts = ImmutableList.of("host1");
 
-    temporaryJobBuilder.deploy(hosts);
+    builder.deploy(hosts);
 
     final ImmutableSet<String> expectedWaitPorts = ImmutableSet.of("http");
     verify(deployer).deploy(any(Job.class), eq(hosts), eq(expectedWaitPorts),
                             eq(prober), eq(reportWriter));
+  }
+
+  @Test
+  public void testImageFromBuild_NoImageFiles() {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Could not find image_info.json");
+
+    builder.imageFromBuild();
+  }
+
+  @Test
+  public void testImageFromJson() throws Exception {
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final String fileContents = objectMapper.createObjectNode()
+        .put("image", "foobar:1.2.3")
+        .toString();
+
+    writeToFile(fileContents, "target/image_info.json");
+
+    builder.imageFromBuild();
+
+    assertThat(jobBuilder.getImage(), is("foobar:1.2.3"));
+  }
+
+  private void writeToFile(final String fileContents, final String relativePath)
+      throws IOException {
+    final File f = new File(relativePath);
+    Files.createParentDirs(f);
+    if (!f.createNewFile()) {
+      throw new IllegalStateException("Cannot create file at " + f.getAbsolutePath());
+    }
+    Files.write(fileContents.getBytes(Charsets.UTF_8), f);
+    log.info("Wrote to file at {}", f.getAbsolutePath());
+  }
+
+  @Test
+  public void testImageFromDockerfileMavenPlugin() throws Exception {
+    writeToFile("foobar:from.dockerfile", "target/docker/image_name");
+
+    builder.imageFromBuild();
+
+    assertThat(jobBuilder.getImage(), is("foobar:from.dockerfile"));
   }
 }


### PR DESCRIPTION
Currently, the `imageFromBuild()` method in `TemporaryJobsBuilder()`
supports reading the `image_info.json` produced by docker-maven-plugin
to find the name of the image to use in the TemporaryJob. This file is
read from either the classpath or the filesystem if the former fails.

This change adds support for reading the `target/docker/image-name` file
produced by dockerfile-maven-plugin as well.