### PR TITLE
codecov: remove changes from PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 comment:
-  layout: header, changes, diff
+  layout: header, diff
 
 coverage: 
   status:


### PR DESCRIPTION
It's not very useful; something about our tests seems to cause it to report changes in coverage totally unrelated to the actual code change.