### PR TITLE
remove docgenerator:scanner dependency

### DIFF
--- a/helios-api-documentation/pom.xml
+++ b/helios-api-documentation/pom.xml
@@ -154,25 +154,4 @@
       </build>
     </profile>
   </profiles>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>com.spotify.docgenerator</groupId>
-        <artifactId>docgenerator-maven-plugin</artifactId>
-        <version>0.0.1</version>
-        <configuration>
-          <jsonClassesFiles>
-            <jsonClassesFile>${project.basedir}/../helios-client/target/classes/JSONClasses</jsonClassesFile>
-          </jsonClassesFiles>
-          <restEndpointsFiles>
-            <restEndpointsFile>${project.basedir}/../helios-services/target/classes/RESTEndpoints</restEndpointsFile>
-          </restEndpointsFiles>
-          <jarFiles>
-            <jarFile>${project.basedir}/../helios-client/target/helios-client-${project.version}.jar</jarFile>
-          </jarFiles>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 </project>

--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -16,11 +16,11 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.spotify.docgenerator</groupId>
-      <artifactId>scanner</artifactId>
-    </dependency>
     <!--compile deps-->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -145,15 +145,15 @@
   </profiles>
 
   <dependencies>
-    <dependency>
-      <groupId>com.spotify.docgenerator</groupId>
-      <artifactId>scanner</artifactId>
-    </dependency>
     <!--compile deps -->
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-core</artifactId>
       <version>0.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,9 +166,9 @@
         <version>2.3</version>
       </dependency>
       <dependency>
-        <groupId>com.spotify.docgenerator</groupId>
-        <artifactId>scanner</artifactId>
-        <version>0.0.1</version>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>jsr311-api</artifactId>
+        <version>1.1.1</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
It's not clear what this is used for, but it seems unnecessary to list
this as a dependency of helios-client as it then drags it into any
user's project.