### PR TITLE
helios-testing: remove logging of typesafe Config objects

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosConfig.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosConfig.java
@@ -43,16 +43,11 @@ public class HeliosConfig {
 
     final Config baseConfig = ConfigFactory.load(
         BASE_CONFIG_FILE, ConfigParseOptions.defaults(), resolveOptions);
-    log.debug(component + " base config: " + baseConfig);
 
     final Config appConfig = ConfigFactory.load(
         APP_CONFIG_FILE, ConfigParseOptions.defaults(), resolveOptions);
-    log.debug(component + " app config: " + appConfig);
 
-    final Config returnConfig = appConfig.withFallback(baseConfig);
-    log.debug(component + "result config: " + returnConfig);
-
-    return returnConfig;
+    return appConfig.withFallback(baseConfig);
   }
 
   /**


### PR DESCRIPTION
These objects are huge, since Typesafe ends up loading all of the Java
system properties (including the classpath) in these options.

When debugging test failures from helios-testing users, these giant log
lines are just pure noise.