### PR TITLE
fix: target/docker/image-name ends in a newline

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -350,7 +350,7 @@ public class TemporaryJobBuilder {
       return false;
     }
     try {
-      final String imageName = Resources.asCharSource(resource, UTF_8).read();
+      final String imageName = Resources.asCharSource(resource, UTF_8).read().trim();
       image(imageName);
       return true;
     } catch (IOException e) {

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobBuilderTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobBuilderTest.java
@@ -158,7 +158,7 @@ public class TemporaryJobBuilderTest {
 
   @Test
   public void testImageFromDockerfileMavenPlugin() throws Exception {
-    writeToFile("foobar:from.dockerfile", "target/docker/image-name");
+    writeToFile("foobar:from.dockerfile\n", "target/docker/image-name");
 
     builder.imageFromBuild();
 


### PR DESCRIPTION
Make sure that the contents of the file are stripped of newlines when
reading `target/docker/image-name`.