### PR TITLE
fix flakiness in JobHistoryTest

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/JobHistoryTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/JobHistoryTest.java
@@ -65,7 +65,7 @@ public class JobHistoryTest extends SystemTestBase {
         int requiredEventCount = -1;
         for (int i = 0; i < size; i++) {
           if (events.getEvents().get(i).getStatus().getState() != State.PULLING_IMAGE) {
-            requiredEventCount = i + 4;
+            requiredEventCount = i + 5;
             break;
           }
         }


### PR DESCRIPTION
80d8eae introduced the logging of an additional state "STOPPING" when
the job is being stopped.

It was missed that the JobHistoryTest has an "expected" amount of events
to see in the job history that it uses to collect the list of events to
assert against later in the test.

This would cause the test to occasionally fail because the list being
iterated might not contain as many elements as the test expected:

```
testJobHistory(com.spotify.helios.system.JobHistoryTest)  Time elapsed: 24.513 sec  <<< ERROR!
java.util.NoSuchElementException: null
  at java.util.ArrayList$Itr.next(ArrayList.java:854)
  at com.spotify.helios.system.JobHistoryTest.testJobHistory(JobHistoryTest.java:103)
```