### PR TITLE
remove docgenerator:scanner dependency

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -16,10 +16,6 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.spotify.docgenerator</groupId>
-      <artifactId>scanner</artifactId>
-    </dependency>
     <!--compile deps-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -145,10 +145,6 @@
   </profiles>
 
   <dependencies>
-    <dependency>
-      <groupId>com.spotify.docgenerator</groupId>
-      <artifactId>scanner</artifactId>
-    </dependency>
     <!--compile deps -->
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -58,6 +58,10 @@
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+    </dependency>
 
     <!--test deps-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,11 @@
         <artifactId>jsr305</artifactId>
         <version>2.0.3</version>
       </dependency>
+      <dependency>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>javax.ws.rs-api</artifactId>
+        <version>2.0.1</version>
+      </dependency>
 
       <!--test deps-->
       <dependency>


### PR DESCRIPTION
It's not clear what this is used for, but it seems unnecessary to list
this as a dependency of helios-client as it then drags it into any
user's project.