### PR TITLE
Add JobHistoryReaper

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/JobHistoryReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/JobHistoryReaper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.spotify.helios.agent.InterruptingScheduledService;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.servicescommon.coordination.Paths;
+import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Removes job histories whose corresponding jobs don't exist anymore.
+ * There are two race conditions where jobs can be deleted but their histories are
+ * left behind in ZooKeeper:
+ *
+ * 1. The master deletes the job (in {@link ZooKeeperMasterModel} and then deletes its history.
+ * During this deletion, the agent creates a znode. The master's deletion operations fail.
+ *
+ * 2. The master deletes all relevant history znodes successfully. The agent still hasn't undeployed
+ * its job and continues writing history to ZooKeeper. This will recreate deleted history znodes
+ * via {@link com.spotify.helios.agent.TaskHistoryWriter}.
+ *
+ * Solve both of these cases by scheduling an instance of this class. It runs once a day once
+ * scheduled.
+ */
+class JobHistoryReaper extends InterruptingScheduledService {
+
+  private static final Logger log = LoggerFactory.getLogger(JobHistoryReaper.class);
+
+  private final MasterModel masterModel;
+  private final ZooKeeperClient client;
+
+  JobHistoryReaper(final MasterModel masterModel,
+                   final ZooKeeperClient client) {
+    this.masterModel = masterModel;
+    this.client = client;
+  }
+
+  @Override
+  protected void runOneIteration() {
+    log.debug("Reaping orphaned job histories.");
+
+    final String path = Paths.historyJobs();
+    List<String> jobIds = Collections.emptyList();
+
+    try {
+      jobIds = client.getChildren(path);
+    } catch (KeeperException e) {
+      log.warn("Failed to get children of znode {}", path, e);
+    }
+
+    for (final String jobId : jobIds) {
+      final JobId id = JobId.fromString(jobId);
+      final Job job = masterModel.getJob(id);
+      if (job == null) {
+        try {
+          client.deleteRecursive(Paths.historyJob(id));
+        } catch (NoNodeException ignored) {
+          // Something deleted the history right before we got to it. Ignore and keep going.
+        } catch (KeeperException e) {
+          log.warn("error removing job history for job {}", jobId, e);
+        }
+      }
+    }
+  }
+
+  @Override
+  protected ScheduledFuture<?> schedule(final Runnable runnable,
+                                        final ScheduledExecutorService executorService) {
+    return executorService.scheduleWithFixedDelay(runnable, 0, 1, TimeUnit.DAYS);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/JobHistoryReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/JobHistoryReaper.java
@@ -81,10 +81,11 @@ class JobHistoryReaper extends InterruptingScheduledService {
       if (job == null) {
         try {
           client.deleteRecursive(Paths.historyJob(id));
+          log.info("Reaped job history for job {}", jobId);
         } catch (NoNodeException ignored) {
           // Something deleted the history right before we got to it. Ignore and keep going.
         } catch (KeeperException e) {
-          log.warn("error removing job history for job {}", jobId, e);
+          log.warn("error reaping job history for job {}", jobId, e);
         }
       }
     }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterConfig.java
@@ -61,6 +61,7 @@ public class MasterConfig extends Configuration {
   private long jobRetention;
   private FastForwardConfig fastForwardConfig;
   private Set<String> whitelistedCapabilities;
+  private boolean jobHistoryReapingEnabled;
 
   public String getDomain() {
     return domain;
@@ -293,6 +294,15 @@ public class MasterConfig extends Configuration {
 
   public MasterConfig setWhitelistedCapabilities(final Set<String> whitelistedCapabilities) {
     this.whitelistedCapabilities = ImmutableSet.copyOf(whitelistedCapabilities);
+    return this;
+  }
+
+  public boolean isJobHistoryReapingEnabled() {
+    return jobHistoryReapingEnabled;
+  }
+
+  public MasterConfig setJobHistoryReapingEnabled(final boolean jobHistoryReapingEnabled) {
+    this.jobHistoryReapingEnabled = jobHistoryReapingEnabled;
     return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterParser.java
@@ -89,7 +89,8 @@ public class MasterParser extends ServiceParser {
         .setJobRetention(options.getLong(jobRetention.getDest()))
         .setFfwdConfig(ffwdConfig(options))
         .setWhitelistedCapabilities(ImmutableSet.copyOf(
-            options.getList(whitelistedCapabilities.getDest())));
+            options.getList(whitelistedCapabilities.getDest())))
+        .setJobHistoryReapingEnabled(getJobHistoryReapingEnabled());
 
     this.masterConfig = config;
   }

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -1077,7 +1077,7 @@ public class ZooKeeperMasterModel implements MasterModel {
 
   /**
    * Returns the job configuration for the job specified by {@code id} as a
-   * {@link Job} object.
+   * {@link Job} object. A return value of null indicates the job doesn't exist.
    */
   @Override
   public Job getJob(final JobId id) {
@@ -1085,7 +1085,6 @@ public class ZooKeeperMasterModel implements MasterModel {
     final ZooKeeperClient client = provider.get("getJobId");
     return getJob(client, id);
   }
-
 
   private Job getJob(final ZooKeeperClient client, final JobId id) {
     final String path = Paths.configJob(id);
@@ -1238,7 +1237,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     } catch (NoNodeException ignored) {
       // There's no history for this job
     } catch (KeeperException e) {
-      log.warn("error removing job history for job {}: {}", id, e);
+      log.warn("error removing job history for job {}", id, e);
     }
 
     return job;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/ServiceParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/ServiceParser.java
@@ -78,6 +78,7 @@ public class ServiceParser {
   private final Argument noLogSetupArg;
   private final Argument kafkaArg;
   private final Argument stateDirArg;
+  private final Argument jobHistoryReapingEnabled;
 
   // ffwd arguments:
   private final Argument ffwdEnabled;
@@ -209,6 +210,11 @@ public class ServiceParser {
         .help("Value to use for `key` in metric data sent to FastForward. "
               + "Defaults to '" + programName + "'");
 
+    jobHistoryReapingEnabled = parser.addArgument("--reap-history")
+        .action(storeTrue())
+        .setDefault(false)
+        .help("Enable periodic reaping of orphaned job histories.");
+
     addArgs(parser);
 
     try {
@@ -305,6 +311,10 @@ public class ServiceParser {
 
   public Path getStateDirectory() {
     return Paths.get(options.getString(stateDirArg.getDest()));
+  }
+
+  public boolean getJobHistoryReapingEnabled() {
+    return options.getBoolean(jobHistoryReapingEnabled.getDest());
   }
 
   private static String getHostName() {

--- a/helios-services/src/test/java/com/spotify/helios/master/JobHistoryReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/JobHistoryReaperTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.spotify.helios.common.Clock;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.servicescommon.coordination.Paths;
+import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class JobHistoryReaperTest {
+
+  private static class Datapoint {
+
+    private final String jobName;
+    private final JobId jobId;
+    private final Job job;
+    private final boolean expectReap;
+
+    private Datapoint(final String jobName, final Job job, final boolean expectReap) {
+      this.jobName = jobName;
+      this.jobId = JobId.fromString(jobName);
+      this.job = job;
+      this.expectReap = expectReap;
+    }
+
+    String getJobName() {
+      return jobName;
+    }
+
+    Job getJob() {
+      return job;
+    }
+
+    JobId getJobId() {
+      return jobId;
+    }
+  }
+
+  @Test
+  public void testJobHistoryReaper() throws Exception {
+    final MasterModel masterModel = mock(MasterModel.class);
+    final Clock clock = mock(Clock.class);
+    when(clock.now()).thenReturn(new Instant(HOURS.toMillis(48)));
+
+    final List<Datapoint> datapoints = Lists.newArrayList(
+        // A job history with a corresponding job should NOT BE reaped.
+        new Datapoint("job1", Job.newBuilder().setName("job1").build(), false),
+        // A job history without a corresponding job should BE reaped.
+        new Datapoint("job2", null, true)
+    );
+
+    for (final Datapoint dp : datapoints) {
+      when(masterModel.getJob(argThat(matchesName(dp.getJobName())))).thenReturn(dp.getJob());
+    }
+
+    final ZooKeeperClient client = mock(ZooKeeperClient.class);
+    final List<String> jobHistories = ImmutableList.of("job1", "job2");
+    when(client.getChildren(Paths.historyJobs())).thenReturn(jobHistories);
+
+    final JobHistoryReaper reaper = new JobHistoryReaper(masterModel, client);
+    reaper.startAsync().awaitRunning();
+
+    for (final Datapoint datapoint : datapoints) {
+      if (datapoint.expectReap) {
+        verify(client, timeout(500)).deleteRecursive(Paths.historyJob(datapoint.getJobId()));
+      } else {
+        verify(client, never()).deleteRecursive(Paths.historyJob(datapoint.getJobId()));
+      }
+    }
+  }
+
+  private CustomTypeSafeMatcher<JobId> matchesName(final String name) {
+    return new CustomTypeSafeMatcher<JobId>("A JobId with name " + name) {
+      @Override
+      protected boolean matchesSafely(final JobId item) {
+        return item.getName().equals(name);
+      }
+    };
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/master/JobHistoryReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/JobHistoryReaperTest.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.master;
 
-import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.servicescommon.coordination.Paths;
@@ -27,12 +26,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.hamcrest.CustomTypeSafeMatcher;
-import org.joda.time.Instant;
 import org.junit.Test;
 
 import java.util.List;
 
-import static java.util.concurrent.TimeUnit.HOURS;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -72,8 +69,6 @@ public class JobHistoryReaperTest {
   @Test
   public void testJobHistoryReaper() throws Exception {
     final MasterModel masterModel = mock(MasterModel.class);
-    final Clock clock = mock(Clock.class);
-    when(clock.now()).thenReturn(new Instant(HOURS.toMillis(48)));
 
     final List<Datapoint> datapoints = Lists.newArrayList(
         // A job history with a corresponding job should NOT BE reaped.


### PR DESCRIPTION
This reaper, disabled by default, runs in the master and will
remove job histories whose corresponding jobs no longer exist.
It runs once a day when enabled.

This reaper is meant to address the scenario where jobs are deleted but
their histories are left behind in ZooKeeper. See JobHistoryReaper's
JavaDocs for more details.