### PR TITLE
less log noise from X509CertificateFactory

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/tls/X509CertificateFactory.java
@@ -143,7 +143,7 @@ public class X509CertificateFactory {
     }
 
     if (useCached) {
-      log.info("using existing certificate for {} from {}", username, cacheCertPath);
+      log.debug("using existing certificate for {} from {}", username, cacheCertPath);
       return cached;
     } else {
       final CertificateAndPrivateKey generated = generate(agentProxy, identity, username);


### PR DESCRIPTION
If programmatically using a HeliosClient, this line is logged once per
request being made to Helios. If programmatically using several
HeliosClient instances, this line gets logged a whole lot.