### PR TITLE
default to not removing helios-solo containers after test

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -568,7 +568,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     private String heliosUsername;
     private Set<String> env;
     private boolean pullBeforeCreate = true;
-    private boolean removeHeliosSoloContainerOnExit = true;
+    private boolean removeHeliosSoloContainerOnExit = false;
     private int jobUndeployWaitSeconds = DEFAULT_WAIT_SECONDS;
 
     Builder(String profile, Config rootConfig) {


### PR DESCRIPTION
The default value of removing the container after it's use makes it much
harder to troubleshoot issues within the helios-solo container itself.