### PR TITLE
always update status to STOPPING when stopping a job

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -346,12 +346,13 @@ public class Supervisor {
         return;
       }
 
+      statusUpdater.setState(STOPPING);
+      statusUpdater.update();
+
       final Integer gracePeriod = job.getGracePeriod();
       if (gracePeriod != null && gracePeriod > 0) {
         log.info("Unregistering from service discovery for {} seconds before stopping",
                  gracePeriod);
-        statusUpdater.setState(STOPPING);
-        statusUpdater.update();
 
         if (runner.unregister()) {
           log.info("Unregistered. Now sleeping for {} seconds.", gracePeriod);

--- a/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
@@ -69,6 +69,7 @@ import static com.spotify.helios.common.descriptors.TaskStatus.State.PULLING_IMA
 import static com.spotify.helios.common.descriptors.TaskStatus.State.RUNNING;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.STARTING;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.STOPPED;
+import static com.spotify.helios.common.descriptors.TaskStatus.State.STOPPING;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.startsWith;
@@ -302,7 +303,17 @@ public class SupervisorTest {
     );
 
 
-    // Verify that the stopped state is signalled
+    // Verify that the STOPPING and STOPPED states are signalled
+    verify(model, timeout(30000)).setTaskStatus(eq(JOB.getId()),
+                                                eq(TaskStatus.newBuilder()
+                                                       .setJob(JOB)
+                                                       .setGoal(STOP)
+                                                       .setState(STOPPING)
+                                                       .setContainerId(containerId)
+                                                       .setEnv(ENV)
+                                                       .build())
+    );
+
     verify(model, timeout(30000)).setTaskStatus(eq(JOB.getId()),
                                                 eq(TaskStatus.newBuilder()
                                                        .setJob(JOB)

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/JobHistoryTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/JobHistoryTest.java
@@ -101,7 +101,10 @@ public class JobHistoryTest extends SystemTestBase {
     assertEquals(State.RUNNING, event3.getStatus().getState());
 
     final TaskStatusEvent event4 = eventsList.get(n + 3);
-    final State finalState = event4.getStatus().getState();
+    assertEquals(State.STOPPING, event4.getStatus().getState());
+
+    final TaskStatusEvent event5 = eventsList.get(n + 4);
+    final State finalState = event5.getStatus().getState();
     assertTrue(finalState == State.EXITED || finalState == State.STOPPED);
   }
 }


### PR DESCRIPTION
Supervisor stores a status update of STOPPED after the container has
been shut down. For jobs with grace periods, it always stores a status
update of STOPPING prior to unregistering the job from service discovery
and sleeping before the container is stopped.

It would make more sense to unconditionally store the status update of
STOPPING prior to the container stop request and the STOPPED state,
since stopping the container may take a number of seconds for the
container to clean itself up or otherwise respond to SIGTERM. This would
lead to more consistent output from the `helios history` command.