### PR TITLE
exec healthchecks: remove check of executionDriver

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
@@ -113,10 +113,8 @@ public final class HealthCheckerFactory {
     }
 
     private static boolean compatibleDockerVersion(final DockerClient docker) {
-      final String executionDriver;
       final String apiVersion;
       try {
-        executionDriver = docker.info().executionDriver();
         apiVersion = docker.version().apiVersion();
       } catch (DockerException e) {
         return false;
@@ -125,9 +123,6 @@ public final class HealthCheckerFactory {
         return false;
       }
 
-      if (Strings.isNullOrEmpty(executionDriver) || !executionDriver.startsWith("native")) {
-        return false;
-      }
       if (Strings.isNullOrEmpty(apiVersion)) {
         return false;
       }

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -189,6 +189,11 @@ class TaskRunner extends InterruptingExecutionThreadService {
                    retryMillis, config, containerId);
           Thread.sleep(retryMillis);
         }
+
+        log.info("healthchecking complete of containerId={} taskConfig={}", containerId, config);
+      } else {
+        log.info("no healthchecks configured for containerId={} taskConfig={}",
+                 containerId, config);
       }
     }
 

--- a/helios-services/src/test/java/com/spotify/helios/agent/ExecHealthCheckerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/ExecHealthCheckerTest.java
@@ -101,15 +101,4 @@ public class ExecHealthCheckerTest {
     exception.expect(UnsupportedOperationException.class);
     checker.check(CONTAINER_ID);
   }
-
-  @Test
-  public void testNotNativeDriver() throws Exception {
-    final Info info = mock(Info.class);
-    when(info.executionDriver()).thenReturn("lxc");
-    when(docker.info()).thenReturn(info);
-
-    exception.expect(UnsupportedOperationException.class);
-    checker.check(CONTAINER_ID);
-  }
-
 }


### PR DESCRIPTION
There are some environments, such as docker-machine on Mac or Docker for
Mac, where `docker exec` works just fine but they seem to return an
empty string for `ExecutionDriver` from the `/info` endpoint in the
Docker Remote API.

This change removes the check that only executes the exec healthcheck
when `executionDriver` starts with `native`, so that exec healthchecks
can still be used (and jobs with them can be deployed) in these
environments.