### PR TITLE
Introduce a 'rolling operation' concept.

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -51,6 +51,7 @@ import com.spotify.helios.common.descriptors.JobStatus;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.protocol.CreateDeploymentGroupResponse;
 import com.spotify.helios.common.protocol.CreateJobResponse;
+import com.spotify.helios.common.protocol.DeploymentGroupResponse;
 import com.spotify.helios.common.protocol.DeploymentGroupStatusResponse;
 import com.spotify.helios.common.protocol.HostDeregisterResponse;
 import com.spotify.helios.common.protocol.JobDeleteResponse;
@@ -407,8 +408,8 @@ public class HeliosClient implements Closeable {
     return transform(request(uri("/jobs/statuses"), "POST", jobs), converter);
   }
 
-  public ListenableFuture<DeploymentGroup> deploymentGroup(final String name) {
-    return get(uri("/deployment-group/" + name), new TypeReference<DeploymentGroup>() {
+  public ListenableFuture<DeploymentGroupResponse> deploymentGroup(final String name) {
+    return get(uri("/deployment-group/" + name), new TypeReference<DeploymentGroupResponse>() {
     });
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -36,7 +34,6 @@ import static java.util.Collections.emptyList;
  * <pre>
  * {
  *   "name":"foo-group",
- *   "job":"foo:0.1.0",
  *   "hostSelectors":[
  *     {
  *       "label":"foo",
@@ -48,14 +45,7 @@ import static java.util.Collections.emptyList;
  *       "operator":"EQUALS"
  *       "operand":"qux",
  *     }
- *   ],
- *   "rolloutOptions":{
- *     "migrate":false,
- *     "parallelism":2,
- *     "timeout":1000,
- *     "overlap":true,
- *     "token": "insecure-access-token"
- *   }
+ *   ]
  * }
  * </pre>
  */
@@ -64,46 +54,30 @@ import static java.util.Collections.emptyList;
 public class DeploymentGroup extends Descriptor {
 
   public static final String EMPTY_NAME = "";
-  public static final JobId EMPTY_JOB_ID = null;
 
   private final String name;
   private final List<HostSelector> hostSelectors;
-  private final JobId jobId;
-  private final RolloutOptions rolloutOptions;
 
   /**
    * Create a Job.
    *
    * @param name The docker name to use.
-   * @param jobId The job ID for the deployment group.
    * @param hostSelectors The selectors that determine which agents are part of the deployment
    *                       group.
    */
   public DeploymentGroup(
       @JsonProperty("name") final String name,
-      @JsonProperty("hostSelectors") final List<HostSelector> hostSelectors,
-      @JsonProperty("job") @Nullable final JobId jobId,
-      @JsonProperty("rolloutOptions") @Nullable final RolloutOptions rolloutOptions) {
+      @JsonProperty("hostSelectors") final List<HostSelector> hostSelectors) {
     this.name = name;
     this.hostSelectors = hostSelectors;
-    this.jobId = jobId;
-    this.rolloutOptions = rolloutOptions;
   }
 
   public String getName() {
     return name;
   }
 
-  public JobId getJobId() {
-    return jobId;
-  }
-
   public List<HostSelector> getHostSelectors() {
     return hostSelectors;
-  }
-
-  public RolloutOptions getRolloutOptions() {
-    return rolloutOptions;
   }
 
   public static Builder newBuilder() {
@@ -121,18 +95,11 @@ public class DeploymentGroup extends Descriptor {
 
     final DeploymentGroup that = (DeploymentGroup) o;
 
-    if (jobId != null ? !jobId.equals(that.jobId) : that.jobId != null) {
-      return false;
-    }
     if (hostSelectors != null ? !hostSelectors.equals(that.hostSelectors)
                                : that.hostSelectors != null) {
       return false;
     }
     if (name != null ? !name.equals(that.name) : that.name != null) {
-      return false;
-    }
-    if (rolloutOptions != null ? !rolloutOptions.equals(that.rolloutOptions)
-                               : that.rolloutOptions != null) {
       return false;
     }
 
@@ -143,8 +110,6 @@ public class DeploymentGroup extends Descriptor {
   public int hashCode() {
     int result = name != null ? name.hashCode() : 0;
     result = 31 * result + (hostSelectors != null ? hostSelectors.hashCode() : 0);
-    result = 31 * result + (jobId != null ? jobId.hashCode() : 0);
-    result = 31 * result + (rolloutOptions != null ? rolloutOptions.hashCode() : 0);
     return result;
   }
 
@@ -153,8 +118,6 @@ public class DeploymentGroup extends Descriptor {
     return "DeploymentGroup{" +
            "name='" + name + '\'' +
            ", hostSelectors=" + hostSelectors +
-           ", job=" + jobId +
-           ", rolloutOptions=" + rolloutOptions +
            '}';
   }
 
@@ -162,9 +125,7 @@ public class DeploymentGroup extends Descriptor {
     final Builder builder = newBuilder();
 
     return builder.setName(name)
-        .setJobId(jobId)
-        .setHostSelectors(hostSelectors)
-        .setRolloutOptions(rolloutOptions);
+        .setHostSelectors(hostSelectors);
   }
 
   public static class Builder implements Cloneable {
@@ -178,15 +139,11 @@ public class DeploymentGroup extends Descriptor {
     private static class Parameters implements Cloneable {
 
       public String name;
-      public JobId jobId;
       public List<HostSelector> hostSelectors;
-      public RolloutOptions rolloutOptions;
 
       private Parameters() {
         this.name = EMPTY_NAME;
-        this.jobId = EMPTY_JOB_ID;
         this.hostSelectors = emptyList();
-        this.rolloutOptions = null;
       }
     }
 
@@ -199,15 +156,6 @@ public class DeploymentGroup extends Descriptor {
       return this;
     }
 
-    public JobId getJobId() {
-      return p.jobId;
-    }
-
-    public Builder setJobId(final JobId jobId) {
-      p.jobId = jobId;
-      return this;
-    }
-
     public List<HostSelector> getHostSelectors() {
       return p.hostSelectors;
     }
@@ -217,17 +165,8 @@ public class DeploymentGroup extends Descriptor {
       return this;
     }
 
-    public RolloutOptions getRolloutOptions() {
-      return p.rolloutOptions;
-    }
-
-    public Builder setRolloutOptions(final RolloutOptions rolloutOptions) {
-      p.rolloutOptions = rolloutOptions;
-      return this;
-    }
-
     public DeploymentGroup build() {
-      return new DeploymentGroup(p.name, p.hostSelectors, p.jobId, p.rolloutOptions);
+      return new DeploymentGroup(p.name, p.hostSelectors);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
@@ -53,7 +53,7 @@ import static java.util.Collections.emptyList;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DeploymentGroup extends Descriptor {
 
-  public static final String EMPTY_NAME = "";
+  private static final String EMPTY_NAME = "";
 
   private final String name;
   private final List<HostSelector> hostSelectors;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperation.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperation.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+/**
+ * Represents a rolling operation on a Helios deployment group.
+ *
+ * An sample expression of it in JSON might be:
+ * <pre>
+ * {
+ *   "id":"some-cool-uuid",
+ *   "deploymentGroupName":"my-awesome-group",
+ *   "job":"foo:0.1.0",
+ *   "reason":"HOSTS_CHANGED",
+ *   "rolloutOptions":{
+ *     "migrate":false,
+ *     "parallelism":2,
+ *     "timeout":1000,
+ *     "overlap":true,
+ *     "token": "insecure-access-token"
+ *   }
+ * }
+ * </pre>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RollingOperation extends Descriptor {
+
+  public enum Reason {
+    MANUAL,
+    HOSTS_CHANGED,
+  }
+
+  private static final String EMPTY_DEPLOYMENT_GROUP_NAME = "";
+  private static final JobId EMPTY_JOB_ID = null;
+
+  private final String id;
+  private final String deploymentGroupName;
+  private final JobId jobId;
+  private final Reason reason;
+  private final RolloutOptions rolloutOptions;
+
+  /**
+   * Create a rolling operation.
+   *
+   * @param id The docker id to use.
+   * @param jobId The job ID for the deployment group.
+   */
+  public RollingOperation(
+      @JsonProperty("id") final String id,
+      @JsonProperty("deploymentGroupName") final String deploymentGroupName,
+      @JsonProperty("reason") final Reason reason,
+      @JsonProperty("job") @Nullable final JobId jobId,
+      @JsonProperty("rolloutOptions") @Nullable final RolloutOptions rolloutOptions) {
+    this.id = id;
+    this.deploymentGroupName = deploymentGroupName;
+    this.jobId = jobId;
+    this.reason = reason;
+    this.rolloutOptions = rolloutOptions;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getDeploymentGroupName() {
+    return deploymentGroupName;
+  }
+
+  public JobId getJobId() {
+    return jobId;
+  }
+
+  public Reason getReason() {
+    return reason;
+  }
+
+  public RolloutOptions getRolloutOptions() {
+    return rolloutOptions;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final RollingOperation that = (RollingOperation) o;
+
+    if (jobId != null ? !jobId.equals(that.jobId) : that.jobId != null) {
+      return false;
+    }
+    if (deploymentGroupName != null ? !deploymentGroupName.equals(that.deploymentGroupName)
+                                    : that.deploymentGroupName != null) {
+      return false;
+    }
+    if (id != null ? !id.equals(that.id) : that.id != null) {
+      return false;
+    }
+    if (reason != null ? !reason.equals(that.reason) : that.reason != null) {
+      return false;
+    }
+    if (rolloutOptions != null ? !rolloutOptions.equals(that.rolloutOptions)
+                               : that.rolloutOptions != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (deploymentGroupName != null ? deploymentGroupName.hashCode() : 0);
+    result = 31 * result + (jobId != null ? jobId.hashCode() : 0);
+    result = 31 * result + (reason != null ? reason.hashCode() : 0);
+    result = 31 * result + (rolloutOptions != null ? rolloutOptions.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "RollingOperation{" +
+           "id='" + id + '\'' +
+           ", deploymentGroupName=" + deploymentGroupName +
+           ", job=" + jobId +
+           ", reason=" + reason +
+           ", rolloutOptions=" + rolloutOptions +
+           '}';
+  }
+
+  public Builder toBuilder() {
+    final Builder builder = newBuilder();
+
+    return builder
+        .setJobId(jobId)
+        .setDeploymentGroupName(deploymentGroupName)
+        .setReason(reason)
+        .setRolloutOptions(rolloutOptions);
+  }
+
+  public static class Builder implements Cloneable {
+
+    private final Parameters p;
+
+    private Builder() {
+      this.p = new Parameters();
+    }
+
+    private static class Parameters implements Cloneable {
+
+      public String id;
+      public String deploymentGroupName;
+      public JobId jobId;
+      public Reason reason;
+      public RolloutOptions rolloutOptions;
+
+      private Parameters() {
+        this.id = UUID.randomUUID().toString();
+        this.deploymentGroupName = EMPTY_DEPLOYMENT_GROUP_NAME;
+        this.jobId = EMPTY_JOB_ID;
+        this.reason = Reason.MANUAL;
+        this.rolloutOptions = null;
+      }
+    }
+
+    public String getId() {
+      return p.id;
+    }
+
+    public Builder setId(final String id) {
+      p.id = id;
+      return this;
+    }
+
+    public String getDeploymentGroupName() {
+      return p.deploymentGroupName;
+    }
+
+    public Builder setDeploymentGroupName(final String deploymentGroupName) {
+      p.deploymentGroupName = deploymentGroupName;
+      return this;
+    }
+
+    public JobId getJobId() {
+      return p.jobId;
+    }
+
+    public Builder setJobId(final JobId jobId) {
+      p.jobId = jobId;
+      return this;
+    }
+
+    public Reason getReason() {
+      return p.reason;
+    }
+
+    public Builder setReason(final Reason reason) {
+      p.reason = reason;
+      return this;
+    }
+
+    public RolloutOptions getRolloutOptions() {
+      return p.rolloutOptions;
+    }
+
+    public Builder setRolloutOptions(final RolloutOptions rolloutOptions) {
+      p.rolloutOptions = rolloutOptions;
+      return this;
+    }
+
+    public RollingOperation build() {
+      return new RollingOperation(p.id, p.deploymentGroupName, p.reason, p.jobId, p.rolloutOptions);
+    }
+  }
+
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperation.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperation.java
@@ -169,78 +169,62 @@ public class RollingOperation extends Descriptor {
         .setRolloutOptions(rolloutOptions);
   }
 
-  public static class Builder implements Cloneable {
+  public static class Builder {
 
-    private final Parameters p;
-
-    private Builder() {
-      this.p = new Parameters();
-    }
-
-    private static class Parameters implements Cloneable {
-
-      public String id;
-      public String deploymentGroupName;
-      public JobId jobId;
-      public Reason reason;
-      public RolloutOptions rolloutOptions;
-
-      private Parameters() {
-        this.id = UUID.randomUUID().toString();
-        this.deploymentGroupName = EMPTY_DEPLOYMENT_GROUP_NAME;
-        this.jobId = EMPTY_JOB_ID;
-        this.reason = Reason.MANUAL;
-        this.rolloutOptions = null;
-      }
-    }
+    private String id = UUID.randomUUID().toString();
+    private String deploymentGroupName = EMPTY_DEPLOYMENT_GROUP_NAME;
+    private JobId jobId = EMPTY_JOB_ID;
+    private Reason reason = Reason.MANUAL;
+    private RolloutOptions rolloutOptions;
 
     public String getId() {
-      return p.id;
+      return this.id;
     }
 
     public Builder setId(final String id) {
-      p.id = id;
+      this.id = id;
       return this;
     }
 
     public String getDeploymentGroupName() {
-      return p.deploymentGroupName;
+      return this.deploymentGroupName;
     }
 
     public Builder setDeploymentGroupName(final String deploymentGroupName) {
-      p.deploymentGroupName = deploymentGroupName;
+      this.deploymentGroupName = deploymentGroupName;
       return this;
     }
 
     public JobId getJobId() {
-      return p.jobId;
+      return this.jobId;
     }
 
     public Builder setJobId(final JobId jobId) {
-      p.jobId = jobId;
+      this.jobId = jobId;
       return this;
     }
 
     public Reason getReason() {
-      return p.reason;
+      return this.reason;
     }
 
     public Builder setReason(final Reason reason) {
-      p.reason = reason;
+      this.reason = reason;
       return this;
     }
 
     public RolloutOptions getRolloutOptions() {
-      return p.rolloutOptions;
+      return this.rolloutOptions;
     }
 
     public Builder setRolloutOptions(final RolloutOptions rolloutOptions) {
-      p.rolloutOptions = rolloutOptions;
+      this.rolloutOptions = rolloutOptions;
       return this;
     }
 
     public RollingOperation build() {
-      return new RollingOperation(p.id, p.deploymentGroupName, p.reason, p.jobId, p.rolloutOptions);
+      return new RollingOperation(
+          this.id, this.deploymentGroupName, this.reason, this.jobId, this.rolloutOptions);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperationStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperationStatus.java
@@ -23,20 +23,30 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * The state of a deployment group.
+ * The state of a rolling operation.
+ *
+ * An sample expression of it in JSON might be:
+ * <pre>
+ * {
+ *   "state":"FAILED",
+ *   "error":"Stopped by user"
+ * }
+ * </pre>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DeploymentGroupStatus extends Descriptor {
+public class RollingOperationStatus extends Descriptor {
 
   public enum State {
-    STABLE,
-    UNSTABLE,
+    NEW,
+    ROLLING_OUT,
+    FAILED,
+    DONE,
   }
 
   private final State state;
   private final String error;
 
-  private DeploymentGroupStatus(
+  private RollingOperationStatus(
       @JsonProperty("state") final State state,
       @JsonProperty("error") final String error) {
     this.state = checkNotNull(state, "state");
@@ -49,7 +59,7 @@ public class DeploymentGroupStatus extends Descriptor {
         .setError(error);
   }
 
-  private DeploymentGroupStatus(final Builder builder) {
+  private RollingOperationStatus(final Builder builder) {
     this.state = checkNotNull(builder.state, "state");
     this.error = builder.error;
   }
@@ -75,7 +85,7 @@ public class DeploymentGroupStatus extends Descriptor {
       return false;
     }
 
-    final DeploymentGroupStatus that = (DeploymentGroupStatus) o;
+    final RollingOperationStatus that = (RollingOperationStatus) o;
 
     if (error != null ? !error.equals(that.error) : that.error != null) {
       return false;
@@ -96,17 +106,17 @@ public class DeploymentGroupStatus extends Descriptor {
 
   @Override
   public String toString() {
-    return "DeploymentGroupStatus{" +
+    return "RollingOperationStatus{" +
            "state=" + state +
            ", error='" + error + '\'' +
            "} " + super.toString();
   }
 
   public static class Builder {
-    private DeploymentGroupStatus.State state;
+    private RollingOperationStatus.State state;
     private String error;
 
-    public Builder setState(DeploymentGroupStatus.State state) {
+    public Builder setState(RollingOperationStatus.State state) {
       this.state = state;
       return this;
     }
@@ -116,8 +126,8 @@ public class DeploymentGroupStatus extends Descriptor {
       return this;
     }
 
-    public DeploymentGroupStatus build() {
-      return new DeploymentGroupStatus(this);
+    public RollingOperationStatus build() {
+      return new RollingOperationStatus(this);
     }
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperationTasks.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RollingOperationTasks.java
@@ -26,32 +26,32 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DeploymentGroupTasks extends Descriptor {
+public class RollingOperationTasks extends Descriptor {
 
   private final List<RolloutTask> rolloutTasks;
   private final int taskIndex;
-  private final DeploymentGroup deploymentGroup;
+  private final RollingOperation rollingOperation;
 
-  private DeploymentGroupTasks(
+  private RollingOperationTasks(
       @JsonProperty("rolloutTasks") final List<RolloutTask> rolloutTasks,
       @JsonProperty("taskIndex") final int taskIndex,
-      @JsonProperty("deploymentGroup") final DeploymentGroup deploymentGroup) {
+      @JsonProperty("rollingOperation") final RollingOperation rollingOperation) {
     this.rolloutTasks = checkNotNull(rolloutTasks, "rolloutTasks");
     this.taskIndex = taskIndex;
-    this.deploymentGroup = deploymentGroup;
+    this.rollingOperation = rollingOperation;
   }
 
   public Builder toBuilder() {
     return newBuilder()
         .setRolloutTasks(rolloutTasks)
         .setTaskIndex(taskIndex)
-        .setDeploymentGroup(deploymentGroup);
+        .setRollingOperation(rollingOperation);
   }
 
-  private DeploymentGroupTasks(final Builder builder) {
+  private RollingOperationTasks(final Builder builder) {
     this.rolloutTasks = checkNotNull(builder.rolloutTasks, "rolloutTasks");
     this.taskIndex = builder.taskIndex;
-    this.deploymentGroup = checkNotNull(builder.deploymentGroup, "deploymentGroup");
+    this.rollingOperation = checkNotNull(builder.rollingOperation, "rollingOperation");
   }
 
   public List<RolloutTask> getRolloutTasks() {
@@ -62,8 +62,8 @@ public class DeploymentGroupTasks extends Descriptor {
     return taskIndex;
   }
 
-  public DeploymentGroup getDeploymentGroup() {
-    return deploymentGroup;
+  public RollingOperation getRollingOperation() {
+    return rollingOperation;
   }
 
   public static Builder newBuilder() {
@@ -79,13 +79,13 @@ public class DeploymentGroupTasks extends Descriptor {
       return false;
     }
 
-    final DeploymentGroupTasks that = (DeploymentGroupTasks) o;
+    final RollingOperationTasks that = (RollingOperationTasks) o;
 
     if (taskIndex != that.taskIndex) {
       return false;
     }
-    if (deploymentGroup != null ? !deploymentGroup.equals(that.deploymentGroup)
-                                : that.deploymentGroup != null) {
+    if (rollingOperation != null ? !rollingOperation.equals(that.rollingOperation)
+                                : that.rollingOperation != null) {
       return false;
     }
     if (rolloutTasks != null ? !rolloutTasks.equals(that.rolloutTasks)
@@ -100,23 +100,23 @@ public class DeploymentGroupTasks extends Descriptor {
   public int hashCode() {
     int result = rolloutTasks != null ? rolloutTasks.hashCode() : 0;
     result = 31 * result + taskIndex;
-    result = 31 * result + (deploymentGroup != null ? deploymentGroup.hashCode() : 0);
+    result = 31 * result + (rollingOperation != null ? rollingOperation.hashCode() : 0);
     return result;
   }
 
   @Override
   public String toString() {
-    return "DeploymentGroupTasks{" +
+    return "RollingOperationTasks{" +
            "rolloutTasks=" + rolloutTasks +
            ", taskIndex=" + taskIndex +
-           ", deploymentGroup=" + deploymentGroup +
+           ", rollingOperation=" + rollingOperation +
            "} " + super.toString();
   }
 
   public static class Builder {
     private List<RolloutTask> rolloutTasks = Collections.emptyList();
     private int taskIndex;
-    private DeploymentGroup deploymentGroup;
+    private RollingOperation rollingOperation;
 
     public Builder setRolloutTasks(List<RolloutTask> rolloutTasks) {
       this.rolloutTasks = rolloutTasks;
@@ -128,13 +128,13 @@ public class DeploymentGroupTasks extends Descriptor {
       return this;
     }
 
-    public Builder setDeploymentGroup(final DeploymentGroup deploymentGroup) {
-      this.deploymentGroup = deploymentGroup;
+    public Builder setRollingOperation(final RollingOperation rollingOperation) {
+      this.rollingOperation = rollingOperation;
       return this;
     }
 
-    public DeploymentGroupTasks build() {
-      return new DeploymentGroupTasks(this);
+    public RollingOperationTasks build() {
+      return new RollingOperationTasks(this);
     }
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
@@ -182,9 +182,17 @@ public class RolloutOptions {
     }
 
 
+    public long getTimeout() {
+      return this.timeout;
+    }
+
     public Builder setTimeout(final long timeout) {
       this.timeout = timeout;
       return this;
+    }
+
+    public int getParallelism() {
+      return this.parallelism;
     }
 
     public Builder setParallelism(final int parallelism) {
@@ -192,14 +200,26 @@ public class RolloutOptions {
       return this;
     }
 
+    public boolean getMigrate() {
+      return this.migrate;
+    }
+
     public Builder setMigrate(final boolean migrate) {
       this.migrate = migrate;
       return this;
     }
 
+    public boolean getOverlap() {
+      return this.overlap;
+    }
+
     public Builder setOverlap(final boolean overlap) {
       this.overlap = overlap;
       return this;
+    }
+
+    public String getToken() {
+      return this.token;
     }
 
     public Builder setToken(final String token) {

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupResponse.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.protocol;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.HostSelector;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.RolloutOptions;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * A DeploymentGroupResponse is a shim to maintain the appearance that a DeploymentGroup has a
+ * job ID and rollout operations per the legacy API, despite the fact that these options are now
+ * associated with rolling operations (which are in turn associated with the DeploymentGroup). A
+ * DeploymentGroupResponse can be created from the DeploymentGroup in question and its last good
+ * rolling operation.
+ */
+public class DeploymentGroupResponse {
+
+  private final String name;
+  private final List<HostSelector> hostSelectors;
+  private final JobId jobId;
+  private final RolloutOptions rolloutOptions;
+
+  public DeploymentGroupResponse(
+      @JsonProperty("name") final String name,
+      @JsonProperty("hostSelectors") final List<HostSelector> hostSelectors,
+      @JsonProperty("job") @Nullable final JobId jobId,
+      @JsonProperty("rolloutOptions") @Nullable final RolloutOptions rolloutOptions) {
+    this.name = name;
+    this.hostSelectors = hostSelectors;
+    this.jobId = jobId;
+    this.rolloutOptions = rolloutOptions;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public JobId getJobId() {
+    return jobId;
+  }
+
+  public List<HostSelector> getHostSelectors() {
+    return hostSelectors;
+  }
+
+  public RolloutOptions getRolloutOptions() {
+    return rolloutOptions;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final DeploymentGroupResponse that = (DeploymentGroupResponse) o;
+
+    if (jobId != null ? !jobId.equals(that.jobId) : that.jobId != null) {
+      return false;
+    }
+    if (hostSelectors != null ? !hostSelectors.equals(that.hostSelectors)
+                              : that.hostSelectors != null) {
+      return false;
+    }
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+    if (rolloutOptions != null ? !rolloutOptions.equals(that.rolloutOptions)
+                               : that.rolloutOptions != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (hostSelectors != null ? hostSelectors.hashCode() : 0);
+    result = 31 * result + (jobId != null ? jobId.hashCode() : 0);
+    result = 31 * result + (rolloutOptions != null ? rolloutOptions.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "DeploymentGroupResponse{" +
+           "name='" + name + '\'' +
+           ", hostSelectors=" + hostSelectors +
+           ", job=" + jobId +
+           ", rolloutOptions=" + rolloutOptions +
+           '}';
+  }
+
+  public String toJsonString() {
+    return Json.asStringUnchecked(this);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+    private List<HostSelector> hostSelectors;
+    private JobId jobId;
+    private RolloutOptions rolloutOptions;
+
+    public Builder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder hostSelectors(final List<HostSelector> hostSelectors) {
+      this.hostSelectors = hostSelectors;
+      return this;
+    }
+
+    public Builder jobId(final JobId jobId) {
+      this.jobId = jobId;
+      return this;
+    }
+
+    public Builder rolloutOptions(final RolloutOptions rolloutOptions) {
+      this.rolloutOptions = rolloutOptions;
+      return this;
+    }
+
+    public DeploymentGroupResponse build() {
+      return new DeploymentGroupResponse(
+          this.name, this.hostSelectors, this.jobId, this.rolloutOptions);
+    }
+  }
+
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupResponse.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.common.protocol;
 
+import com.google.common.collect.ImmutableList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.HostSelector;
@@ -136,7 +138,7 @@ public class DeploymentGroupResponse {
     }
 
     public Builder hostSelectors(final List<HostSelector> hostSelectors) {
-      this.hostSelectors = hostSelectors;
+      this.hostSelectors = ImmutableList.copyOf(hostSelectors);
       return this;
     }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
@@ -17,13 +17,12 @@
 
 package com.spotify.helios.common.protocol;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
 import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.RollingOperationStatus;
 import com.spotify.helios.common.descriptors.TaskStatus;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -97,27 +96,31 @@ public class DeploymentGroupStatusResponse {
     }
   }
 
-  private final DeploymentGroup deploymentGroup;
+  private final DeploymentGroupResponse deploymentGroupResponse;
   private final Status status;
   private final String error;
   private final List<HostStatus> hostStatuses;
   private final DeploymentGroupStatus deploymentGroupStatus;
+  private final RollingOperationStatus lastRollingOpStatus;
 
   public DeploymentGroupStatusResponse(
-      @JsonProperty("deploymentGroup") final DeploymentGroup deploymentGroup,
+      // Named deploymentGroup rather than deploymentGroupResponse to avoid breaking Helios API.
+      @JsonProperty("deploymentGroup") final DeploymentGroupResponse deploymentGroupResponse,
       @JsonProperty("status") final Status status,
       @JsonProperty("error") final String error,
       @JsonProperty("hostStatuses") final List<HostStatus> hostStatuses,
-      @JsonProperty("deploymentGroupStatus") @Nullable final DeploymentGroupStatus dgs) {
-    this.deploymentGroup = deploymentGroup;
+      @JsonProperty("deploymentGroupStatus") @Nullable final DeploymentGroupStatus dgs,
+      @JsonProperty("lastRollingOpStatus") @Nullable final RollingOperationStatus lros) {
+    this.deploymentGroupResponse = deploymentGroupResponse;
     this.status = status;
     this.error = error;
     this.hostStatuses = hostStatuses;
     this.deploymentGroupStatus = dgs;
+    this.lastRollingOpStatus = lros;
   }
 
-  public DeploymentGroup getDeploymentGroup() {
-    return deploymentGroup;
+  public DeploymentGroupResponse getDeploymentGroupResponse() {
+    return deploymentGroupResponse;
   }
 
   public Status getStatus() {
@@ -136,14 +139,19 @@ public class DeploymentGroupStatusResponse {
     return deploymentGroupStatus;
   }
 
+  public RollingOperationStatus getLastRollingOpStatus() {
+    return lastRollingOpStatus;
+  }
+
   @Override
   public String toString() {
     return "DeploymentGroupStatusResponse{" +
-           "deploymentGroup=" + deploymentGroup +
+           "deploymentGroupResponse=" + deploymentGroupResponse +
            ", status=" + status +
            ", error='" + error + '\'' +
            ", hostStatuses=" + hostStatuses +
            ", deploymentGroupStatus=" + deploymentGroupStatus +
+           ", lastRollingOpStatus=" + lastRollingOpStatus +
            '}';
   }
 
@@ -162,13 +170,18 @@ public class DeploymentGroupStatusResponse {
 
     final DeploymentGroupStatusResponse response = (DeploymentGroupStatusResponse) o;
 
-    if (deploymentGroup != null ? !deploymentGroup.equals(response.deploymentGroup)
-                                : response.deploymentGroup != null) {
+    if (deploymentGroupResponse != null ? !deploymentGroupResponse
+        .equals(response.deploymentGroupResponse)
+                                        : response.deploymentGroupResponse != null) {
       return false;
     }
     if (deploymentGroupStatus != null ? !deploymentGroupStatus
         .equals(response.deploymentGroupStatus)
                                       : response.deploymentGroupStatus != null) {
+      return false;
+    }
+    if (lastRollingOpStatus != null ? !lastRollingOpStatus.equals(response.lastRollingOpStatus)
+                                    : response.lastRollingOpStatus != null) {
       return false;
     }
     if (error != null ? !error.equals(response.error) : response.error != null) {
@@ -187,11 +200,65 @@ public class DeploymentGroupStatusResponse {
 
   @Override
   public int hashCode() {
-    int result = deploymentGroup != null ? deploymentGroup.hashCode() : 0;
+    int result = deploymentGroupResponse != null ? deploymentGroupResponse.hashCode() : 0;
     result = 31 * result + (status != null ? status.hashCode() : 0);
     result = 31 * result + (error != null ? error.hashCode() : 0);
     result = 31 * result + (hostStatuses != null ? hostStatuses.hashCode() : 0);
     result = 31 * result + (deploymentGroupStatus != null ? deploymentGroupStatus.hashCode() : 0);
+    result = 31 * result + (lastRollingOpStatus != null ? lastRollingOpStatus.hashCode() : 0);
     return result;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private DeploymentGroupResponse deploymentGroupResponse;
+    private Status status;
+    private String error;
+    private List<HostStatus> hostStatuses;
+    private DeploymentGroupStatus deploymentGroupStatus;
+    private RollingOperationStatus lastRollingOpStatus;
+
+    public Builder deploymentGroupResponse(final DeploymentGroupResponse response) {
+      this.deploymentGroupResponse = response;
+      return this;
+    }
+
+    public Builder status(final Status status) {
+      this.status = status;
+      return this;
+    }
+
+    public Builder error(final String error) {
+      this.error = error;
+      return this;
+    }
+
+    public Builder hostStatuses(final List<HostStatus> hostStatuses) {
+      this.hostStatuses = hostStatuses;
+      return this;
+    }
+
+    public Builder deploymentGroupStatus(final DeploymentGroupStatus dgs) {
+      this.deploymentGroupStatus = dgs;
+      return this;
+    }
+
+    public Builder lastRollingOpStatus(final RollingOperationStatus lros) {
+      this.lastRollingOpStatus = lros;
+      return this;
+    }
+
+    public DeploymentGroupStatusResponse build() {
+      return new DeploymentGroupStatusResponse(
+          this.deploymentGroupResponse,
+          this.status,
+          this.error,
+          this.hostStatuses,
+          this.deploymentGroupStatus,
+          this.lastRollingOpStatus);
+    }
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/protocol/DeploymentGroupStatusResponse.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.common.protocol;
 
+import com.google.common.collect.ImmutableList;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
@@ -237,7 +239,7 @@ public class DeploymentGroupStatusResponse {
     }
 
     public Builder hostStatuses(final List<HostStatus> hostStatuses) {
-      this.hostStatuses = hostStatuses;
+      this.hostStatuses = ImmutableList.copyOf(hostStatuses);
       return this;
     }
 

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/DeploymentGroupTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/DeploymentGroupTest.java
@@ -36,29 +36,17 @@ public class DeploymentGroupTest {
     //noinspection ConstantConditions
     final List<HostSelector> setHostSelectors =
         ImmutableList.of(HostSelector.parse("foo=bar"), HostSelector.parse("baz=qux"));
-    final JobId setJobId = JobId.fromString("foo:0.1.0");
-    final RolloutOptions setRolloutOptions = RolloutOptions.newBuilder()
-        .setTimeout(1000)
-        .setParallelism(2)
-        .setMigrate(false)
-        .build();
 
     // Check setXXX methods
     builder.setName(setName);
     builder.setHostSelectors(setHostSelectors);
-    builder.setJobId(setJobId);
-    builder.setRolloutOptions(setRolloutOptions);
 
     assertEquals("name", setName, builder.getName());
     assertEquals("hostSelectors", setHostSelectors, builder.getHostSelectors());
-    assertEquals("jobId", setJobId, builder.getJobId());
-    assertEquals("rolloutOptions", setRolloutOptions, builder.getRolloutOptions());
 
     // Check final output
     final DeploymentGroup deploymentGroup = builder.build();
     assertEquals("name", setName, deploymentGroup.getName());
     assertEquals("hostSelectors", setHostSelectors, deploymentGroup.getHostSelectors());
-    assertEquals("jobId", setJobId, deploymentGroup.getJobId());
-    assertEquals("rolloutOptions", setRolloutOptions, deploymentGroup.getRolloutOptions());
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/RollingOperationTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/RollingOperationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class RollingOperationTest {
+
+  @Test
+  public void verifyBuilder() {
+    final RollingOperation.Builder builder = RollingOperation.newBuilder();
+
+    // Input to setXXX
+    final String setDeploymentGroupName = "foo-group";
+    //noinspection ConstantConditions
+    final List<HostSelector> setHostSelectors =
+        ImmutableList.of(HostSelector.parse("foo=bar"), HostSelector.parse("baz=qux"));
+    final JobId setJobId = JobId.fromString("foo:0.1.0");
+    final RolloutOptions setRolloutOptions = RolloutOptions.newBuilder()
+        .setTimeout(1000)
+        .setParallelism(2)
+        .setMigrate(false)
+        .build();
+    final RollingOperation.Reason setReason = RollingOperation.Reason.MANUAL;
+
+    // Check setXXX methods
+    builder.setDeploymentGroupName(setDeploymentGroupName);
+    builder.setJobId(setJobId);
+    builder.setRolloutOptions(setRolloutOptions);
+    builder.setReason(setReason);
+
+    assertEquals("name", setDeploymentGroupName, builder.getDeploymentGroupName());
+    assertEquals("jobId", setJobId, builder.getJobId());
+    assertEquals("rolloutOptions", setRolloutOptions, builder.getRolloutOptions());
+    assertEquals("reason", setReason, builder.getReason());
+
+    // Check final output
+    final RollingOperation deploymentGroup = builder.build();
+    assertEquals("name", setDeploymentGroupName, deploymentGroup.getDeploymentGroupName());
+    assertEquals("jobId", setJobId, deploymentGroup.getJobId());
+    assertEquals("rolloutOptions", setRolloutOptions, deploymentGroup.getRolloutOptions());
+    assertEquals("reason", setReason, deploymentGroup.getReason());
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/RollingOperationTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/RollingOperationTest.java
@@ -17,11 +17,7 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.collect.ImmutableList;
-
 import org.junit.Test;
-
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -33,9 +29,6 @@ public class RollingOperationTest {
 
     // Input to setXXX
     final String setDeploymentGroupName = "foo-group";
-    //noinspection ConstantConditions
-    final List<HostSelector> setHostSelectors =
-        ImmutableList.of(HostSelector.parse("foo=bar"), HostSelector.parse("baz=qux"));
     final JobId setJobId = JobId.fromString("foo:0.1.0");
     final RolloutOptions setRolloutOptions = RolloutOptions.newBuilder()
         .setTimeout(1000)

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/RolloutOptionsTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/RolloutOptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RolloutOptionsTest {
+
+  @Test
+  public void verifyBuilder() {
+    final RolloutOptions.Builder builder = RolloutOptions.newBuilder();
+
+    // Input to setXXX
+    final long setTimeout = 1000;
+    final int setParallelism = 2;
+    final boolean setMigrate = true;
+    final boolean setOverlap = true;
+    final String setToken = "derp";
+
+    // Check setXXX methods
+    builder.setTimeout(setTimeout);
+    builder.setParallelism(setParallelism);
+    builder.setMigrate(setMigrate);
+    builder.setOverlap(setOverlap);
+    builder.setToken(setToken);
+
+    assertEquals("timeout", setTimeout, builder.getTimeout());
+    assertEquals("parallellism", setParallelism, builder.getParallelism());
+    assertEquals("migrate", setMigrate, builder.getMigrate());
+    assertEquals("overlap", setOverlap, builder.getOverlap());
+    assertEquals("token", setToken, builder.getToken());
+
+    // Check final output
+    final RolloutOptions options = builder.build();
+    assertEquals("timeout", setTimeout, options.getTimeout());
+    assertEquals("parallellism", setParallelism, options.getParallelism());
+    assertEquals("migrate", setMigrate, options.getMigrate());
+    assertEquals("overlap", setOverlap, options.getOverlap());
+    assertEquals("token", setToken, options.getToken());
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -24,6 +24,8 @@ import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
+import com.spotify.helios.common.descriptors.RollingOperation;
+import com.spotify.helios.common.descriptors.RollingOperationStatus;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatusEvent;
 
@@ -113,6 +115,12 @@ public interface MasterModel {
 
   DeploymentGroupStatus getDeploymentGroupStatus(String name)
       throws DeploymentGroupDoesNotExistException;
+
+  RollingOperation getLastRollingOperation(final String groupName)
+      throws DeploymentGroupDoesNotExistException;
+
+  RollingOperationStatus getRollingOperationStatus(final String rollingOpId)
+      throws RollingOperationDoesNotExistException;
 
   void removeDeploymentGroup(String name) throws DeploymentGroupDoesNotExistException;
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -116,6 +116,9 @@ public interface MasterModel {
   DeploymentGroupStatus getDeploymentGroupStatus(String name)
       throws DeploymentGroupDoesNotExistException;
 
+  List<RollingOperation> getRollingOperations(final String groupName)
+      throws DeploymentGroupDoesNotExistException;
+
   RollingOperation getLastRollingOperation(final String groupName)
       throws DeploymentGroupDoesNotExistException;
 

--- a/helios-services/src/main/java/com/spotify/helios/master/RollingOperationDoesNotExistException.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/RollingOperationDoesNotExistException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.spotify.helios.common.HeliosException;
+
+public class RollingOperationDoesNotExistException extends HeliosException {
+
+  public RollingOperationDoesNotExistException(final String message) {
+    super(message);
+  }
+
+  public RollingOperationDoesNotExistException(final Throwable cause) {
+    super(cause);
+  }
+
+  public RollingOperationDoesNotExistException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/DefaultRolloutPlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/DefaultRolloutPlanner.java
@@ -20,7 +20,7 @@ package com.spotify.helios.rollingupdate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.RollingOperation;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
@@ -31,14 +31,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DefaultRolloutPlanner implements RolloutPlanner {
 
-  private final DeploymentGroup deploymentGroup;
+  private final RollingOperation rollingOp;
 
-  private DefaultRolloutPlanner(final DeploymentGroup deploymentGroup) {
-    this.deploymentGroup = checkNotNull(deploymentGroup, "deploymentGroup");
+  private DefaultRolloutPlanner(final RollingOperation rollingOp) {
+    this.rollingOp = checkNotNull(rollingOp, "rollingOp");
   }
 
-  public static DefaultRolloutPlanner of(final DeploymentGroup deploymentGroup) {
-    return new DefaultRolloutPlanner(deploymentGroup);
+  public static DefaultRolloutPlanner of(final RollingOperation rollingOp) {
+    return new DefaultRolloutPlanner(rollingOp);
   }
 
   @Override
@@ -53,10 +53,10 @@ public class DefaultRolloutPlanner implements RolloutPlanner {
 
     // generate the rollout tasks
     final List<RolloutTask> rolloutTasks = Lists.newArrayList();
-    final int parallelism = deploymentGroup.getRolloutOptions() != null ?
-                            deploymentGroup.getRolloutOptions().getParallelism() : 1;
-    final boolean overlap = deploymentGroup.getRolloutOptions() != null &&
-                            deploymentGroup.getRolloutOptions().getOverlap();
+    final int parallelism = rollingOp.getRolloutOptions() != null ?
+                            rollingOp.getRolloutOptions().getParallelism() : 1;
+    final boolean overlap = rollingOp.getRolloutOptions() != null &&
+                            rollingOp.getRolloutOptions().getOverlap();
 
     for (final List<String> partition : Lists.partition(hosts, parallelism)) {
       rolloutTasks.addAll(overlap ? rolloutTasksWithOverlap(partition) : rolloutTasks(partition));

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingOperationError.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingOperationError.java
@@ -17,7 +17,7 @@
 
 package com.spotify.helios.rollingupdate;
 
-public enum RollingUpdateError {
+public enum RollingOperationError {
   PORT_CONFLICT,
   JOB_UNEXPECTEDLY_UNDEPLOYED,
   JOB_ALREADY_DEPLOYED,

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingOperationEventFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingOperationEventFactory.java
@@ -19,25 +19,20 @@ package com.spotify.helios.rollingupdate;
 
 import com.google.common.collect.Maps;
 
-import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.RollingOperation;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
 import java.util.Collections;
 import java.util.Map;
 
-public class DeploymentGroupEventFactory {
-
-  public enum RollingUpdateReason {
-    MANUAL,
-    HOSTS_CHANGED
-  }
+public class RollingOperationEventFactory {
 
   private Map<String, Object> createEvent(final String eventType,
-                                          final DeploymentGroup deploymentGroup) {
+                                          final RollingOperation rolling) {
     final Map<String, Object> ev = Maps.newHashMap();
     ev.put("eventType", eventType);
     ev.put("timestamp", System.currentTimeMillis());
-    ev.put("deploymentGroup", deploymentGroup);
+    ev.put("rollingOperation", rolling);
     return ev;
   }
 
@@ -48,20 +43,20 @@ public class DeploymentGroupEventFactory {
     return ev;
   }
 
-  public Map<String, Object> rollingUpdateTaskFailed(final DeploymentGroup deploymentGroup,
+  public Map<String, Object> rollingUpdateTaskFailed(final RollingOperation rolling,
                                                      final RolloutTask task,
                                                      final String error,
-                                                     final RollingUpdateError errorCode) {
-    return rollingUpdateTaskFailed(deploymentGroup, task, error, errorCode,
+                                                     final RollingOperationError errorCode) {
+    return rollingUpdateTaskFailed(rolling, task, error, errorCode,
                                    Collections.<String, Object>emptyMap());
   }
 
-  public Map<String, Object> rollingUpdateTaskFailed(final DeploymentGroup deploymentGroup,
+  public Map<String, Object> rollingUpdateTaskFailed(final RollingOperation rolling,
                                                      final RolloutTask task,
                                                      final String error,
-                                                     final RollingUpdateError errorCode,
+                                                     final RollingOperationError errorCode,
                                                      final Map<String, Object> metadata) {
-    final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", deploymentGroup);
+    final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", rolling);
     ev.putAll(metadata);
     ev.put("success", 0);
     ev.put("error", error);
@@ -69,29 +64,27 @@ public class DeploymentGroupEventFactory {
     return addTaskFields(ev, task);
   }
 
-  public Map<String, Object> rollingUpdateTaskSucceeded(final DeploymentGroup deploymentGroup,
+  public Map<String, Object> rollingUpdateTaskSucceeded(final RollingOperation rolling,
                                                         final RolloutTask task) {
-    final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", deploymentGroup);
+    final Map<String, Object> ev = createEvent("rollingUpdateTaskResult", rolling);
     ev.put("success", 1);
     return addTaskFields(ev, task);
   }
 
-  public Map<String, Object> rollingUpdateStarted(final DeploymentGroup deploymentGroup,
-                                                  final RollingUpdateReason reason) {
-    final Map<String, Object> ev = createEvent("rollingUpdateStarted", deploymentGroup);
-    ev.put("reason", reason);
+  public Map<String, Object> rollingUpdateStarted(final RollingOperation rolling) {
+    final Map<String, Object> ev = createEvent("rollingUpdateStarted", rolling);
     return ev;
   }
 
-  public Map<String, Object> rollingUpdateDone(final DeploymentGroup deploymentGroup) {
-    final Map<String, Object> ev = createEvent("rollingUpdateFinished", deploymentGroup);
+  public Map<String, Object> rollingUpdateDone(final RollingOperation rolling) {
+    final Map<String, Object> ev = createEvent("rollingUpdateFinished", rolling);
     ev.put("success", 1);
     return ev;
   }
 
-  public Map<String, Object> rollingUpdateFailed(final DeploymentGroup deploymentGroup,
+  public Map<String, Object> rollingUpdateFailed(final RollingOperation rolling,
                                                  final Map<String, Object> failEvent) {
-    final Map<String, Object> ev = createEvent("rollingUpdateFinished", deploymentGroup);
+    final Map<String, Object> ev = createEvent("rollingUpdateFinished", rolling);
     ev.put("success", 0);
     ev.put("failedTask", failEvent);
     return ev;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/Paths.java
@@ -39,7 +39,8 @@ public class Paths {
   private static final String LABELS = "labels";
   private static final String ID = "id";
   private static final String DEPLOYMENT_GROUPS = "deployment-groups";
-  private static final String DEPLOYMENT_GROUP_TASKS = "deployment-group-tasks";
+  private static final String ROLLING_OPS = "rolling-operations";
+  private static final String ROLLING_OPS_TASKS = "rolling-operation-tasks";
 
   private static final PathFactory CONFIG_ID = new PathFactory("/", CONFIG, ID);
   private static final PathFactory CONFIG_JOBS = new PathFactory("/", CONFIG, JOBS);
@@ -47,13 +48,15 @@ public class Paths {
   private static final PathFactory CONFIG_HOSTS = new PathFactory("/", CONFIG, HOSTS);
   private static final PathFactory CONFIG_DEPLOYMENT_GROUPS = new PathFactory(
       "/", CONFIG, DEPLOYMENT_GROUPS);
+  private static final PathFactory CONFIG_ROLLING_OPS = new PathFactory("/", CONFIG, ROLLING_OPS);
 
   private static final PathFactory STATUS_HOSTS = new PathFactory("/", STATUS, HOSTS);
   private static final PathFactory STATUS_MASTERS = new PathFactory("/", STATUS, MASTERS);
   private static final PathFactory STATUS_DEPLOYMENT_GROUPS = new PathFactory(
       "/", STATUS, DEPLOYMENT_GROUPS);
-  private static final PathFactory STATUS_DEPLOYMENT_GROUP_TASKS = new PathFactory(
-      "/", STATUS, DEPLOYMENT_GROUP_TASKS);
+  private static final PathFactory STATUS_ROLLING_OPS = new PathFactory("/", STATUS, ROLLING_OPS);
+  private static final PathFactory STATUS_ROLLING_OP_TASKS = new PathFactory(
+      "/", STATUS, ROLLING_OPS_TASKS);
 
   private static final PathFactory HISTORY_JOBS = new PathFactory("/", HISTORY, JOBS);
   private static final String CREATION_PREFIX = "creation-";
@@ -80,6 +83,14 @@ public class Paths {
 
   public static String configDeploymentGroup(final String name) {
     return CONFIG_DEPLOYMENT_GROUPS.path(name);
+  }
+
+  public static String configRollingOps() {
+    return CONFIG_ROLLING_OPS.path();
+  }
+
+  public static String configRollingOp(final String rollingOpId) {
+    return CONFIG_ROLLING_OPS.path(rollingOpId);
   }
 
   public static boolean isConfigJobCreation(final String child) {
@@ -208,12 +219,24 @@ public class Paths {
     return STATUS_DEPLOYMENT_GROUPS.path(name, HOSTS);
   }
 
-  public static String statusDeploymentGroupTasks() {
-    return STATUS_DEPLOYMENT_GROUP_TASKS.path();
+  public static String statusDeploymentGroupRollingOps(final String name) {
+    return STATUS_DEPLOYMENT_GROUPS.path(name, ROLLING_OPS);
   }
 
-  public static String statusDeploymentGroupTasks(final String deploymentGroupName) {
-    return STATUS_DEPLOYMENT_GROUP_TASKS.path(deploymentGroupName);
+  public static String statusRollingOps() {
+    return STATUS_ROLLING_OPS.path();
+  }
+
+  public static String statusRollingOp(final String rollingOpId) {
+    return STATUS_ROLLING_OPS.path(rollingOpId);
+  }
+
+  public static String statusRollingOpsTasks() {
+    return STATUS_ROLLING_OP_TASKS.path();
+  }
+
+  public static String statusRollingOpsTasks(final String rollingOpId) {
+    return STATUS_ROLLING_OP_TASKS.path(rollingOpId);
   }
 
   public static String historyJobHostEventsTimestamp(final JobId jobId,

--- a/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
@@ -278,7 +278,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   @Test
   public void testAddDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "my_group", ImmutableList.of(HostSelector.parse("role=foo")), null, null);
+        "my_group", ImmutableList.of(HostSelector.parse("role=foo")));
     model.addDeploymentGroup(dg);
     assertEquals(dg, model.getDeploymentGroup("my_group"));
   }
@@ -286,7 +286,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   @Test
   public void testAddExistingDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "my_group", ImmutableList.of(HostSelector.parse("role=foo")), null, null);
+        "my_group", ImmutableList.of(HostSelector.parse("role=foo")));
     model.addDeploymentGroup(dg);
     exception.expect(DeploymentGroupExistsException.class);
     model.addDeploymentGroup(dg);
@@ -295,7 +295,7 @@ public class ZooKeeperMasterModelIntegrationTest {
   @Test
   public void testRemoveDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "my_group", ImmutableList.of(HostSelector.parse("role=foo")), null, null);
+        "my_group", ImmutableList.of(HostSelector.parse("role=foo")));
     model.addDeploymentGroup(dg);
     model.removeDeploymentGroup("my_group");
     exception.expect(DeploymentGroupDoesNotExistException.class);

--- a/helios-services/src/test/java/com/spotify/helios/master/resources/DeploymentGroupResourceTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/resources/DeploymentGroupResourceTest.java
@@ -24,6 +24,7 @@ import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.protocol.CreateDeploymentGroupResponse;
+import com.spotify.helios.common.protocol.DeploymentGroupResponse;
 import com.spotify.helios.common.protocol.RemoveDeploymentGroupResponse;
 import com.spotify.helios.common.protocol.RollingUpdateRequest;
 import com.spotify.helios.common.protocol.RollingUpdateResponse;
@@ -76,13 +77,19 @@ public class DeploymentGroupResourceTest {
   @Test
   public void testGetDeploymentGroup() throws Exception {
     final DeploymentGroup dg = new DeploymentGroup(
-        "foo", Lists.newArrayList(ROLE_SELECTOR, FOO_SELECTOR),
-        new JobId("my_job", "0.2", "1234"), null);
+        "foo",
+        Lists.newArrayList(ROLE_SELECTOR, FOO_SELECTOR));
     when(model.getDeploymentGroup("foo")).thenReturn(dg);
+
+    final DeploymentGroupResponse dgr = new DeploymentGroupResponse(
+        "foo",
+        Lists.newArrayList(ROLE_SELECTOR, FOO_SELECTOR),
+        null,
+        null);
 
     final Response response = resource.getDeploymentGroup("foo");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertEquals(dg, response.getEntity());
+    assertEquals(dgr, response.getEntity());
   }
 
   @Test

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/DefaultRolloutPlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/DefaultRolloutPlannerTest.java
@@ -21,8 +21,8 @@ package com.spotify.helios.rollingupdate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.RollingOperation;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
@@ -39,7 +39,7 @@ public class DefaultRolloutPlannerTest {
 
   @Test
   public void testSerialRollout() {
-    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+    final RollingOperation rolling = RollingOperation.newBuilder()
         .setRolloutOptions(RolloutOptions.newBuilder()
                                .setParallelism(1)
                                .build())
@@ -53,7 +53,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(rolling);
 
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
@@ -76,7 +76,7 @@ public class DefaultRolloutPlannerTest {
 
   @Test
   public void testParallelRollout() {
-    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+    final RollingOperation rolling = RollingOperation.newBuilder()
         .setRolloutOptions(RolloutOptions.newBuilder()
                                .setParallelism(2)
                                .build())
@@ -90,7 +90,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(rolling);
 
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
@@ -113,7 +113,7 @@ public class DefaultRolloutPlannerTest {
 
   @Test
   public void testParallelRolloutWithRemainder() {
-    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+    final RollingOperation rolling = RollingOperation.newBuilder()
         .setRolloutOptions(RolloutOptions.newBuilder()
                                .setParallelism(3)
                                .build())
@@ -127,7 +127,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(rolling);
 
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
@@ -150,7 +150,7 @@ public class DefaultRolloutPlannerTest {
 
   @Test
   public void testOverlapRollout() {
-    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+    final RollingOperation rolling = RollingOperation.newBuilder()
         .setRolloutOptions(RolloutOptions.newBuilder().setOverlap(true).build())
         .build();
     final HostStatus statusUp = mock(HostStatus.class);
@@ -162,7 +162,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(rolling);
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
     final List<RolloutTask> expected = Lists.newArrayList(
@@ -184,7 +184,7 @@ public class DefaultRolloutPlannerTest {
 
   @Test
   public void testOverlapParallelRollout() {
-    final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
+    final RollingOperation rolling = RollingOperation.newBuilder()
         .setRolloutOptions(RolloutOptions.newBuilder()
                                .setOverlap(true)
                                .setParallelism(2)
@@ -199,7 +199,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(rolling);
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
     final List<RolloutTask> expected = Lists.newArrayList(

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/ZooKeeperAclProvidersTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/ZooKeeperAclProvidersTest.java
@@ -106,7 +106,11 @@ public class ZooKeeperAclProvidersTest {
     assertEquals(agentPerms(aclProvider.getAclForPath("/random/path")), READ);
     assertEquals(agentPerms(aclProvider.getAclForPath("/config")), READ);
     assertEquals(agentPerms(aclProvider.getAclForPath("/status")), READ);
-    assertEquals(agentPerms(aclProvider.getAclForPath(Paths.statusDeploymentGroupTasks())), READ);
+    assertEquals(agentPerms(aclProvider.getAclForPath(Paths.statusRollingOps())), READ);
+    assertEquals(agentPerms(aclProvider.getAclForPath(Paths.statusRollingOpsTasks())), READ);
+    assertEquals(agentPerms(aclProvider.getAclForPath(Paths.statusRollingOpsTasks("id"))), READ);
+    assertEquals(agentPerms(aclProvider.getAclForPath(Paths.configRollingOps())), READ);
+    assertEquals(agentPerms(aclProvider.getAclForPath(Paths.configRollingOp("id"))), READ);
     assertEquals(agentPerms(aclProvider.getAclForPath(Paths.configDeploymentGroups())), READ);
     assertEquals(agentPerms(aclProvider.getAclForPath(Paths.configDeploymentGroup("group"))), READ);
     assertEquals(agentPerms(aclProvider.getAclForPath(Paths.configHostJobs("host"))), READ);

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
@@ -130,6 +130,10 @@ public class DeploymentGroupTest extends SystemTestBase {
     // trigger a rolling update
     cli("rolling-update", "--async", testJobNameAndVersion, TEST_GROUP);
 
+    // trigger another one immediately afterwards.
+    // This duplicate rolling update should be discarded.
+    cli("rolling-update", "--async", testJobNameAndVersion, TEST_GROUP);
+
     // ensure the job is running on all agents and the deployment group reaches DONE
     for (final String host : hosts) {
       awaitTaskState(jobId, host, TaskStatus.State.RUNNING);

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -58,13 +58,13 @@ import com.spotify.helios.cli.CliMain;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.Deployment;
-import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.Job.Builder;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
 import com.spotify.helios.common.descriptors.PortMapping;
+import com.spotify.helios.common.descriptors.RollingOperationStatus;
 import com.spotify.helios.common.descriptors.ServiceEndpoint;
 import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -987,22 +987,22 @@ public abstract class SystemTestBase {
     });
   }
 
-  protected DeploymentGroupStatus awaitDeploymentGroupStatus(
+  protected RollingOperationStatus awaitRollingOperationStatus(
       final HeliosClient client,
       final String name,
-      final DeploymentGroupStatus.State state)
+      final RollingOperationStatus.State state)
       throws Exception {
-    return Polling.await(LONG_WAIT_SECONDS, SECONDS, new Callable<DeploymentGroupStatus>() {
+    return Polling.await(LONG_WAIT_SECONDS, SECONDS, new Callable<RollingOperationStatus>() {
       @Override
-      public DeploymentGroupStatus call() throws Exception {
+      public RollingOperationStatus call() throws Exception {
         final DeploymentGroupStatusResponse response = getOrNull(
             client.deploymentGroupStatus(name));
 
         if (response != null) {
-          final DeploymentGroupStatus status = response.getDeploymentGroupStatus();
+          final RollingOperationStatus status = response.getLastRollingOpStatus();
           if (status.getState().equals(state)) {
             return status;
-          } else if (status.getState().equals(DeploymentGroupStatus.State.FAILED)) {
+          } else if (status.getState().equals(RollingOperationStatus.State.FAILED)) {
             assertEquals(state, status.getState());
           }
         }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommand.java
@@ -21,8 +21,8 @@ import com.google.common.collect.Maps;
 
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostSelector;
+import com.spotify.helios.common.protocol.DeploymentGroupResponse;
 
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -54,7 +54,7 @@ public class DeploymentGroupInspectCommand extends ControlCommand {
       throws ExecutionException, InterruptedException, IOException {
     final String name = options.getString(nameArg.getDest());
 
-    final DeploymentGroup deploymentGroup = client.deploymentGroup(name).get();
+    final DeploymentGroupResponse deploymentGroup = client.deploymentGroup(name).get();
 
     if (deploymentGroup == null) {
       if (json) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStatusCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStatusCommand.java
@@ -89,9 +89,10 @@ public class DeploymentGroupStatusCommand extends ControlCommand {
     if (json) {
       out.println(Json.asPrettyStringUnchecked(status));
     } else {
-      final JobId jobId = status.getDeploymentGroup().getJobId();
+      final JobId jobId = status.getDeploymentGroupResponse().getJobId();
       final String error = status.getError();
-      final List<HostSelector> hostSelectors = status.getDeploymentGroup().getHostSelectors();
+      final List<HostSelector> hostSelectors =
+          status.getDeploymentGroupResponse().getHostSelectors();
 
       out.printf("Name: %s%n", name);
       out.printf("Job Id: %s%n", full ? jobId : (jobId == null ? null : jobId.toShortString()));

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -206,7 +206,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         break;
       }
 
-      if (!jobId.equals(status.getDeploymentGroup().getJobId())) {
+      if (!jobId.equals(status.getDeploymentGroupResponse().getJobId())) {
         // Another rolling-update was started, overriding this one -- exit
         failed = true;
         error = "Deployment-group job id changed during rolling-update";

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/DeploymentGroupInspectCommandTest.java
@@ -24,9 +24,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.protocol.DeploymentGroupResponse;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
@@ -57,8 +57,12 @@ public class DeploymentGroupInspectCommandTest {
   private static final List<HostSelector> HOST_SELECTORS = ImmutableList.of(
       HostSelector.parse("foo=bar"),
       HostSelector.parse("baz=qux"));
-  private static final DeploymentGroup DEPLOYMENT_GROUP = DeploymentGroup.newBuilder()
-      .setName(NAME).setHostSelectors(HOST_SELECTORS).setJobId(JOB).build();
+  private static final DeploymentGroupResponse DEPLOYMENT_GROUP =
+      DeploymentGroupResponse.builder()
+          .name(NAME)
+          .hostSelectors(HOST_SELECTORS)
+          .jobId(JOB)
+          .build();
 
   private final Namespace options = mock(Namespace.class);
   private final HeliosClient client = mock(HeliosClient.class);
@@ -79,7 +83,7 @@ public class DeploymentGroupInspectCommandTest {
     command = new DeploymentGroupInspectCommand(subparser);
 
     when(client.deploymentGroup(NAME)).thenReturn(Futures.immediateFuture(DEPLOYMENT_GROUP));
-    final ListenableFuture<DeploymentGroup> nullFuture = Futures.immediateFuture(null);
+    final ListenableFuture<DeploymentGroupResponse> nullFuture = Futures.immediateFuture(null);
     when(client.deploymentGroup(NON_EXISTENT_NAME)).thenReturn(nullFuture);
   }
 
@@ -103,7 +107,8 @@ public class DeploymentGroupInspectCommandTest {
     final int ret = command.run(options, client, out, true, null);
 
     assertEquals(0, ret);
-    final DeploymentGroup output = Json.read(baos.toString(), DeploymentGroup.class);
+    final DeploymentGroupResponse output = Json.read(
+        baos.toString(), DeploymentGroupResponse.class);
 
     assertEquals(DEPLOYMENT_GROUP, output);
   }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/DeploymentGroupStatusCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/DeploymentGroupStatusCommandTest.java
@@ -25,11 +25,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatus;
+import com.spotify.helios.common.protocol.DeploymentGroupResponse;
 import com.spotify.helios.common.protocol.DeploymentGroupStatusResponse;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
@@ -62,8 +62,13 @@ public class DeploymentGroupStatusCommandTest {
   private static final List<HostSelector> HOST_SELECTORS = ImmutableList.of(
       HostSelector.parse("a=b"), HostSelector.parse("foo=bar"));
   private static final RolloutOptions ROLLOUT_OPTIONS = RolloutOptions.newBuilder().build();
-  private static final DeploymentGroup DEPLOYMENT_GROUP = new DeploymentGroup(
-      GROUP_NAME, HOST_SELECTORS, JOB_ID, ROLLOUT_OPTIONS);
+  private static final DeploymentGroupResponse DEPLOYMENT_GROUP = DeploymentGroupResponse.builder()
+      .name(GROUP_NAME)
+      .hostSelectors(HOST_SELECTORS)
+      .jobId(JOB_ID)
+      .rolloutOptions(ROLLOUT_OPTIONS)
+      .build();
+
 
   private final Namespace options = mock(Namespace.class);
   private final HeliosClient client = mock(HeliosClient.class);
@@ -94,9 +99,11 @@ public class DeploymentGroupStatusCommandTest {
     hostStatuses.add(new DeploymentGroupStatusResponse.HostStatus(
         "host3", null, null));
 
-    final DeploymentGroupStatusResponse status = new DeploymentGroupStatusResponse(
-        DEPLOYMENT_GROUP, DeploymentGroupStatusResponse.Status.ROLLING_OUT, null,
-        hostStatuses, null);
+    final DeploymentGroupStatusResponse status = DeploymentGroupStatusResponse.builder()
+        .deploymentGroupResponse(DEPLOYMENT_GROUP)
+        .status(DeploymentGroupStatusResponse.Status.ROLLING_OUT)
+        .hostStatuses(hostStatuses)
+        .build();
 
     when(client.deploymentGroupStatus(GROUP_NAME)).thenReturn(Futures.immediateFuture(status));
     when(options.getString("name")).thenReturn(GROUP_NAME);
@@ -123,8 +130,11 @@ public class DeploymentGroupStatusCommandTest {
 
   @Test
   public void testDeploymentGroupStatusBeforeRollingUpdate() throws Exception {
-    final DeploymentGroup deploymentGroupWithNoJob = new DeploymentGroup(
-        GROUP_NAME, HOST_SELECTORS, null, ROLLOUT_OPTIONS);
+    final DeploymentGroupResponse deploymentGroupWithNoJob = DeploymentGroupResponse.builder()
+        .name(GROUP_NAME)
+        .hostSelectors(HOST_SELECTORS)
+        .rolloutOptions(ROLLOUT_OPTIONS)
+        .build();
 
     final List<DeploymentGroupStatusResponse.HostStatus> hostStatuses = Lists.newArrayList();
     hostStatuses.add(new DeploymentGroupStatusResponse.HostStatus(
@@ -134,9 +144,11 @@ public class DeploymentGroupStatusCommandTest {
     hostStatuses.add(new DeploymentGroupStatusResponse.HostStatus(
         "host3", null, null));
 
-    final DeploymentGroupStatusResponse status = new DeploymentGroupStatusResponse(
-        deploymentGroupWithNoJob, DeploymentGroupStatusResponse.Status.IDLE, null,
-        hostStatuses, null);
+    final DeploymentGroupStatusResponse status = DeploymentGroupStatusResponse.builder()
+        .deploymentGroupResponse(deploymentGroupWithNoJob)
+        .status(DeploymentGroupStatusResponse.Status.IDLE)
+        .hostStatuses(hostStatuses)
+        .build();
 
     when(client.deploymentGroupStatus(GROUP_NAME)).thenReturn(Futures.immediateFuture(status));
     when(options.getString("name")).thenReturn(GROUP_NAME);
@@ -171,9 +183,12 @@ public class DeploymentGroupStatusCommandTest {
     hostStatuses.add(new DeploymentGroupStatusResponse.HostStatus(
         "host3", null, null));
 
-    final DeploymentGroupStatusResponse status = new DeploymentGroupStatusResponse(
-        DEPLOYMENT_GROUP, DeploymentGroupStatusResponse.Status.ROLLING_OUT, "Oops!",
-        hostStatuses, null);
+    final DeploymentGroupStatusResponse status = DeploymentGroupStatusResponse.builder()
+        .deploymentGroupResponse(DEPLOYMENT_GROUP)
+        .status(DeploymentGroupStatusResponse.Status.ROLLING_OUT)
+        .error("Oops!")
+        .hostStatuses(hostStatuses)
+        .build();
 
     when(client.deploymentGroupStatus(GROUP_NAME)).thenReturn(Futures.immediateFuture(status));
     when(options.getString("name")).thenReturn(GROUP_NAME);
@@ -225,9 +240,11 @@ public class DeploymentGroupStatusCommandTest {
     hostStatuses.add(new DeploymentGroupStatusResponse.HostStatus(
         "host3", JOB_ID, TaskStatus.State.PULLING_IMAGE));
 
-    final DeploymentGroupStatusResponse status = new DeploymentGroupStatusResponse(
-        DEPLOYMENT_GROUP, DeploymentGroupStatusResponse.Status.ROLLING_OUT, null,
-        hostStatuses, null);
+    final DeploymentGroupStatusResponse status = DeploymentGroupStatusResponse.builder()
+        .deploymentGroupResponse(DEPLOYMENT_GROUP)
+        .status(DeploymentGroupStatusResponse.Status.ROLLING_OUT)
+        .hostStatuses(hostStatuses)
+        .build();
 
     when(client.deploymentGroupStatus(GROUP_NAME)).thenReturn(Futures.immediateFuture(status));
     when(options.getString("name")).thenReturn(GROUP_NAME);

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -24,11 +24,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatus;
+import com.spotify.helios.common.protocol.DeploymentGroupResponse;
 import com.spotify.helios.common.protocol.DeploymentGroupStatusResponse;
 import com.spotify.helios.common.protocol.RollingUpdateResponse;
 
@@ -102,10 +102,18 @@ public class RollingUpdateCommandTest {
   private static DeploymentGroupStatusResponse statusResponse(
       final DeploymentGroupStatusResponse.Status status, final JobId jobId, final String error,
       DeploymentGroupStatusResponse.HostStatus... args) {
-    return new DeploymentGroupStatusResponse(
-        new DeploymentGroup(GROUP_NAME, Collections.<HostSelector>emptyList(), jobId,
-                            RolloutOptions.newBuilder().build()),
-        status, error, Arrays.asList(args), null);
+    final DeploymentGroupResponse dgr = DeploymentGroupResponse.builder()
+        .name(GROUP_NAME)
+        .hostSelectors(Collections.<HostSelector>emptyList())
+        .jobId(jobId)
+        .rolloutOptions(RolloutOptions.newBuilder().build())
+        .build();
+    return DeploymentGroupStatusResponse.builder()
+        .deploymentGroupResponse(dgr)
+        .status(status)
+        .error(error)
+        .hostStatuses(Arrays.asList(args))
+        .build();
   }
 
   @Test


### PR DESCRIPTION
The target job ID and rollout options of a rolling update are associated with the rolling operation - not the deployment group itself. Each rolling operation is associated with a deployment group. The 'reason' for a rolling update (i.e. manual or 'hosts changed') is a property of the rolling operation.

Deployment groups may now have state 'stable' or 'unstable'. Stable deployment groups are known to be running the same job across all agents. Unstable groups are known to have some containers down, or to be running different jobs across agents. Rolling operations model the states previously associated with deployment groups (ROLLING_OUT, DONE, FAILED).

Some hacks (i.e. the DeploymentGroupResponse) have been put in place in order to avoid breaking the existing REST and CLI APIs.

This change means:
* A failed rolling update will no longer require human intervention to unblock future automatic (i.e. 'hosts changed') rolling updates.
* Rolling restarts could be implemented as a variant of a rolling operation - perhaps as a rolling operation with a null jobId?
* We could expose an audit trail of a deployment group's rolling updates.