### PR TITLE
filter host list by selectors/pattern on server-side

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -17,26 +17,25 @@
 
 package com.spotify.helios.client;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.escape.Escaper;
-import com.google.common.net.UrlEscapers;
-import com.google.common.util.concurrent.AsyncFunction;
-import com.google.common.util.concurrent.FutureFallback;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.transform;
+import static com.google.common.util.concurrent.Futures.withFallback;
+import static com.spotify.helios.common.VersionCompatibility.HELIOS_SERVER_VERSION_HEADER;
+import static com.spotify.helios.common.VersionCompatibility.HELIOS_VERSION_STATUS_HEADER;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.Resolver;
@@ -65,6 +64,29 @@ import com.spotify.helios.common.protocol.VersionResponse;
 import com.spotify.sshagentproxy.AgentProxies;
 import com.spotify.sshagentproxy.AgentProxy;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.base.Throwables;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
+import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.FutureFallback;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -84,25 +106,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
-import static com.google.common.util.concurrent.Futures.transform;
-import static com.google.common.util.concurrent.Futures.withFallback;
-import static com.spotify.helios.common.VersionCompatibility.HELIOS_SERVER_VERSION_HEADER;
-import static com.spotify.helios.common.VersionCompatibility.HELIOS_VERSION_STATUS_HEADER;
-import static java.lang.String.format;
-import static java.net.HttpURLConnection.HTTP_BAD_METHOD;
-import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
-import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static java.util.concurrent.Executors.newScheduledThreadPool;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class HeliosClient implements Closeable {
 
@@ -127,14 +130,17 @@ public class HeliosClient implements Closeable {
   }
 
   private URI uri(final String path, final Map<String, String> query) {
+    return uri(path, Multimaps.forMap(query));
+  }
+
+  private URI uri(final String path, final Multimap<String, String> query) {
     checkArgument(path.startsWith("/"));
 
     final URIBuilder builder = new URIBuilder()
         .setScheme("http")
         .setHost("helios")
         .setPath(path);
-
-    for (final Map.Entry<String, String> q : query.entrySet()) {
+    for (final Map.Entry<String, String> q : query.entries()) {
       builder.addParameter(q.getKey(), q.getValue());
     }
     builder.addParameter("user", user);
@@ -336,7 +342,32 @@ public class HeliosClient implements Closeable {
   }
 
   public ListenableFuture<List<String>> listHosts() {
-    return get(uri("/hosts/"), new TypeReference<List<String>>() {
+    return listHosts(ImmutableMultimap.<String, String>of());
+  }
+
+  public ListenableFuture<List<String>> listHosts(final String namePattern) {
+    return listHosts(ImmutableMultimap.of("namePattern", namePattern));
+  }
+
+  public ListenableFuture<List<String>> listHosts(final List<String> labels) {
+    final Multimap<String, String> query = HashMultimap.create();
+    query.putAll("labels", labels);
+
+    return listHosts(query);
+  }
+
+  public ListenableFuture<List<String>> listHosts(final String namePattern,
+                                                  final List<String> labels) {
+
+    final Multimap<String, String> query = HashMultimap.create();
+    query.put("namePattern", namePattern);
+    query.putAll("labels", labels);
+
+    return listHosts(query);
+  }
+
+  private ListenableFuture<List<String>> listHosts(final Multimap<String, String> query) {
+    return get(uri("/hosts/", query), new TypeReference<List<String>>() {
     });
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -341,27 +341,48 @@ public class HeliosClient implements Closeable {
                                                   ImmutableSet.of(HTTP_OK, HTTP_NOT_FOUND)));
   }
 
+  /**
+   * Returns a list of all hosts registered in the Helios cluster.
+   */
   public ListenableFuture<List<String>> listHosts() {
     return listHosts(ImmutableMultimap.<String, String>of());
   }
 
+  /**
+   * Returns a list of all hosts registered in the Helios cluster whose name matches the given
+   * pattern.
+   */
   public ListenableFuture<List<String>> listHosts(final String namePattern) {
     return listHosts(ImmutableMultimap.of("namePattern", namePattern));
   }
 
-  public ListenableFuture<List<String>> listHosts(final List<String> labels) {
+  /**
+   * Returns a list of all hosts registered in the Helios cluster which match the given list of
+   * host
+   * selectors.
+   * <p>
+   * For example, {@code listHosts(Arrays.asList("site=foo"))} will return all agents in the
+   * cluster whose labels match the expression {@code site=foo}.</p>
+   */
+  public ListenableFuture<List<String>> listHosts(final Set<String> unparsedHostSelectors) {
     final Multimap<String, String> query = HashMultimap.create();
-    query.putAll("labels", labels);
+    query.putAll("selector", unparsedHostSelectors);
 
     return listHosts(query);
   }
 
+  /**
+   * Returns a list of all hosts registered in the Helios cluster that match both the given hostname
+   * pattern and set of host selectors.
+   *
+   * @see #listHosts(Set)
+   */
   public ListenableFuture<List<String>> listHosts(final String namePattern,
-                                                  final List<String> labels) {
+                                                  final Set<String> unparsedHostSelectors) {
 
     final Multimap<String, String> query = HashMultimap.create();
     query.put("namePattern", namePattern);
-    query.putAll("labels", labels);
+    query.putAll("selector", unparsedHostSelectors);
 
     return listHosts(query);
   }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
@@ -17,13 +17,14 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -31,9 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.String.format;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HostSelector extends Descriptor {
@@ -43,13 +41,14 @@ public class HostSelector extends Descriptor {
     boolean test(T t, U u);
   }
 
-  private static BiPredicate<String, Object> IN_BIPREDICATE = new BiPredicate<String, Object>() {
-    @Override
-    public boolean test(final String a, final Object b) {
-      @SuppressWarnings("unchecked") final Iterable<String> iterable = (Iterable<String>) b;
-      return Iterables.contains(iterable, a);
-    }
-  };
+  private static final BiPredicate<String, Object> IN_BIPREDICATE =
+      new BiPredicate<String, Object>() {
+        @Override
+        public boolean test(final String a, final Object b) {
+          @SuppressWarnings("unchecked") final Iterable<String> iterable = (Iterable<String>) b;
+          return Iterables.contains(iterable, a);
+        }
+      };
 
   public enum Operator {
     EQUALS("=", new BiPredicate<String, Object>() {

--- a/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
@@ -17,17 +17,111 @@
 
 package com.spotify.helios.client;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.spotify.helios.common.Json;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 
 public class HeliosClientTest {
+
+  private final RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+  private final HeliosClient client = new HeliosClient("test", dispatcher);
 
   @Test(expected = IllegalStateException.class)
   public void testBuildWithNoEndpoints() {
     HeliosClient.newBuilder()
         .setEndpoints(Collections.<URI>emptyList())
         .build();
+  }
+
+  @Test
+  public void listHosts() throws Exception {
+    final List<String> hosts = ImmutableList.of("foo1", "foo2", "foo3");
+
+    mockResponse("GET", hasPath("/hosts/"), response("GET", 200, hosts));
+
+    assertThat(client.listHosts().get(), equalTo(hosts));
+  }
+
+  private static Response response(final String method, int statusCode, Object payload) {
+    // second param is request URI, which is not relevant here
+    return new Response(method, null, statusCode, Json.asBytesUnchecked(payload),
+                        Collections.<String, List<String>>emptyMap());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void mockResponse(final String method,
+                            final Matcher<URI> uriMatcher,
+                            final Response response) {
+
+    final byte[] emptyRequestPayload = new byte[0];
+    when(dispatcher.request(argThat(uriMatcher), eq(method), eq(emptyRequestPayload), anyMap()))
+        .thenReturn(Futures.immediateFuture(response));
+  }
+
+  /** A Mathcer that tests that the URI has a path equal to the given path. */
+  private static Matcher<URI> hasPath(final String path) {
+    return new FeatureMatcher<URI, String>(Matchers.equalTo(path), "path", "path") {
+      @Override
+      protected String featureValueOf(final URI actual) {
+        return actual.getPath();
+      }
+    };
+  }
+
+  /**
+   * A Matcher that tests that the rawQuery of the URI (i.e. encoded) contains the given substring.
+   */
+  private static Matcher<URI> containsQuery(final String rawQuerySubstring) {
+    return new FeatureMatcher<URI, String>(Matchers.containsString(rawQuerySubstring), "query",
+                                           "query") {
+      @Override
+      protected String featureValueOf(final URI actual) {
+        return actual.getRawQuery();
+      }
+    };
+  }
+
+  @Test
+  public void listHostsFilterByNamePattern() throws Exception {
+    final List<String> hosts = ImmutableList.of("foo1", "foo2", "foo3");
+
+    mockResponse("GET",
+                 allOf(hasPath("/hosts/"), containsQuery("namePattern=foo")),
+                 response("GET", 200, hosts));
+
+    assertThat(client.listHosts("foo").get(), equalTo(hosts));
+  }
+
+  @Test
+  public void listHostsFilterByLabels() throws Exception {
+    final List<String> hosts = ImmutableList.of("foo1", "foo2", "foo3");
+
+    mockResponse("GET",
+                 allOf(hasPath("/hosts/"),
+                       containsQuery("labels=foo%3Dbar"),
+                       containsQuery("labels=site%3Dabc")
+                 ),
+                 response("GET", 200, hosts));
+
+    final List<String> labels = ImmutableList.of("foo=bar", "site=abc");
+    assertThat(client.listHosts(labels).get(), equalTo(hosts));
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import com.spotify.helios.common.Json;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -38,6 +39,7 @@ import org.junit.Test;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class HeliosClientTest {
 
@@ -111,17 +113,17 @@ public class HeliosClientTest {
   }
 
   @Test
-  public void listHostsFilterByLabels() throws Exception {
+  public void listHostsFilterBySelectors() throws Exception {
     final List<String> hosts = ImmutableList.of("foo1", "foo2", "foo3");
 
     mockResponse("GET",
                  allOf(hasPath("/hosts/"),
-                       containsQuery("labels=foo%3Dbar"),
-                       containsQuery("labels=site%3Dabc")
+                       containsQuery("selector=foo%3Dbar"),
+                       containsQuery("selector=site%3Dabc")
                  ),
                  response("GET", 200, hosts));
 
-    final List<String> labels = ImmutableList.of("foo=bar", "site=abc");
-    assertThat(client.listHosts(labels).get(), equalTo(hosts));
+    final Set<String> selectors = ImmutableSet.of("foo=bar", "site=abc");
+    assertThat(client.listHosts(selectors).get(), equalTo(hosts));
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/HostMatcher.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/HostMatcher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.emptyList;
+
+import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.HostSelector;
+import com.spotify.helios.rollingupdate.AlphaNumericComparator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Filters hosts based on their labels according to a List of HostSelectors.
+ */
+public class HostMatcher {
+
+  private static final Logger log = LoggerFactory.getLogger(HostMatcher.class);
+
+  private final Map<String, Map<String, String>> hostsAndLabels;
+
+  public HostMatcher(final Map<String, Map<String, String>> hostsAndLabels) {
+    this.hostsAndLabels = ImmutableMap.copyOf(checkNotNull(hostsAndLabels, "hostsAndLabels"));
+  }
+
+  public List<String> getMatchingHosts(final DeploymentGroup deploymentGroup) {
+    final List<HostSelector> selectors = deploymentGroup.getHostSelectors();
+    if (selectors == null || selectors.isEmpty()) {
+      log.error("skipping deployment group with no host selectors: " + deploymentGroup.getName());
+      return emptyList();
+    }
+
+    return getMatchingHosts(selectors);
+  }
+
+  public List<String> getMatchingHosts(final List<HostSelector> selectors) {
+
+    final List<String> matchingHosts = Lists.newArrayList();
+
+    for (final Map.Entry<String, Map<String, String>> entry : hostsAndLabels.entrySet()) {
+      final String host = entry.getKey();
+      final Map<String, String> hostLabels = entry.getValue();
+
+      // every hostSelector in the group has to have a match in this host.
+      // a match meaning the host has a label for that key and the value matches
+      final boolean match = selectors.stream()
+          .allMatch(selector -> hostLabels.containsKey(selector.getLabel())
+                                && selector.matches(hostLabels.get(selector.getLabel())));
+
+      if (match) {
+        matchingHosts.add(host);
+      }
+    }
+
+    Collections.sort(matchingHosts, new AlphaNumericComparator(Locale.ENGLISH));
+    return ImmutableList.copyOf(matchingHosts);
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -17,12 +17,20 @@
 
 package com.spotify.helios.master.resources;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Maps;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
+import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.FORBIDDEN;
+import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.HOST_NOT_FOUND;
+import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.INVALID_ID;
+import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.JOB_NOT_FOUND;
+import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.OK;
+import static com.spotify.helios.master.http.Responses.badRequest;
+import static com.spotify.helios.master.http.Responses.forbidden;
+import static com.spotify.helios.master.http.Responses.notFound;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Timed;
 import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.protocol.HostDeregisterResponse;
@@ -39,12 +47,21 @@ import com.spotify.helios.master.JobPortAllocationConflictException;
 import com.spotify.helios.master.MasterModel;
 import com.spotify.helios.master.TokenVerificationException;
 import com.spotify.helios.master.http.PATCH;
+import com.spotify.helios.master.HostMatcher;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
@@ -57,18 +74,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
-import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.FORBIDDEN;
-import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.HOST_NOT_FOUND;
-import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.INVALID_ID;
-import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.JOB_NOT_FOUND;
-import static com.spotify.helios.common.protocol.JobUndeployResponse.Status.OK;
-import static com.spotify.helios.master.http.Responses.badRequest;
-import static com.spotify.helios.master.http.Responses.forbidden;
-import static com.spotify.helios.master.http.Responses.notFound;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/hosts")
 public class HostsResource {
@@ -88,8 +93,35 @@ public class HostsResource {
   @Produces(APPLICATION_JSON)
   @Timed
   @ExceptionMetered
-  public List<String> list() {
-    return model.listHosts();
+  public List<String> list(@QueryParam("namePatternFilter") final String namePattern,
+                           @QueryParam("labelPatternFilter") final List<String> labels) {
+
+    List<String> hosts = model.listHosts();
+
+    if (namePattern != null) {
+      final Predicate<String> matchesPattern = Pattern.compile(namePattern).asPredicate();
+      hosts = hosts.stream()
+          .filter(matchesPattern)
+          .collect(Collectors.toList());
+    }
+
+    if (!labels.isEmpty()) {
+
+      final Map<String, Map<String, String>> hostsAndLabels = hosts.stream()
+          .collect(Collectors.toMap(Function.identity(),
+                                    host -> model.getHostStatus(host).getLabels()
+                   )
+          );
+
+      final List<HostSelector> selectors = labels.stream()
+          .map(HostSelector::parse)
+          .collect(Collectors.toList());
+
+      final HostMatcher matcher = new HostMatcher(hostsAndLabels);
+      hosts = matcher.getMatchingHosts(selectors);
+    }
+
+    return hosts;
   }
 
   /**

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -94,7 +94,7 @@ public class HostsResource {
   @Timed
   @ExceptionMetered
   public List<String> list(@QueryParam("namePattern") final String namePattern,
-                           @QueryParam("labels") final List<String> labels) {
+                           @QueryParam("selector") final List<String> hostSelectors) {
 
     List<String> hosts = model.listHosts();
 
@@ -105,7 +105,7 @@ public class HostsResource {
           .collect(Collectors.toList());
     }
 
-    if (!labels.isEmpty()) {
+    if (!hostSelectors.isEmpty()) {
 
       final Map<String, Map<String, String>> hostsAndLabels = hosts.stream()
           .collect(Collectors.toMap(Function.identity(),
@@ -113,7 +113,7 @@ public class HostsResource {
                    )
           );
 
-      final List<HostSelector> selectors = labels.stream()
+      final List<HostSelector> selectors = hostSelectors.stream()
           .map(HostSelector::parse)
           .collect(Collectors.toList());
 

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -93,8 +93,8 @@ public class HostsResource {
   @Produces(APPLICATION_JSON)
   @Timed
   @ExceptionMetered
-  public List<String> list(@QueryParam("namePatternFilter") final String namePattern,
-                           @QueryParam("labelPatternFilter") final List<String> labels) {
+  public List<String> list(@QueryParam("namePattern") final String namePattern,
+                           @QueryParam("labels") final List<String> labels) {
 
     List<String> hosts = model.listHosts();
 

--- a/helios-services/src/test/java/com/spotify/helios/master/HostMatcherTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/HostMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB.
+ * Copyright (c) 2016 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,21 @@
  * under the License.
  */
 
-package com.spotify.helios.rollingupdate;
+package com.spotify.helios.master;
 
-import com.google.common.collect.ImmutableMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostSelector;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
 
 public class HostMatcherTest {
 
@@ -42,8 +41,7 @@ public class HostMatcherTest {
       "bar-c1", ImmutableMap.of("role", "bar", "pool", "c")
   );
 
-  private final RollingUpdateService.HostMatcher matcher = new
-      RollingUpdateService.HostMatcher(hosts);
+  private final HostMatcher matcher = new HostMatcher(hosts);
 
   private static DeploymentGroup group(String... selectorStrings) {
     final List<HostSelector> selectors = new ArrayList<>();

--- a/helios-services/src/test/java/com/spotify/helios/master/resources/HostsResourceTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/resources/HostsResourceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master.resources;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.master.MasterModel;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HostsResourceTest {
+
+  private static final List<String> NO_LABELS_ARG = Collections.emptyList();
+
+  private final MasterModel model = mock(MasterModel.class);
+  private final HostsResource resource = new HostsResource(model);
+
+  private final ImmutableList<String> hosts = ImmutableList.of(
+      "host1.foo.example.com",
+      "host2.foo.example.com",
+      "host3.foo.example.com",
+      "host4.foo.example.com"
+  );
+
+  @Before
+  public void setUp() {
+    when(model.listHosts()).thenReturn(hosts);
+
+    final HostStatus.Builder statusBuilder = HostStatus.newBuilder()
+        .setStatus(HostStatus.Status.UP)
+        .setJobs(Collections.emptyMap())
+        .setStatuses(Collections.emptyMap());
+
+    int i = 1;
+    for (final String host : hosts) {
+      final Map<String, String> labels = new HashMap<>();
+      labels.put("site", "foo");
+      labels.put("index", String.valueOf(i++));
+
+      final HostStatus hostStatus = statusBuilder
+          .setLabels(labels)
+          .build();
+
+      when(model.getHostStatus(host)).thenReturn(hostStatus);
+    }
+  }
+
+  @Test
+  public void listHosts() {
+    assertThat(resource.list(null, NO_LABELS_ARG), equalTo(hosts));
+  }
+
+  @Test
+  public void listHostsNameFilter() {
+    assertThat(resource.list("foo.example", NO_LABELS_ARG), equalTo(hosts));
+    assertThat(resource.list("host1", NO_LABELS_ARG), contains("host1.foo.example.com"));
+    assertThat(resource.list("host5", NO_LABELS_ARG), empty());
+  }
+
+  @Test
+  public void listHostsLabelFilter() {
+    assertThat(resource.list(null, ImmutableList.of("site=foo")), equalTo(hosts));
+
+    assertThat(resource.list(null, ImmutableList.of("site=bar")), empty());
+    assertThat(resource.list(null, ImmutableList.of("site!=foo")), empty());
+
+    assertThat(resource.list(null, ImmutableList.of("index in (1,2)")),
+               contains("host1.foo.example.com", "host2.foo.example.com"));
+
+    assertThat(resource.list(null, ImmutableList.of("site=foo", "index in (1,2)")),
+               contains("host1.foo.example.com", "host2.foo.example.com"));
+  }
+
+  /** Test behavior when both a name pattern and labels list is specified */
+  @Test
+  public void listHostsNameAndLabelFilter() {
+    assertThat(resource.list("foo.example.com", ImmutableList.of("site=foo")), equalTo(hosts));
+
+    assertThat(resource.list("host3", ImmutableList.of("index =2")), empty());
+
+    assertThat(resource.list("host3", ImmutableList.of("index!=2")),
+               contains("host3.foo.example.com"));
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/master/resources/HostsResourceTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/resources/HostsResourceTest.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class HostsResourceTest {
 
-  private static final List<String> NO_LABELS_ARG = Collections.emptyList();
+  private static final List<String> NO_SELECTOR_ARG = Collections.emptyList();
 
   private final MasterModel model = mock(MasterModel.class);
   private final HostsResource resource = new HostsResource(model);
@@ -75,18 +75,18 @@ public class HostsResourceTest {
 
   @Test
   public void listHosts() {
-    assertThat(resource.list(null, NO_LABELS_ARG), equalTo(hosts));
+    assertThat(resource.list(null, NO_SELECTOR_ARG), equalTo(hosts));
   }
 
   @Test
   public void listHostsNameFilter() {
-    assertThat(resource.list("foo.example", NO_LABELS_ARG), equalTo(hosts));
-    assertThat(resource.list("host1", NO_LABELS_ARG), contains("host1.foo.example.com"));
-    assertThat(resource.list("host5", NO_LABELS_ARG), empty());
+    assertThat(resource.list("foo.example", NO_SELECTOR_ARG), equalTo(hosts));
+    assertThat(resource.list("host1", NO_SELECTOR_ARG), contains("host1.foo.example.com"));
+    assertThat(resource.list("host5", NO_SELECTOR_ARG), empty());
   }
 
   @Test
-  public void listHostsLabelFilter() {
+  public void listHostsSelectorFilter() {
     assertThat(resource.list(null, ImmutableList.of("site=foo")), equalTo(hosts));
 
     assertThat(resource.list(null, ImmutableList.of("site=bar")), empty());
@@ -99,9 +99,9 @@ public class HostsResourceTest {
                contains("host1.foo.example.com", "host2.foo.example.com"));
   }
 
-  /** Test behavior when both a name pattern and labels list is specified */
+  /** Test behavior when both a name pattern and selector list is specified */
   @Test
-  public void listHostsNameAndLabelFilter() {
+  public void listHostsNameAndSelectorFilter() {
     assertThat(resource.list("foo.example.com", ImmutableList.of("site=foo")), equalTo(hosts));
 
     assertThat(resource.list("host3", ImmutableList.of("index =2")), empty());

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
@@ -17,21 +17,6 @@
 
 package com.spotify.helios.system;
 
-import com.google.common.collect.ImmutableMap;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.spotify.helios.Polling;
-import com.spotify.helios.common.Json;
-import com.spotify.helios.common.descriptors.HostStatus;
-
-import com.google.common.collect.ImmutableSet;
-
-import org.junit.Test;
-
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -39,6 +24,19 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+
+import com.spotify.helios.Polling;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.HostStatus;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
 
 public class LabelTest extends SystemTestBase {
 
@@ -101,31 +99,31 @@ public class LabelTest extends SystemTestBase {
 
     // Test all these host selectors in one test method to reduce testing time.
     // We can't start masters and agents in @BeforeClass because startDefaultMaster() isn't static
-    final String fooHosts = cli("hosts", "--labels", "role=foo");
+    final String fooHosts = cli("hosts", "--selector", "role=foo");
     assertThat(fooHosts, containsString(testHost1));
     assertThat(fooHosts, not(containsString(testHost2)));
 
-    final String xyzHosts = cli("hosts", "--labels", "xyz=123");
+    final String xyzHosts = cli("hosts", "--selector", "xyz=123");
     assertThat(xyzHosts, allOf(containsString(testHost1), containsString(testHost2)));
 
-    final String fooAndXyzHosts = cli("hosts", "--labels", "role=foo", "xyz=123");
+    final String fooAndXyzHosts = cli("hosts", "--selector", "role=foo", "xyz=123");
     assertThat(fooAndXyzHosts, containsString(testHost1));
     assertThat(fooAndXyzHosts, not(containsString(testHost2)));
 
-    final String notFooHosts = cli("hosts", "--labels", "role!=foo");
+    final String notFooHosts = cli("hosts", "--selector", "role!=foo");
     assertThat(notFooHosts, not(containsString(testHost1)));
     assertThat(notFooHosts, containsString(testHost2));
 
-    final String inFooBarHosts = cli("hosts", "--labels", "role in (foo, bar)");
+    final String inFooBarHosts = cli("hosts", "--selector", "role in (foo, bar)");
     assertThat(inFooBarHosts, allOf(containsString(testHost1), containsString(testHost2)));
 
-    final String notInFooBarHosts = cli("hosts", "--labels", "role notin (foo, bar)");
+    final String notInFooBarHosts = cli("hosts", "--selector", "role notin (foo, bar)");
     assertThat(notInFooBarHosts, not(anyOf(containsString(testHost1), containsString(testHost2))));
 
-    final String nonHosts = cli("hosts", "--labels", "role=doesnt_exist");
+    final String nonHosts = cli("hosts", "--selector", "role=doesnt_exist");
     assertThat(nonHosts, not(anyOf(containsString(testHost1), containsString(testHost2))));
 
-    final String nonHosts2 = cli("hosts", "--labels", "role=doesnt_exist", "xyz=123");
+    final String nonHosts2 = cli("hosts", "--selector", "role=doesnt_exist", "xyz=123");
     assertThat(nonHosts2, not(anyOf(containsString(testHost1), containsString(testHost2))));
   }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -26,7 +26,6 @@ import static com.spotify.helios.cli.Utils.allAsMap;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
-import static net.sourceforge.argparse4j.impl.Arguments.append;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import com.spotify.helios.cli.Table;
@@ -105,7 +104,6 @@ public class HostListCommand extends ControlCommand {
         .help("Filter hosts by its status. Valid statuses are: " + statusChoicesString);
 
     hostSelectorsArg = parser.addArgument("-l", "--labels")
-        .action(append())
         .setDefault(new ArrayList<String>())
         .nargs("+")
         .help("Host selector expression. Hosts matching this expression will be part of the " +

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/HostListCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/HostListCommandTest.java
@@ -17,9 +17,17 @@
 
 package com.spotify.helios.cli.command;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Futures;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.spotify.helios.common.descriptors.HostStatus.Status.DOWN;
+import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.spotify.helios.cli.TestUtils;
 import com.spotify.helios.client.HeliosClient;
@@ -33,34 +41,23 @@ import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.text.ParseException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import static com.spotify.helios.common.descriptors.HostStatus.Status.DOWN;
-import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
-import static java.util.Collections.singletonList;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyMapOf;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class HostListCommandTest {
 
@@ -104,15 +101,11 @@ public class HostListCommandTest {
           .setState(TaskStatus.State.RUNNING).build()
   );
 
-  private static final Map<String, String> LABELS1 = ImmutableMap.of(
-      "label1", "value1", "label2", "value2a");
-  private static final Map<String, String> LABELS2 = ImmutableMap.of(
-      "label1", "value1", "label2", "value2b");
-  private static final Map<String, String> LABELS3 = ImmutableMap.of(
-      "label3", "value3", "label2", "value2c");
+  private static final Map<String, String> LABELS = ImmutableMap.of("foo", "bar", "baz", "qux");
 
   private static final List<String> EXPECTED_ORDER = ImmutableList.of("host1.", "host2.", "host3.");
-
+  private HostStatus upStatus;
+  private HostStatus downStatus;
 
   @Before
   public void setUp() throws ParseException {
@@ -122,7 +115,7 @@ public class HostListCommandTest {
     command = new HostListCommand(subparser);
 
     when(options.getString("pattern")).thenReturn("");
-    when(client.listHosts()).thenReturn(Futures.immediateFuture(HOSTS));
+    when(client.listHosts()).thenReturn(immediateFuture(HOSTS));
 
     final HostInfo hostInfo = HostInfo.newBuilder()
         .setCpus(4)
@@ -143,38 +136,37 @@ public class HostListCommandTest {
         .setStartTime(startTime)
         .build();
 
-    final HostStatus.Builder statusBuilder = HostStatus.newBuilder()
+    upStatus = HostStatus.newBuilder()
         .setJobs(JOBS)
         .setStatuses(JOB_STATUSES)
         .setStatus(UP)
         .setHostInfo(hostInfo)
-        .setAgentInfo(agentInfo);
+        .setAgentInfo(agentInfo)
+        .setLabels(LABELS)
+        .build();
 
-    final HostStatus status = statusBuilder.setLabels(LABELS1).build();
-    final HostStatus status2 = statusBuilder.setLabels(LABELS2).build();
-
-    final HostStatus downStatus = HostStatus.newBuilder()
+    downStatus = HostStatus.newBuilder()
         .setJobs(JOBS)
         .setStatuses(JOB_STATUSES)
         .setStatus(DOWN)
         .setHostInfo(hostInfo)
         .setAgentInfo(agentInfo)
-        .setLabels(LABELS3)
+        .setLabels(LABELS)
         .build();
 
     final Map<String, HostStatus> statuses = ImmutableMap.of(
-        HOSTS.get(0), status,
-        HOSTS.get(1), status2,
+        HOSTS.get(0), upStatus,
+        HOSTS.get(1), upStatus,
         HOSTS.get(2), downStatus
     );
 
-    when(client.hostStatuses(anyListOf(String.class), anyMapOf(String.class, String.class)))
-        .thenReturn(Futures.immediateFuture(statuses));
+    when(client.hostStatuses(eq(HOSTS), anyMapOf(String.class, String.class)))
+        .thenReturn(immediateFuture(statuses));
   }
 
   @Test
   public void testCommand() throws Exception {
-    final int ret = command.run(options, client, out, false, null);
+    final int ret = runCommand();
     final String output = baos.toString();
 
     assertEquals(0, ret);
@@ -183,19 +175,23 @@ public class HostListCommandTest {
         + "OS              HELIOS     DOCKER          LABELS"));
     assertThat(output, containsString(
         "host1.    Up 2 days     3           3          4       1 gb    0.10        0.53         "
-        + "OS foo 0.1.0    0.8.420    1.7.0 (1.18)    label1=value1, label2=value2a"));
+        + "OS foo 0.1.0    0.8.420    1.7.0 (1.18)    foo=bar, baz=qux"));
     assertThat(output, containsString(
         "host2.    Up 2 days     3           3          4       1 gb    0.10        0.53         "
-        + "OS foo 0.1.0    0.8.420    1.7.0 (1.18)    label1=value1, label2=value2b"));
+        + "OS foo 0.1.0    0.8.420    1.7.0 (1.18)    foo=bar, baz=qux"));
     assertThat(output, containsString(
         "host3.    Down 1 day    3           3          4       1 gb    0.10        0.53         "
-        + "OS foo 0.1.0    0.8.420    1.7.0 (1.18)    label3=value3, label2=value2c"));
+        + "OS foo 0.1.0    0.8.420    1.7.0 (1.18)    foo=bar, baz=qux"));
+  }
+
+  private int runCommand() throws ExecutionException, InterruptedException {
+    return command.run(options, client, out, false, null);
   }
 
   @Test
   public void testQuietOutputIsSorted() throws Exception {
     when(options.getBoolean("q")).thenReturn(true);
-    final int ret = command.run(options, client, out, false, null);
+    final int ret = runCommand();
 
     assertEquals(0, ret);
     assertEquals(EXPECTED_ORDER, TestUtils.readFirstColumnFromOutput(baos.toString(), false));
@@ -204,7 +200,7 @@ public class HostListCommandTest {
   @Test
   public void testNonQuietOutputIsSorted() throws Exception {
     when(options.getBoolean("q")).thenReturn(false);
-    final int ret = command.run(options, client, out, false, null);
+    final int ret = runCommand();
 
     assertEquals(0, ret);
     assertEquals(EXPECTED_ORDER, TestUtils.readFirstColumnFromOutput(baos.toString(), true));
@@ -213,7 +209,7 @@ public class HostListCommandTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidStatusThrowsError() throws Exception {
     when(options.getString("status")).thenReturn("DWN");
-    final int ret = command.run(options, client, out, false, null);
+    final int ret = runCommand();
     final String output = baos.toString();
 
     assertEquals(1, ret);
@@ -221,48 +217,46 @@ public class HostListCommandTest {
   }
 
   @Test
-  public void testHostSelectorEquals() throws Exception {
-    checkSelectors(ImmutableList.of("label1=value1"), ImmutableList.of("host1.", "host2."));
-  }
+  public void testPatternFilter() throws Exception {
+    when(options.getString("pattern")).thenReturn("host1");
 
-  @Test
-  public void testHostSelectorNotEquals() throws Exception {
-    checkSelectors(ImmutableList.of("label2!=value2a"), ImmutableList.of("host2.", "host3."));
-  }
+    final String hostname = "host1.example.com";
+    final List<String> hosts = ImmutableList.of(hostname);
+    when(client.listHosts("host1")).thenReturn(Futures.immediateFuture(hosts));
 
-  @Test
-  public void testHostSelectorIn() throws Exception {
-    checkSelectors(ImmutableList.of("label2 in (value2a, value2b)"),
-                   ImmutableList.of("host1.", "host2."));
-  }
+    final Map<String, HostStatus> statusResponse = ImmutableMap.of(hostname, upStatus);
 
-  @Test
-  public void testHostSelectorNotIn() throws Exception {
-    checkSelectors(ImmutableList.of("label2 notin (value2a, value2b)"), singletonList("host3."));
-  }
+    when(client.hostStatuses(eq(hosts), anyMapOf(String.class, String.class)))
+        .thenReturn(Futures.immediateFuture(statusResponse));
 
-  @Test
-  public void testMultipleHostSelectors() throws Exception {
-    checkSelectors(ImmutableList.of("label1=value1", "label2=value2a"), singletonList("host1."));
-    checkSelectors(ImmutableList.of("label1=value1", "label2=value2b"), singletonList("host2."));
-    checkSelectors(ImmutableList.of("label2 notin (value2a, value2b)", "label1=value1"),
-                   Collections.<String>emptyList());
-  }
-
-  /**
-   * Checks that running `helios hosts` with the specified host selectors returns expected hosts.
-   * @param hostSelectors A list of host selector strings to pass to the --labels switch.
-   * @param expectedHosts A list of expected hosts in that order.
-   * @throws Exception If some exception occurs.
-   */
-  private void checkSelectors(final List<String> hostSelectors,
-                              final List<String> expectedHosts) throws Exception {
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final PrintStream out = new PrintStream(baos);
-
-    when(options.getList("labels")).thenReturn(ImmutableList.of((Object) hostSelectors));
-    final int ret = command.run(options, client, out, false, null);
+    final int ret = runCommand();
     assertEquals(0, ret);
-    assertThat(TestUtils.readFirstColumnFromOutput(baos.toString(), true), equalTo(expectedHosts));
+
+    assertEquals(ImmutableList.of("HOST", hostname + "."),
+                 TestUtils.readFirstColumnFromOutput(baos.toString(), false));
+  }
+
+  @Test
+  public void testLabelsFilter() throws Exception {
+    final List<Object> labelsArg = ImmutableList.<Object>of("foo=bar");
+    when(options.getList("labels")).thenReturn(labelsArg);
+
+    final List<String> labels = ImmutableList.of("foo=bar");
+
+    final String hostname = "foo1.example.com";
+    final List<String> hosts = ImmutableList.of(hostname);
+    when(client.listHosts(labels)).thenReturn(Futures.immediateFuture(hosts));
+
+    final Map<String, HostStatus> statusResponse = ImmutableMap.of(hostname, upStatus);
+
+    when(client.hostStatuses(eq(hosts), anyMapOf(String.class, String.class)))
+        .thenReturn(Futures.immediateFuture(statusResponse));
+
+    final int ret = runCommand();
+    assertEquals(0, ret);
+
+    assertEquals(ImmutableList.of("HOST", hostname + "."),
+                 TestUtils.readFirstColumnFromOutput(baos.toString(), false));
+
   }
 }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/HostListCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/HostListCommandTest.java
@@ -43,6 +43,7 @@ import com.spotify.helios.common.descriptors.TaskStatus;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
@@ -237,15 +238,13 @@ public class HostListCommandTest {
   }
 
   @Test
-  public void testLabelsFilter() throws Exception {
-    final List<Object> labelsArg = ImmutableList.<Object>of("foo=bar");
-    when(options.getList("labels")).thenReturn(labelsArg);
-
-    final List<String> labels = ImmutableList.of("foo=bar");
+  public void testSelectorFilter() throws Exception {
+    final List<Object> selectorArg = ImmutableList.<Object>of("foo=bar");
+    when(options.getList("selector")).thenReturn(selectorArg);
 
     final String hostname = "foo1.example.com";
     final List<String> hosts = ImmutableList.of(hostname);
-    when(client.listHosts(labels)).thenReturn(Futures.immediateFuture(hosts));
+    when(client.listHosts(ImmutableSet.of("foo=bar"))).thenReturn(Futures.immediateFuture(hosts));
 
     final Map<String, HostStatus> statusResponse = ImmutableMap.of(hostname, upStatus);
 


### PR DESCRIPTION
This PR moves the logic that currently only exists within the CLI for filtering the list of hosts by "name pattern" or list of labels into the server/master instead.

This allows users of HeliosClient to be able to list hosts, filtering by the pattern and/or label list, without duplicating the logic within the CLI.

Each of the three components is updated here:
- server-side filtering within the `/hosts/` endpoint
- HeliosClient support for these filters in `listHosts(..)` method overloads
- HostListCommand in the CLI will use the new HeliosClient methods