### PR TITLE
bugfix: HostListCommand selector argument is greedy

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
@@ -99,31 +99,31 @@ public class LabelTest extends SystemTestBase {
 
     // Test all these host selectors in one test method to reduce testing time.
     // We can't start masters and agents in @BeforeClass because startDefaultMaster() isn't static
-    final String fooHosts = cli("hosts", "--selector", "role=foo");
+    final String fooHosts = cli("hosts", "-s", "role=foo");
     assertThat(fooHosts, containsString(testHost1));
     assertThat(fooHosts, not(containsString(testHost2)));
 
-    final String xyzHosts = cli("hosts", "--selector", "xyz=123");
+    final String xyzHosts = cli("hosts", "-s", "xyz=123");
     assertThat(xyzHosts, allOf(containsString(testHost1), containsString(testHost2)));
 
-    final String fooAndXyzHosts = cli("hosts", "--selector", "role=foo", "xyz=123");
+    final String fooAndXyzHosts = cli("hosts", "-s", "role=foo", "-s", "xyz=123");
     assertThat(fooAndXyzHosts, containsString(testHost1));
     assertThat(fooAndXyzHosts, not(containsString(testHost2)));
 
-    final String notFooHosts = cli("hosts", "--selector", "role!=foo");
+    final String notFooHosts = cli("hosts", "-s", "role!=foo");
     assertThat(notFooHosts, not(containsString(testHost1)));
     assertThat(notFooHosts, containsString(testHost2));
 
-    final String inFooBarHosts = cli("hosts", "--selector", "role in (foo, bar)");
+    final String inFooBarHosts = cli("hosts", "-s", "role in (foo, bar)");
     assertThat(inFooBarHosts, allOf(containsString(testHost1), containsString(testHost2)));
 
-    final String notInFooBarHosts = cli("hosts", "--selector", "role notin (foo, bar)");
+    final String notInFooBarHosts = cli("hosts", "-s", "role notin (foo, bar)");
     assertThat(notInFooBarHosts, not(anyOf(containsString(testHost1), containsString(testHost2))));
 
-    final String nonHosts = cli("hosts", "--selector", "role=doesnt_exist");
+    final String nonHosts = cli("hosts", "-s", "role=doesnt_exist");
     assertThat(nonHosts, not(anyOf(containsString(testHost1), containsString(testHost2))));
 
-    final String nonHosts2 = cli("hosts", "--selector", "role=doesnt_exist", "xyz=123");
+    final String nonHosts2 = cli("hosts", "-s", "role=doesnt_exist", "-s", "xyz=123");
     assertThat(nonHosts2, not(anyOf(containsString(testHost1), containsString(testHost2))));
   }
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -26,6 +26,7 @@ import static com.spotify.helios.cli.Utils.allAsMap;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
+import static net.sourceforge.argparse4j.impl.Arguments.append;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import com.spotify.helios.cli.Table;
@@ -105,13 +106,13 @@ public class HostListCommand extends ControlCommand {
         .help("Filter hosts by its status. Valid statuses are: " + statusChoicesString);
 
     hostSelectorsArg = parser.addArgument("-s", "--selector")
+        .action(append())
         .setDefault(new ArrayList<String>())
-        .nargs("+")
         .help("Host selector expression. The list of hosts will be filtered to match only those "
               + "whose labels match all of the supplied expressions. "
-              + "Multiple expressions can be specified, separated by spaces "
-              + "(e.g. `-s site=foo bar!=yes`). " +
-              "Supported operators are '=', '!=', 'in' and 'notin'.");
+              + "Multiple selector expressions can be specified with multiple `-s` arguments "
+              + "(e.g. `-s site=foo -s bar!=yes`). "
+              + "Supported operators are '=', '!=', 'in' and 'notin'.");
   }
 
   @Override


### PR DESCRIPTION
The use of `nargs("+")` for an optional argument combined with a
positional argument with a default value leads to some unexpected
behavior. A command like:

```
helios hosts --selector foo=bar blah
```

results in the arguments being parsed as if there were two `selector`
arguments - one for `foo=bar` and one for `blah`.

The correct way to allow multiple values for an optional argument is to
instead use `action(append())` and not `nargs(..)`.

With this change, all of these combinations of arguments are interpreted
as expected:

```
helios hosts --selector foo=bar pattern
helios hosts pattern --selector foo=bar
helios hosts --selector foo=bar --selector three=four pattern
helios hosts pattern --selector foo=bar --selector three=four
```