### PR TITLE
fix helios-solo scripts for Docker for Mac

### DIFF
--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -12,11 +12,11 @@ SKYDNS_PATH=$(echo $HELIOS_NAME|python -c "import sys;h=sys.stdin.read().strip()
 
 # Write skydns configuration and retry for 30 seconds until successful
 for i in {1..30}; do
-	if curl --retry 30 -XPUT http://127.0.0.1:4001/v2/keys/skydns/config \
-		-d value="{\"dns_addr\":\"0.0.0.0:5353\", \"ttl\":3600, \"nameservers\": $NAMESERVERS, \"domain\":\"local.\"}"; then
-		break
-	fi
-	sleep 1
+  if curl --retry 30 -XPUT http://127.0.0.1:4001/v2/keys/skydns/config \
+    -d value="{\"dns_addr\":\"0.0.0.0:5353\", \"ttl\":3600, \"nameservers\": $NAMESERVERS, \"domain\":\"local.\"}"; then
+    break
+  fi
+  sleep 1
 done
 
 # Create A record for the solo host
@@ -53,7 +53,7 @@ $HELIOS_AGENT_OPTS \
 # Start master
 mkdir -p /master
 if [ -n "$LOGSTASH_DESTINATION" ]; then
-	cat > /master/logback-access.xml <<- EOF
+  cat > /master/logback-access.xml <<- EOF
 <configuration>
   <appender name="stash" class="net.logstash.logback.appender.LogstashAccessTcpSocketAppender">
     <destination>${LOGSTASH_DESTINATION}</destination>

--- a/solo/helios-cleanup
+++ b/solo/helios-cleanup
@@ -4,20 +4,20 @@ echo 'Removing all helios-solo jobs and containers...'
 # Instruct helios to undeploy and remove all jobs
 RUNNING=$(docker inspect -f '{{ .State.Running }}' helios-solo-container 2>/dev/null)
 if [ "$RUNNING" == "true" ]; then
-	JOBS=$(PATH=.:$PATH helios-solo jobs -q)
-	for job in $JOBS; do
-		PATH=.:$PATH helios-solo undeploy -a --yes $job
-		PATH=.:$PATH helios-solo remove --yes $job
-	done
+  JOBS=$(PATH=.:$PATH helios-solo jobs -q)
+  for job in $JOBS; do
+    PATH=.:$PATH helios-solo undeploy -a --yes $job
+    PATH=.:$PATH helios-solo remove --yes $job
+  done
 fi
 
 # Kill containers until they're gone
 while true; do
-	CTRS=$(docker ps -a | grep helios-solo-host- | awk '{ print $(NF) }')
-	if [ -z "$CTRS" ]; then break; fi
-	for ctr in $CTRS; do
-		docker kill $ctr
-		docker rm $ctr
-	done
-	sleep 1
+  CTRS=$(docker ps -a | grep helios-solo-host- | awk '{ print $(NF) }')
+  if [ -z "$CTRS" ]; then break; fi
+  for ctr in $CTRS; do
+    docker kill $ctr
+    docker rm $ctr
+  done
+  sleep 1
 done

--- a/solo/helios-down
+++ b/solo/helios-down
@@ -1,7 +1,7 @@
 #!/bin/bash
 if ! docker inspect helios-solo-container &> /dev/null; then
-	echo 'helios-solo not running'
-	exit 1
+  echo 'helios-solo not running'
+  exit 1
 fi
 
 docker kill helios-solo-container > /dev/null

--- a/solo/helios-env
+++ b/solo/helios-env
@@ -1,26 +1,26 @@
 #!/bin/bash
 
 if [ "x$DOCKER_HOST" == "x" ]; then
-	# On Linux, assume DOCKER_HOST is the unix socket. On other platforms, if an
-	# arbitrary `docker` CLI command can be run, then we can also assume that the
-	# daemon is listening on the unix socket (or else the docker CLI would not
-	# work)
-	if [ "$(uname -s)" == "Linux" ] || docker info >/dev/null 2>&1; then
-		DOCKER_HOST=unix:///var/run/docker.sock
-		echo export DOCKER_HOST=$DOCKER_HOST
-	else
-		echo "DOCKER_HOST needs to be set"
-		exit 1
-	fi
+  # On Linux, assume DOCKER_HOST is the unix socket. On other platforms, if an
+  # arbitrary `docker` CLI command can be run, then we can also assume that the
+  # daemon is listening on the unix socket (or else the docker CLI would not
+  # work)
+  if [ "$(uname -s)" == "Linux" ] || docker info >/dev/null 2>&1; then
+    DOCKER_HOST=unix:///var/run/docker.sock
+    echo export DOCKER_HOST=$DOCKER_HOST
+  else
+    echo "DOCKER_HOST needs to be set"
+    exit 1
+  fi
 fi
 
 
 if [[ "$DOCKER_HOST" == unix:///* ]]; then
-	DOCKER_HOST_RAW=localhost
-	DOCKER_HOST_ADDRESS=127.0.0.1
+  DOCKER_HOST_RAW=localhost
+  DOCKER_HOST_ADDRESS=127.0.0.1
 else
-	DOCKER_HOST_RAW=$(echo $DOCKER_HOST | sed 's/^[a-zA-Z]\{1,\}:\/\///')
-	DOCKER_HOST_ADDRESS=$(echo $DOCKER_HOST_RAW | cut -d: -f1)
+  DOCKER_HOST_RAW=$(echo $DOCKER_HOST | sed 's/^[a-zA-Z]\{1,\}:\/\///')
+  DOCKER_HOST_ADDRESS=$(echo $DOCKER_HOST_RAW | cut -d: -f1)
 fi
 HELIOS_URI=http://$DOCKER_HOST_ADDRESS:5801
 

--- a/solo/helios-env
+++ b/solo/helios-env
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 if [ "x$DOCKER_HOST" == "x" ]; then
-	if [ "$(uname -s)" == "Linux" ]; then
+	# On Linux, assume DOCKER_HOST is the unix socket. On other platforms, if an
+	# arbitrary `docker` CLI command can be run, then we can also assume that the
+	# daemon is listening on the unix socket (or else the docker CLI would not
+	# work)
+	if [ "$(uname -s)" == "Linux" ] || docker info >/dev/null 2>&1; then
 		DOCKER_HOST=unix:///var/run/docker.sock
 		echo export DOCKER_HOST=$DOCKER_HOST
 	else

--- a/solo/helios-up
+++ b/solo/helios-up
@@ -9,7 +9,7 @@ HELIOS_IMAGE=$REPO:latest
 RUNNING=$(docker inspect -f '{{ .State.Running }}' helios-solo-container 2>/dev/null)
 
 if [ "$RUNNING" == "true" ]; then
-	echo 'helios-solo already running'
+  echo 'helios-solo already running'
 else
     # Horrible hack to preserve some configuration internal to Spotify.
     # Unfortunately, I don't have a better way to do this.
@@ -24,80 +24,80 @@ else
         DOCKER_OPTS="$DOCKER_OPTS -e REGISTRAR_HOST_FORMAT=$registrar_host_format"
     fi
 
-	PROBE=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 32)
+  PROBE=$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | head -c 32)
 
-	# figure out the CONTAINER_DOCKER_HOST and CONTINER_DOCKER_CERT_PATH, which are the DOCKER_HOST
-	# and DOCKER_CERT_PATH from the perspective of the helios-solo container. these differ
-	# from the local DOCKER_HOST/CERT_PATH in the case of using Boot2Docker.
-	if [[ "$(docker info | grep 'Operating System')" == *Boot2Docker* ]]; then
-		# when using Boot2Docker, just use the unix socket endpoint for talking to Docker from
-		# the Helios container
-		CONTAINER_DOCKER_HOST=unix:///var/run/docker.sock
-		CONTAINER_DOCKER_CERT_PATH=
-	else
-		CONTAINER_DOCKER_HOST="$DOCKER_HOST"
-		CONTAINER_DOCKER_CERT_PATH="$DOCKER_CERT_PATH"
-	fi
+  # figure out the CONTAINER_DOCKER_HOST and CONTINER_DOCKER_CERT_PATH, which are the DOCKER_HOST
+  # and DOCKER_CERT_PATH from the perspective of the helios-solo container. these differ
+  # from the local DOCKER_HOST/CERT_PATH in the case of using Boot2Docker.
+  if [[ "$(docker info | grep 'Operating System')" == *Boot2Docker* ]]; then
+    # when using Boot2Docker, just use the unix socket endpoint for talking to Docker from
+    # the Helios container
+    CONTAINER_DOCKER_HOST=unix:///var/run/docker.sock
+    CONTAINER_DOCKER_CERT_PATH=
+  else
+    CONTAINER_DOCKER_HOST="$DOCKER_HOST"
+    CONTAINER_DOCKER_CERT_PATH="$DOCKER_CERT_PATH"
+  fi
 
-	if [ -z "$CONTAINER_DOCKER_CERT_PATH" ]; then
-		PROTOCOL="http"
-	else
-		DOCKER_OPTS="$DOCKER_OPTS -v $CONTAINER_DOCKER_CERT_PATH:/certs -e DOCKER_CERT_PATH=/certs"
-		CURL_OPTS="--insecure --cert /certs/cert.pem --key /certs/key.pem"
-		PROTOCOL="https"
-	fi
+  if [ -z "$CONTAINER_DOCKER_CERT_PATH" ]; then
+    PROTOCOL="http"
+  else
+    DOCKER_OPTS="$DOCKER_OPTS -v $CONTAINER_DOCKER_CERT_PATH:/certs -e DOCKER_CERT_PATH=/certs"
+    CURL_OPTS="--insecure --cert /certs/cert.pem --key /certs/key.pem"
+    PROTOCOL="https"
+  fi
 
-	if [[ "$CONTAINER_DOCKER_HOST" == unix:///* ]]; then
-		DOCKER_SOCKET_PATH=$(echo $CONTAINER_DOCKER_HOST | sed 's/^[a-zA-Z]\{1,\}:\/\///')
-		DOCKER_OPTS="$DOCKER_OPTS -v $DOCKER_SOCKET_PATH:/var/run/docker.sock"
-		CURL_OPTS="$CURL_OPTS --unix-socket $DOCKER_SOCKET_PATH"
-	fi
+  if [[ "$CONTAINER_DOCKER_HOST" == unix:///* ]]; then
+    DOCKER_SOCKET_PATH=$(echo $CONTAINER_DOCKER_HOST | sed 's/^[a-zA-Z]\{1,\}:\/\///')
+    DOCKER_OPTS="$DOCKER_OPTS -v $DOCKER_SOCKET_PATH:/var/run/docker.sock"
+    CURL_OPTS="$CURL_OPTS --unix-socket $DOCKER_SOCKET_PATH"
+  fi
 
-	if type -p nmcli >/dev/null; then
-		# get DNS servers from NetworkManager when it's available, since /etc/resolv.conf is likely
-		# to just point to local dnsmasq
-		dns_servers="$(nmcli -terse -field IP4 device list | grep DNS | cut -d: -f2)"
-		for dns in $dns_servers; do
-			DOCKER_OPTS="$DOCKER_OPTS --dns $dns"
-		done
-	fi
+  if type -p nmcli >/dev/null; then
+    # get DNS servers from NetworkManager when it's available, since /etc/resolv.conf is likely
+    # to just point to local dnsmasq
+    dns_servers="$(nmcli -terse -field IP4 device list | grep DNS | cut -d: -f2)"
+    for dns in $dns_servers; do
+      DOCKER_OPTS="$DOCKER_OPTS --dns $dns"
+    done
+  fi
 
-	# Check that CONTAINER_DOCKER_HOST is reachable from within the container by starting a container
-	# with a unique name and probing docker for the existence of this named container, from within the
-	# container itself. If CONTINER_DOCKER_CERT_PATH exists, we will connect using TLS, otherwise HTTP.
-	# We're using the onescience/alpine image, which has curl with Unix socket support.
-	docker run --rm --name $PROBE $DOCKER_OPTS onescience/alpine \
-		curl -f $CURL_OPTS $PROTOCOL://$DOCKER_HOST_RAW/containers/$PROBE/json &>/dev/null
+  # Check that CONTAINER_DOCKER_HOST is reachable from within the container by starting a container
+  # with a unique name and probing docker for the existence of this named container, from within the
+  # container itself. If CONTINER_DOCKER_CERT_PATH exists, we will connect using TLS, otherwise HTTP.
+  # We're using the onescience/alpine image, which has curl with Unix socket support.
+  docker run --rm --name $PROBE $DOCKER_OPTS onescience/alpine \
+    curl -f $CURL_OPTS $PROTOCOL://$DOCKER_HOST_RAW/containers/$PROBE/json &>/dev/null
 
-	DOCKER_HOST_OK=$?
-	if [ $DOCKER_HOST_OK -ne 0 ]; then
-		echo "Docker was not reachable using DOCKER_HOST=$DOCKER_HOST_RAW and DOCKER_CERT_PATH=$DOCKER_CERT_PATH from within a container."
-		echo "Please ensure that DOCKER_HOST contains a full hostname or ip address, not localhost or 127.0.0.1, etc."
-		exit 1
-	fi
+  DOCKER_HOST_OK=$?
+  if [ $DOCKER_HOST_OK -ne 0 ]; then
+    echo "Docker was not reachable using DOCKER_HOST=$DOCKER_HOST_RAW and DOCKER_CERT_PATH=$DOCKER_CERT_PATH from within a container."
+    echo "Please ensure that DOCKER_HOST contains a full hostname or ip address, not localhost or 127.0.0.1, etc."
+    exit 1
+  fi
 
-	HELIOS_HOST_ADDRESS="$DOCKER_HOST_ADDRESS"
-	if [ "$HELIOS_HOST_ADDRESS" == "127.0.0.1" ]; then
-		# HELIOS_HOST_ADDRESS must be addressable from both the physical host and containers.
-		# If Docker is running on the localhost, use the bridge address instead of 127.0.0.1.
-		HELIOS_HOST_ADDRESS=$(docker run --rm onescience/alpine \
-			sh -c "ip route | awk '/default/ { print \$3 }'")
-	fi
+  HELIOS_HOST_ADDRESS="$DOCKER_HOST_ADDRESS"
+  if [ "$HELIOS_HOST_ADDRESS" == "127.0.0.1" ]; then
+    # HELIOS_HOST_ADDRESS must be addressable from both the physical host and containers.
+    # If Docker is running on the localhost, use the bridge address instead of 127.0.0.1.
+    HELIOS_HOST_ADDRESS=$(docker run --rm onescience/alpine \
+      sh -c "ip route | awk '/default/ { print \$3 }'")
+  fi
 
-	docker rm helios-solo-container &> /dev/null
-	docker inspect "$HELIOS_IMAGE" &>/dev/null || docker pull "$HELIOS_IMAGE"
-	if ! docker inspect "$HELIOS_IMAGE" &>/dev/null; then
-		echo "Failed to pull $HELIOS_IMAGE"
-		exit 1
-	fi
-	CID=$(docker run -d \
-		  -e DOCKER_HOST=$CONTAINER_DOCKER_HOST \
-		  -e HELIOS_NAME=solo.local. \
-		  -e HOST_ADDRESS=$HELIOS_HOST_ADDRESS \
-		  -p 5801:5801 \
-		  --name helios-solo-container \
-		  $DOCKER_OPTS \
-		  $HELIOS_IMAGE)
+  docker rm helios-solo-container &> /dev/null
+  docker inspect "$HELIOS_IMAGE" &>/dev/null || docker pull "$HELIOS_IMAGE"
+  if ! docker inspect "$HELIOS_IMAGE" &>/dev/null; then
+    echo "Failed to pull $HELIOS_IMAGE"
+    exit 1
+  fi
+  CID=$(docker run -d \
+      -e DOCKER_HOST=$CONTAINER_DOCKER_HOST \
+      -e HELIOS_NAME=solo.local. \
+      -e HOST_ADDRESS=$HELIOS_HOST_ADDRESS \
+      -p 5801:5801 \
+      --name helios-solo-container \
+      $DOCKER_OPTS \
+      $HELIOS_IMAGE)
     if [ $? -ne 0 ]; then
         echo "The helios-solo container couldn't start."
     else

--- a/solo/helios-use
+++ b/solo/helios-use
@@ -6,14 +6,14 @@ REPO=spotify/helios-solo
 HELIOS_IMAGE=$REPO:latest
 
 function get_helios_version() {
-	docker run --rm --entrypoint bash $HELIOS_IMAGE \
-		-c "ls *.jar | cut -d- -f3"
+  docker run --rm --entrypoint bash $HELIOS_IMAGE \
+    -c "ls *.jar | cut -d- -f3"
 }
 
 function get_cli_version() {
-	if type -p helios >/dev/null; then
-		helios --version | grep 'Helios CLI' | grep -oe '[0-9\.]\+'
-	fi
+  if type -p helios >/dev/null; then
+    helios --version | grep 'Helios CLI' | grep -oe '[0-9\.]\+'
+  fi
 }
 
 orig_version=$(get_helios_version)
@@ -21,67 +21,67 @@ echo "Currently using Helios v$orig_version"
 echo
 
 if [ ! -z "$1" ]; then
-	requested_version="$1"
-	if [ "$orig_version" == "$requested_version" ]; then
-		echo "Already at v$requested_version"
-		exit 0
-	fi
+  requested_version="$1"
+  if [ "$orig_version" == "$requested_version" ]; then
+    echo "Already at v$requested_version"
+    exit 0
+  fi
 
-	echo "Switching to $requested_version"
-	docker pull "$REPO:$requested_version"
-	docker tag -f "$REPO:$requested_version" "$REPO:latest"
-	echo
+  echo "Switching to $requested_version"
+  docker pull "$REPO:$requested_version"
+  docker tag -f "$REPO:$requested_version" "$REPO:latest"
+  echo
 
-	new_version=$(get_helios_version)
+  new_version=$(get_helios_version)
 
-	if [ "$requested_version" == "latest" ] && [ "$new_version" == "$orig_version" ]; then
-		echo "Already at latest version (v$new_version)."
-		exit 0
-	fi
+  if [ "$requested_version" == "latest" ] && [ "$new_version" == "$orig_version" ]; then
+    echo "Already at latest version (v$new_version)."
+    exit 0
+  fi
 
-	echo "Switched to v$new_version. To use it, please restart helios-solo:"
-	echo
-	echo '    helios-restart'
-	echo
-	echo 'Note that this will destroy all Helios jobs on helios-solo.'
+  echo "Switched to v$new_version. To use it, please restart helios-solo:"
+  echo
+  echo '    helios-restart'
+  echo
+  echo 'Note that this will destroy all Helios jobs on helios-solo.'
 
-	cli_version=$(get_cli_version)
-	if [ ! -z "$cli_version" ] && [ "$cli_version" != "$new_version" ]; then
-		echo
-		echo "WARNING: Your Helios CLI version is different (v$cli_version)."
-		echo 'Upgrade or downgrade to the correct CLI version if you have issues.'
-		echo 'This is usually accomplished with `brew` or `apt-get`.'
-	fi
+  cli_version=$(get_cli_version)
+  if [ ! -z "$cli_version" ] && [ "$cli_version" != "$new_version" ]; then
+    echo
+    echo "WARNING: Your Helios CLI version is different (v$cli_version)."
+    echo 'Upgrade or downgrade to the correct CLI version if you have issues.'
+    echo 'This is usually accomplished with `brew` or `apt-get`.'
+  fi
 else
-	echo 'Upgrade to the latest version with:'
-	echo
-	echo '    helios-use latest'
-	echo
-	echo 'You can also switch to a specific version with:'
-	echo
-	echo '    helios-use <version>'
-	echo
+  echo 'Upgrade to the latest version with:'
+  echo
+  echo '    helios-use latest'
+  echo
+  echo 'You can also switch to a specific version with:'
+  echo
+  echo '    helios-use <version>'
+  echo
 
-	set +e
-	echo 'Fetching list of available versions...'
-	echo
-	versions=$(curl -sSL https://index.docker.io/v1/repositories/$REPO/tags \
-		| jq  --raw-output '.[].name')
-	versions_ok=$?
-	set -e
+  set +e
+  echo 'Fetching list of available versions...'
+  echo
+  versions=$(curl -sSL https://index.docker.io/v1/repositories/$REPO/tags \
+    | jq  --raw-output '.[].name')
+  versions_ok=$?
+  set -e
 
     if [[ ! "$versions" =~ 'latest' ]]; then
         # if "latest" isn't an available version, something went wrong
         versions_ok=1
     fi
 
-	if [ $versions_ok -ne 0 ]; then
-		echo 'Error fetching available versions.'
-	else
-		echo 'Available versions:'
-		for v in $versions; do
-			echo "* $v"
-		done
-	fi
-	echo
+  if [ $versions_ok -ne 0 ]; then
+    echo 'Error fetching available versions.'
+  else
+    echo 'Available versions:'
+    for v in $versions; do
+      echo "* $v"
+    done
+  fi
+  echo
 fi

--- a/solo/helios-use
+++ b/solo/helios-use
@@ -63,6 +63,8 @@ else
 	echo
 
 	set +e
+	echo 'Fetching list of available versions...'
+	echo
 	versions=$(curl -sSL https://index.docker.io/v1/repositories/$REPO/tags \
 		| jq  --raw-output '.[].name')
 	versions_ok=$?


### PR DESCRIPTION
When `DOCKER_HOST` is not set, the `helios-env` script assumes that if the local OS is Linux then the Unix socket at `/var/run/docker.sock` can be used to communicate with the Docker daemon.

Docker for Mac also uses this socket and path and does not need `DOCKER_HOST` to be set to work, so add a test to see if a bare `docker info` command exits with a success and use the same Unix socket path when it exits successfully.

Also fixed some other low-hanging fruit in these scripts, specifically the mixing of tabs and spaces for indentation 😎 