### PR TITLE
solo: Allow clients to retrieve the solo agent name

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -98,6 +98,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   private final String heliosSoloImage;
   private final boolean pullBeforeCreate;
   private final String namespace;
+  private final String agentName;
   private final List<String> env;
   private final List<String> binds;
   private final String heliosContainerId;
@@ -128,6 +129,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
         .or(containerDockerHost(dockerInfo));
 
     this.namespace = Optional.fromNullable(builder.namespace).or(randomString());
+    this.agentName = this.namespace + HELIOS_NAME_SUFFIX;
     this.env = containerEnv(builder.env);
     this.binds = containerBinds();
 
@@ -207,6 +209,10 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   @Override
   public HostAndPort address() {
       return deploymentAddress;
+  }
+
+  public String agentName() {
+    return agentName;
   }
 
   private boolean isBoot2Docker(final Info dockerInfo) {
@@ -338,7 +344,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     //TODO(negz): Don't make this.env immutable so early?
     final List<String> env = new ArrayList<>();
     env.addAll(this.env);
-    env.add("HELIOS_NAME=" + this.namespace + HELIOS_NAME_SUFFIX);
+    env.add("HELIOS_NAME=" + agentName);
     env.add("HELIOS_ID=" + this.namespace + HELIOS_ID_SUFFIX);
     env.add("HOST_ADDRESS=" + heliosHost);
 

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
@@ -201,7 +202,9 @@ public class HeliosSoloDeploymentTest {
         .withValue("helios.solo.profiles.test.namespace", ConfigValueFactory.fromAnyRef(ns))
         .withValue("helios.solo.profiles.test.env.TEST", ConfigValueFactory.fromAnyRef(env));
 
-    buildHeliosSoloDeployment(new HeliosSoloDeployment.Builder(null, config));
+    final HeliosSoloDeployment deployment = buildHeliosSoloDeployment(
+        new HeliosSoloDeployment.Builder(null, config));
+    assertEquals(ns + ".solo.local", deployment.agentName());
 
     boolean foundSolo = false;
     for (final ContainerConfig cc : containerConfig.getAllValues()) {


### PR DESCRIPTION
This can be useful in case you want to manually interact with the Helios
deployment. Previously you would have to call `solo.client().listHosts`.