### PR TITLE
remove docgenerator:scanner dependency

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -16,10 +16,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.spotify.docgenerator</groupId>
-      <artifactId>scanner</artifactId>
-    </dependency>
     <!--compile deps-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -145,10 +145,6 @@
   </profiles>
 
   <dependencies>
-    <dependency>
-      <groupId>com.spotify.docgenerator</groupId>
-      <artifactId>scanner</artifactId>
-    </dependency>
     <!--compile deps -->
     <dependency>
       <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
It's not clear what this is used for, but it seems unnecessary to list
this as a dependency of helios-client as it then drags it into any
user's project.