### PR TITLE
helios-solo: Allow whitelisting capabilities in helios-solo

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -237,6 +238,11 @@ public class TemporaryJobBuilder {
 
   public TemporaryJobBuilder tcpHealthCheck(final String port) {
     this.builder.setHealthCheck(TcpHealthCheck.of(port));
+    return this;
+  }
+
+  public TemporaryJobBuilder addCapabilities(final Collection<String> capabilities) {
+    this.builder.setAddCapabilities(capabilities);
     return this;
   }
 

--- a/solo/docker/start.sh
+++ b/solo/docker/start.sh
@@ -72,6 +72,10 @@ if [ -n "$LOGSTASH_DESTINATION" ]; then
 EOF
 fi
 
+# Capabilities to be whitelisted are specified as a comma separate env var. E.g.
+# WHITELISTED_CAPS=IPC_LOCK,SYSLOG
+WHITELISTED_CAPS=(${WHITELISTED_CAPS//,/ })
+
 cd /master
 java -cp '/*' \
 -Xmx128m \
@@ -79,6 +83,7 @@ java -cp '/*' \
 com.spotify.helios.master.MasterMain \
 --service-registrar-plugin /usr/share/helios/lib/plugins/helios-skydns-0.1.jar \
 --domain '' \
+"${WHITELISTED_CAPS[@]/#/--whitelisted-capability=}" \
 $HELIOS_MASTER_OPTS \
 &
 

--- a/solo/helios-up
+++ b/solo/helios-up
@@ -94,6 +94,7 @@ else
       -e DOCKER_HOST=$CONTAINER_DOCKER_HOST \
       -e HELIOS_NAME=solo.local. \
       -e HOST_ADDRESS=$HELIOS_HOST_ADDRESS \
+      -e "WHITELISTED_CAPS=$WHITELISTED_CAPS" \
       -p 5801:5801 \
       --name helios-solo-container \
       $DOCKER_OPTS \


### PR DESCRIPTION
Which capabilities to whitelist are controlled by the `WHITELISTED_CAPS`
environment variable. Values are comma separated.

To use from a `HeliosSoloDeployment` set the `WHITELISTED_CAPS` env var when
the deployment is created:

```
  HeliosSoloDeployment hsd = HeliosSoloDeployment.builder()
    .env("WHITELISTED_CAPS", "IPC_LOCK,SYSLOG")
    ...
    .build();
```

When using `helios-up` capabilities are whitelisted in a similar fashion:

```
  WHITELISTED_CAPS="IPC_LOCK,SYSLOG" helios-up
```