### PR TITLE
fix NPE in Supervisor.Stop when job has gracePeriod

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -349,14 +349,16 @@ public class Supervisor {
       statusUpdater.setState(STOPPING);
       statusUpdater.update();
 
-      final Integer gracePeriod = job.getGracePeriod();
-      if (gracePeriod != null && gracePeriod > 0) {
-        log.info("Unregistering from service discovery for {} seconds before stopping",
-                 gracePeriod);
+      if (runner != null) {
+        final Integer gracePeriod = job.getGracePeriod();
+        if (gracePeriod != null && gracePeriod > 0) {
+          log.info("Unregistering from service discovery for {} seconds before stopping",
+              gracePeriod);
 
-        if (runner.unregister()) {
-          log.info("Unregistered. Now sleeping for {} seconds.", gracePeriod);
-          sleeper.sleep(TimeUnit.MILLISECONDS.convert(gracePeriod, TimeUnit.SECONDS));
+          if (runner.unregister()) {
+            log.info("Unregistered. Now sleeping for {} seconds.", gracePeriod);
+            sleeper.sleep(TimeUnit.MILLISECONDS.convert(gracePeriod, TimeUnit.SECONDS));
+          }
         }
       }
 
@@ -376,7 +378,7 @@ public class Supervisor {
       // Kill the container after stopping the runner
       while (!containerNotRunning()) {
         killContainer();
-        Thread.sleep(retryScheduler.nextMillis());
+        sleeper.sleep(retryScheduler.nextMillis());
       }
 
       statusUpdater.setState(STOPPED);


### PR DESCRIPTION
It's possible for a Supervisor to receive a goal of UNDEPLOY for a job that
it has not been told to START - perhaps because the agent was restarted
during the undeploy of a previous job (during the grace period sleeping).

Since the TaskRunner is only set after receiving the START goal, the call
to `runner.unregister()` when the job being undeployed throws a
NullPointerException.

Add a test to verify behavior.