### PR TITLE
Add meters for ZooKeeper operations

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ReportingZooKeeperClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ReportingZooKeeperClient.java
@@ -55,7 +55,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public void ensurePath(String path) throws KeeperException {
-    reporter.time(tag, "ensurePath", () -> {
+    reporter.timeAndMeter(tag, "ensurePath", () -> {
       client.ensurePath(path);
       return null;
     });
@@ -63,7 +63,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public void ensurePath(String path, boolean excludingLast) throws KeeperException {
-    reporter.time(tag, "ensurePath", () -> {
+    reporter.timeAndMeter(tag, "ensurePath", () -> {
       client.ensurePath(path, excludingLast);
       return null;
     });
@@ -71,17 +71,17 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public byte[] getData(String path) throws KeeperException {
-    return reporter.time(tag, "getData", () -> client.getData(path));
+    return reporter.timeAndMeter(tag, "getData", () -> client.getData(path));
   }
 
   @Override
   public List<String> getChildren(String path) throws KeeperException {
-    return reporter.time(tag, "getChildren", () -> client.getChildren(path));
+    return reporter.timeAndMeter(tag, "getChildren", () -> client.getChildren(path));
   }
 
   @Override
   public void delete(String path) throws KeeperException {
-    reporter.time(tag, "delete", () -> {
+    reporter.timeAndMeter(tag, "delete", () -> {
       client.delete(path);
       return null;
     });
@@ -89,7 +89,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public void setData(String path, byte[] bytes) throws KeeperException {
-    reporter.time(tag, "setData", () -> {
+    reporter.timeAndMeter(tag, "setData", () -> {
       client.setData(path, bytes);
       return null;
     });
@@ -97,7 +97,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public void createAndSetData(String path, byte[] data) throws KeeperException {
-    reporter.time(tag, "createAndSetData", () -> {
+    reporter.timeAndMeter(tag, "createAndSetData", () -> {
       client.createAndSetData(path, data);
       return null;
     });
@@ -105,7 +105,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public void createWithMode(String path, CreateMode mode) throws KeeperException {
-    reporter.time(tag, "createWithMode", () -> {
+    reporter.timeAndMeter(tag, "createWithMode", () -> {
       client.createWithMode(path, mode);
       return null;
     });
@@ -113,12 +113,12 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public Stat stat(String path) throws KeeperException {
-    return reporter.time(tag, "stat", () -> client.stat(path));
+    return reporter.timeAndMeter(tag, "stat", () -> client.stat(path));
   }
 
   @Override
   public void deleteRecursive(String path) throws KeeperException {
-    reporter.time(tag, "deleteRecursive", () -> {
+    reporter.timeAndMeter(tag, "deleteRecursive", () -> {
       client.deleteRecursive(path);
       return null;
     });
@@ -126,12 +126,12 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public List<String> listRecursive(String path) throws KeeperException {
-    return reporter.time(tag, "listRecursive", () -> client.listRecursive(path));
+    return reporter.timeAndMeter(tag, "listRecursive", () -> client.listRecursive(path));
   }
 
   @Override
   public void create(String path) throws KeeperException {
-    reporter.time(tag, "create", () -> {
+    reporter.timeAndMeter(tag, "create", () -> {
       client.create(path);
       return null;
     });
@@ -147,18 +147,18 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
   @Override
   public Collection<CuratorTransactionResult> transaction(List<ZooKeeperOperation> operations)
       throws KeeperException {
-    return reporter.time(tag, "transaction", () -> client.transaction(operations));
+    return reporter.timeAndMeter(tag, "transaction", () -> client.transaction(operations));
   }
 
   @Override
   public Collection<CuratorTransactionResult> transaction(ZooKeeperOperation... operations)
       throws KeeperException {
-    return reporter.time(tag, "transaction", () -> client.transaction(operations));
+    return reporter.timeAndMeter(tag, "transaction", () -> client.transaction(operations));
   }
 
   @Override
   public void delete(String path, int version) throws KeeperException {
-    reporter.time(tag, "delete", () -> {
+    reporter.timeAndMeter(tag, "delete", () -> {
       client.delete(path, version);
       return null;
     });
@@ -166,12 +166,12 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public Node getNode(String path) throws KeeperException {
-    return reporter.time(tag, "getNode", () -> client.getNode(path));
+    return reporter.timeAndMeter(tag, "getNode", () -> client.getNode(path));
   }
 
   @Override
   public Stat exists(String path) throws KeeperException {
-    return reporter.time(tag, "exists", () -> client.exists(path));
+    return reporter.timeAndMeter(tag, "exists", () -> client.exists(path));
   }
 
   @Override
@@ -181,7 +181,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public ZooKeeper.States getState() throws KeeperException {
-    return reporter.time(tag, "getState", client::getState);
+    return reporter.timeAndMeter(tag, "getState", client::getState);
   }
 
   @Override
@@ -208,7 +208,7 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public void setAcl(final String path, final List<ACL> aclList) throws KeeperException {
-    reporter.time(tag, "setAcl", () -> {
+    reporter.timeAndMeter(tag, "setAcl", () -> {
       client.setAcl(path, aclList);
       return null;
     });
@@ -216,6 +216,6 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
 
   @Override
   public List<ACL> getAcl(final String path) throws KeeperException {
-    return reporter.time(tag, "getAcl", () -> client.getAcl(path));
+    return reporter.timeAndMeter(tag, "getAcl", () -> client.getAcl(path));
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperModelReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperModelReporter.java
@@ -74,7 +74,7 @@ public class ZooKeeperModelReporter {
     metrics.zookeeperTransientError();
   }
 
-  public <T> T time(final String tag, final String name, ZooKeeperCallable<T> callable)
+  public <T> T timeAndMeter(final String tag, final String name, ZooKeeperCallable<T> callable)
       throws KeeperException {
     final long startTime = clock.getTick();
     try {
@@ -86,6 +86,7 @@ public class ZooKeeperModelReporter {
       throw Throwables.propagate(e);
     } finally {
       metrics.updateTimer(name, clock.getTick() - startTime, TimeUnit.NANOSECONDS);
+      metrics.updateMeter(name);
     }
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/NoopZooKeeperMetrics.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/NoopZooKeeperMetrics.java
@@ -26,4 +26,8 @@ public class NoopZooKeeperMetrics implements ZooKeeperMetrics {
   @Override
   public void updateTimer(String name, long duration, TimeUnit timeUnit) {
   }
+
+  @Override
+  public void updateMeter(final String name) {
+  }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetrics.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetrics.java
@@ -37,4 +37,12 @@ public interface ZooKeeperMetrics {
    * @param timeUnit Time unit of the duration.
    */
   void updateTimer(String name, long duration, TimeUnit timeUnit);
+
+  /**
+   * Call this to update the appropriate meter.
+   * A meter measures the rate of events over time (e.g., "requests per second").
+   *
+   * @param name The meter to update.
+   */
+  void updateMeter(String name);
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetricsImpl.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetricsImpl.java
@@ -49,4 +49,9 @@ public class ZooKeeperMetricsImpl implements ZooKeeperMetrics {
   public void updateTimer(final String name, final long duration, final TimeUnit timeUnit) {
     registry.timer(prefix + name).update(duration, timeUnit);
   }
+
+  @Override
+  public void updateMeter(final String name) {
+    registry.meter(prefix + name).mark();
+  }
 }


### PR DESCRIPTION
Currently there are only gauges for outstanding ZooKeeper
operations. Add meters to see the rate of various types of
ZooKeeper operations. We can sum these meters to get the rate of all
operations.