### PR TITLE
When a DG fails due to port allocation issues, hint what the problem …

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactory.java
@@ -188,6 +188,14 @@ public class RollingUpdateOpFactory {
 
   public RollingUpdateOp error(final Exception e, final String host,
                                final RollingUpdateError errorCode) {
-    return error(e.getMessage(), host, errorCode);
+    final String message;
+    if (errorCode == RollingUpdateError.PORT_CONFLICT) {
+      message = e.getMessage() +
+                " (the conflicting job was deployed manually or by a different deployment group)";
+    } else {
+      message = e.getMessage();
+    }
+
+    return error(message, host, errorCode);
   }
 }


### PR DESCRIPTION
…might be

This commit adds the note in the parentheses below:

  "Allocation of port <port> for job <dg-job> collides with job <other-job>
  on host <host> (the conflicting job was deployed manually or by a
  different deployment group)"