### PR TITLE
Support all host selector operators in host cmd

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupCreateCommand.java
@@ -60,7 +60,7 @@ public class DeploymentGroupCreateCommand extends ControlCommand {
         .help("Host selector expression. Hosts matching this expression will be part of the " +
               "deployment-group. Multiple conditions can be specified, separated by spaces (as " +
               "separate arguments). If multiple conditions are given, all must be fulfilled. " +
-              "Operators supported are '=' and '!='. Example: foo=bar baz!=qux");
+              "Operators supported are =, !=, in and notin. Example: foo=bar baz!=qux");
 
     quietArg = parser.addArgument("-q")
         .action(storeTrue())


### PR DESCRIPTION
We previously only supported the "=" host selector operator in
`helios hosts --labels`. This change supports using "!=", "in",
and "notin" operators.