### PR TITLE
helios-testing: include error messages when throwing TimeoutException

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -17,12 +17,11 @@
 
 package com.spotify.helios.testing;
 
-import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.ListenableFuture;
-
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.HostStatus;
 
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +60,9 @@ public class HeliosDeploymentResource extends ExternalResource {
     super.before();
 
     // wait for the helios master to be available
-    Polling.awaitUnchecked(30, TimeUnit.SECONDS, new Callable<Boolean>() {
+    Polling.awaitUnchecked(30, TimeUnit.SECONDS,
+        "Could not connect to HeliosDeployment at " + deployment.address() + " after %d %s",
+        new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
         final HostAndPort hap = deployment.address();
@@ -84,7 +85,9 @@ public class HeliosDeploymentResource extends ExternalResource {
     // This prevents continuing with the test when starting up helios-solo before the agent is
     // registered.
     final HeliosClient client = client();
-    Polling.awaitUnchecked(30, TimeUnit.SECONDS, new Callable<Boolean>() {
+    Polling.awaitUnchecked(30, TimeUnit.SECONDS,
+        "No agents were available at HeliosDeployment at " + deployment.address() + " after %d %s",
+        new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
         final ListenableFuture<List<String>> future = client.listHosts();

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -17,6 +17,10 @@
 
 package com.spotify.helios.testing;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Collections.singletonList;
+
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerHost;
@@ -50,7 +54,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
-
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,10 +69,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.Collections.singletonList;
 
 /**
  * A HeliosSoloDeployment represents a deployment of Helios Solo, which is to say one Helios
@@ -530,7 +529,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   private Boolean awaitJobUndeployed(final HeliosClient client, final String host,
                                      final JobId jobId, final int timeout,
                                      final TimeUnit timeunit) throws Exception {
-    return Polling.await(timeout, timeunit, new Callable<Boolean>() {
+    return Polling.await(timeout, timeunit, "Job " + jobId + " did not undeploy after %d %s",
+        new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
         final HostStatus hostStatus = getOrNull(client.hostStatus(host));

--- a/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/Polling.java
@@ -17,18 +17,18 @@
 
 package com.spotify.helios.testing;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.base.Throwables.propagateIfInstanceOf;
 import static java.lang.System.nanoTime;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 class Polling {
 
   static <T> T await(final long timeout, final TimeUnit timeUnit,
-                     final Callable<T> callable) throws Exception {
+                     final String message, final Callable<T> callable) throws Exception {
     final long deadline = nanoTime() + timeUnit.toNanos(timeout);
     while (nanoTime() < deadline) {
       final T value = callable.call();
@@ -37,13 +37,14 @@ class Polling {
       }
       Thread.sleep(500);
     }
-    throw new TimeoutException();
+    throw new TimeoutException(String.format(message, timeout, timeUnit.toString().toLowerCase()));
   }
 
   public static <T> T awaitUnchecked(final long timeout, final TimeUnit timeUnit,
-                                     final Callable<T> callable) throws TimeoutException {
+                                     final String message, final Callable<T> callable)
+      throws TimeoutException {
     try {
-      return await(timeout, timeUnit, callable);
+      return await(timeout, timeUnit, message, callable);
     } catch (Throwable e) {
       propagateIfInstanceOf(e, TimeoutException.class);
       throw propagate(e);


### PR DESCRIPTION
When a call to `Polling.await(..)` fails within helios-testing / TemporaryJobs, it is very hard to troubleshoot what went wrong when there is no message in the thrown exception.