### PR TITLE
TemporaryJobs: handle DOCKER_HOST with unix sockets

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -596,7 +596,7 @@ public class TemporaryJobs implements TestRule {
       final String dockerHost = env.get("DOCKER_HOST");
       if (dockerHost == null) {
         endpoints("http://localhost:5801");
-      } else {
+      } else if (!dockerHost.startsWith("unix://")) {
         try {
           final URI uri = new URI(dockerHost);
           endpoints("http://" + uri.getHost() + ":5801");

--- a/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsBuilderTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/TemporaryJobsBuilderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TemporaryJobsBuilderTest {
+
+  /**
+   * Ensure that the TemporaryJobs.Builder can be constructed ok when DOCKER_HOST looks like a unix
+   * socket path.
+   */
+  @Test
+  public void testDockerHostIsUnixSocket() {
+    final Map<String, String> env = ImmutableMap.of("DOCKER_HOST", "unix:///var/run/docker.sock");
+    final TemporaryJobs.Builder builder = TemporaryJobs.builder(env);
+    assertNotNull(builder);
+  }
+}


### PR DESCRIPTION
`TemporaryJobs.builder()` attempts to set up default values for the
`endpoints` to connect to (representing the address of the Helios
cluster to talk to), prior to the user setting any endpoints or
HeliosClient of their own.

After checking a few environment variables for which Helios host to talk
to, `TemporaryJobs.Builder` then checks if `DOCKER_HOST` is set and uses
it as the host in a `http://` URI.

This fails if `DOCKER_HOST` is a URI to a Unix socket (e.g.
`unix:///var/run/docker.sock`), such as when using Docker for Mac.

To fix this, change the Builder to ignore `DOCKER_HOST` values that
start with `unix://`, and rely on the user to set the endpoints or
HeliosClient to use themselves.