### PR TITLE
Undeploy a deployment group's job from hosts that are removed

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/Endpoints.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/Endpoints.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.client;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
@@ -30,8 +32,6 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A class that provides static factory methods for {@link Endpoint}.

--- a/helios-client/src/main/java/com/spotify/helios/client/Response.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/Response.java
@@ -17,11 +17,11 @@
 
 package com.spotify.helios.client;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 class Response {
 

--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosIT.java
@@ -17,7 +17,10 @@
 
 package com.spotify.helios;
 
-import com.google.common.collect.ImmutableList;
+import static com.spotify.helios.Utils.agentImage;
+import static com.spotify.helios.Utils.masterImage;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 import com.spotify.helios.Utils.AgentStatusProber;
 import com.spotify.helios.common.protocol.CreateJobResponse;
@@ -30,15 +33,12 @@ import com.spotify.helios.testing.TemporaryJob;
 import com.spotify.helios.testing.TemporaryJobBuilder;
 import com.spotify.helios.testing.TemporaryJobs;
 
+import com.google.common.collect.ImmutableList;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static com.spotify.helios.Utils.agentImage;
-import static com.spotify.helios.Utils.masterImage;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 
 public class HeliosIT {
 

--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
@@ -17,13 +17,20 @@
 
 package com.spotify.helios;
 
-import com.google.common.net.HostAndPort;
+import static com.spotify.helios.system.SystemTestBase.ALPINE;
+import static com.spotify.helios.system.SystemTestBase.NGINX;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
 
 import com.spotify.helios.testing.HeliosDeploymentResource;
 import com.spotify.helios.testing.HeliosSoloDeployment;
+import com.spotify.helios.testing.InMemoryLogStreamProvider;
 import com.spotify.helios.testing.TemporaryJob;
 import com.spotify.helios.testing.TemporaryJobs;
-import com.spotify.helios.testing.InMemoryLogStreamProvider;
+
+import com.google.common.net.HostAndPort;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
@@ -32,13 +39,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.net.Socket;
-
-import static com.spotify.helios.system.SystemTestBase.ALPINE;
-import static com.spotify.helios.system.SystemTestBase.NGINX;
-import static java.util.Arrays.asList;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 public class HeliosSoloIT {
 

--- a/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
@@ -17,16 +17,19 @@
 
 package com.spotify.helios;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
+import static com.fasterxml.jackson.databind.node.JsonNodeType.STRING;
+import static java.util.Arrays.asList;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.spotify.helios.cli.CliMain;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.testing.Prober;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,9 +40,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static com.fasterxml.jackson.databind.node.JsonNodeType.STRING;
-import static java.util.Arrays.asList;
 
 public class Utils {
 

--- a/helios-services/src/main/java/com/spotify/helios/master/HostChanges.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/HostChanges.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+
+import java.util.List;
+import java.util.Set;
+
+class HostChanges  {
+  private final List<String> added;
+  private final List<String> removed;
+
+  HostChanges(final Set<String> newHosts, final Set<String> currentHosts) {
+    this.added = ImmutableList.copyOf(Sets.difference(newHosts, currentHosts));
+    this.removed = ImmutableList.copyOf(Sets.difference(currentHosts, newHosts));
+  }
+
+  List<String> added() {
+    return this.added;
+  }
+
+  List<String> removed() {
+    return this.removed;
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/UserProvider.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/UserProvider.java
@@ -18,6 +18,7 @@
 package com.spotify.helios.master;
 
 import com.spotify.helios.master.resources.RequestUser;
+
 import com.sun.jersey.api.core.HttpContext;
 import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.core.spi.component.ComponentScope;

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -58,11 +58,11 @@ import com.spotify.helios.common.descriptors.Task;
 import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.common.descriptors.TaskStatusEvent;
 import com.spotify.helios.common.descriptors.ThrottleState;
-import com.spotify.helios.rollingupdate.DefaultRolloutPlanner;
 import com.spotify.helios.rollingupdate.DeploymentGroupEventFactory;
 import com.spotify.helios.rollingupdate.RollingUpdateError;
 import com.spotify.helios.rollingupdate.RollingUpdateOp;
 import com.spotify.helios.rollingupdate.RollingUpdateOpFactory;
+import com.spotify.helios.rollingupdate.RollingUpdatePlanner;
 import com.spotify.helios.rollingupdate.RolloutPlanner;
 import com.spotify.helios.servicescommon.KafkaRecord;
 import com.spotify.helios.servicescommon.KafkaSender;
@@ -622,7 +622,7 @@ public class ZooKeeperMasterModel implements MasterModel {
       }
     }
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
     final List<RolloutTask> rolloutTasks = rolloutPlanner.plan(hostsAndStatuses);
     final DeploymentGroupTasks tasks = DeploymentGroupTasks.newBuilder()
         .setRolloutTasks(rolloutTasks)

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/DefaultRolloutPlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/DefaultRolloutPlanner.java
@@ -17,17 +17,17 @@
 
 package com.spotify.helios.rollingupdate;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DefaultRolloutPlanner implements RolloutPlanner {
 

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUndeployPlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUndeployPlanner.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.rollingupdate;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.spotify.helios.common.descriptors.DeploymentGroup;
+import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.RolloutTask;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RollingUndeployPlanner implements RolloutPlanner {
+
+  private final DeploymentGroup deploymentGroup;
+
+  private RollingUndeployPlanner(final DeploymentGroup deploymentGroup) {
+    this.deploymentGroup = checkNotNull(deploymentGroup, "deploymentGroup");
+  }
+
+  public static RollingUndeployPlanner of(final DeploymentGroup deploymentGroup) {
+    return new RollingUndeployPlanner(deploymentGroup);
+  }
+
+  @Override
+  public List<RolloutTask> plan(final Map<String, HostStatus> hostsAndStatuses) {
+    // we only care about hosts that are UP
+    final List<String> hosts = hostsAndStatuses.entrySet()
+        .stream()
+        .filter(entry -> entry.getValue().getStatus().equals(HostStatus.Status.UP))
+        .map(entry -> entry.getKey())
+        .collect(Collectors.toList());
+
+    // generate the rollout tasks
+    final List<RolloutTask> rolloutTasks = Lists.newArrayList();
+    final int parallelism = deploymentGroup.getRolloutOptions() != null
+                            ? deploymentGroup.getRolloutOptions().getParallelism() : 1;
+
+    Lists.partition(hosts, parallelism)
+        .forEach(partition -> rolloutTasks.addAll(rolloutTasks(partition)));
+
+    return ImmutableList.copyOf(rolloutTasks);
+  }
+
+  private List<RolloutTask> rolloutTasks(final List<String> hosts) {
+    return hosts.stream()
+        .map(host -> RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, host))
+        .collect(Collectors.toList());
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdatePlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdatePlanner.java
@@ -29,16 +29,16 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
 
-public class DefaultRolloutPlanner implements RolloutPlanner {
+public class RollingUpdatePlanner implements RolloutPlanner {
 
   private final DeploymentGroup deploymentGroup;
 
-  private DefaultRolloutPlanner(final DeploymentGroup deploymentGroup) {
+  private RollingUpdatePlanner(final DeploymentGroup deploymentGroup) {
     this.deploymentGroup = checkNotNull(deploymentGroup, "deploymentGroup");
   }
 
-  public static DefaultRolloutPlanner of(final DeploymentGroup deploymentGroup) {
-    return new DefaultRolloutPlanner(deploymentGroup);
+  public static RollingUpdatePlanner of(final DeploymentGroup deploymentGroup) {
+    return new RollingUpdatePlanner(deploymentGroup);
   }
 
   @Override

--- a/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
@@ -17,7 +17,16 @@
 
 package com.spotify.helios;
 
-import com.google.common.collect.ImmutableList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.descriptors.Deployment;
@@ -40,6 +49,8 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperModelReporter;
 
+import com.google.common.collect.ImmutableList;
+
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -53,17 +64,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ZooKeeperMasterModelIntegrationTest {

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdatePlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdatePlannerTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DefaultRolloutPlannerTest {
+public class RollingUpdatePlannerTest {
 
   @Test
   public void testSerialRollout() {
@@ -53,7 +53,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
 
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
@@ -90,7 +90,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
 
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
@@ -127,7 +127,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
 
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
@@ -162,7 +162,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
     final List<RolloutTask> expected = Lists.newArrayList(
@@ -199,7 +199,7 @@ public class DefaultRolloutPlannerTest {
         "agent4", statusUp
     );
 
-    final RolloutPlanner rolloutPlanner = DefaultRolloutPlanner.of(deploymentGroup);
+    final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
     final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
 
     final List<RolloutTask> expected = Lists.newArrayList(

--- a/helios-testing-common/src/main/java/com/spotify/helios/MockServiceRegistrarFactory.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/MockServiceRegistrarFactory.java
@@ -17,10 +17,10 @@
 
 package com.spotify.helios;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
 import com.spotify.helios.serviceregistration.ServiceRegistrarFactory;
-
-import static org.junit.Assert.assertNotNull;
 
 public class MockServiceRegistrarFactory implements ServiceRegistrarFactory {
 

--- a/helios-testing-common/src/main/java/com/spotify/helios/MockServiceRegistrarRegistry.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/MockServiceRegistrarRegistry.java
@@ -17,9 +17,9 @@
 
 package com.spotify.helios;
 
-import com.google.common.collect.Maps;
-
 import com.spotify.helios.serviceregistration.ServiceRegistrar;
+
+import com.google.common.collect.Maps;
 
 import java.util.Map;
 

--- a/helios-testing-common/src/main/java/com/spotify/helios/Polling.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/Polling.java
@@ -17,13 +17,13 @@
 
 package com.spotify.helios;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.base.Throwables.propagateIfInstanceOf;
 import static java.lang.System.nanoTime;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class Polling {
 

--- a/helios-testing-common/src/main/java/com/spotify/helios/TemporaryPorts.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/TemporaryPorts.java
@@ -17,6 +17,14 @@
 
 package com.spotify.helios;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Throwables.propagate;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -40,14 +48,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Throwables.propagate;
-import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.WRITE;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TemporaryPorts extends ExternalResource {
 

--- a/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingClusterManager.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingClusterManager.java
@@ -17,6 +17,10 @@
 
 package com.spotify.helios;
 
+import static com.google.common.collect.Iterables.transform;
+import static java.util.Arrays.asList;
+import static org.apache.commons.io.FileUtils.deleteDirectory;
+
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
@@ -46,10 +50,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nullable;
-
-import static com.google.common.collect.Iterables.transform;
-import static java.util.Arrays.asList;
-import static org.apache.commons.io.FileUtils.deleteDirectory;
 
 /**
  * A ZooKeeperTestManager that uses the {@link org.apache.curator.test.TestingServer}

--- a/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingServerManager.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingServerManager.java
@@ -17,6 +17,9 @@
 
 package com.spotify.helios;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
+
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
 
@@ -40,9 +43,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.apache.commons.io.FileUtils.deleteQuietly;
 
 /**
  * A ZooKeeperTestManager that uses the {@link org.apache.curator.test.TestingServer}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliConfig.java
@@ -17,11 +17,13 @@
 
 package com.spotify.helios.cli;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
@@ -33,9 +35,6 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class CliConfig {
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliMain.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliMain.java
@@ -17,8 +17,13 @@
 
 package com.spotify.helios.cli;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
+import static ch.qos.logback.classic.Level.ALL;
+import static ch.qos.logback.classic.Level.DEBUG;
+import static ch.qos.logback.classic.Level.INFO;
+import static ch.qos.logback.classic.Level.WARN;
+import static com.google.common.collect.Iterables.get;
+import static java.util.Arrays.asList;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 import com.spotify.helios.common.LoggingConfig;
 
@@ -30,13 +35,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 
-import static ch.qos.logback.classic.Level.ALL;
-import static ch.qos.logback.classic.Level.DEBUG;
-import static ch.qos.logback.classic.Level.INFO;
-import static ch.qos.logback.classic.Level.WARN;
-import static com.google.common.collect.Iterables.get;
-import static java.util.Arrays.asList;
-import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 
 /**
  * Instantiates and runs helios CLI.

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -17,9 +17,16 @@
 
 package com.spotify.helios.cli;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static com.google.common.base.Objects.equal;
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.addAll;
+import static com.google.common.collect.Iterables.filter;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static net.sourceforge.argparse4j.impl.Arguments.SUPPRESS;
+import static net.sourceforge.argparse4j.impl.Arguments.append;
+import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import com.spotify.helios.cli.command.CliCommand;
 import com.spotify.helios.cli.command.DeploymentGroupCreateCommand;
@@ -49,6 +56,10 @@ import com.spotify.helios.cli.command.VersionCommand;
 import com.spotify.helios.common.LoggingConfig;
 import com.spotify.helios.common.Version;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Argument;
@@ -66,17 +77,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import static com.google.common.base.Objects.equal;
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.base.Predicates.not;
-import static com.google.common.collect.Iterables.addAll;
-import static com.google.common.collect.Iterables.filter;
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static net.sourceforge.argparse4j.impl.Arguments.SUPPRESS;
-import static net.sourceforge.argparse4j.impl.Arguments.append;
-import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 public class CliParser {
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/JobStatusTable.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/JobStatusTable.java
@@ -17,7 +17,9 @@
 
 package com.spotify.helios.cli;
 
-import com.google.common.base.Joiner;
+import static com.google.common.base.Ascii.truncate;
+import static com.google.common.base.Optional.fromNullable;
+import static com.spotify.helios.cli.Output.table;
 
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.JobId;
@@ -25,14 +27,12 @@ import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.common.descriptors.ThrottleState;
 
+import com.google.common.base.Joiner;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Ascii.truncate;
-import static com.google.common.base.Optional.fromNullable;
-import static com.spotify.helios.cli.Output.table;
 
 public class JobStatusTable {
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Output.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Output.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.cli;
 
+import static java.lang.String.format;
+
 import org.joda.time.Duration;
 import org.joda.time.Period;
 import org.xbill.DNS.Name;
@@ -24,8 +26,6 @@ import org.xbill.DNS.ResolverConfig;
 import org.xbill.DNS.TextParseException;
 
 import java.io.PrintStream;
-
-import static java.lang.String.format;
 
 public class Output {
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Table.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Table.java
@@ -17,14 +17,14 @@
 
 package com.spotify.helios.cli;
 
+import static java.lang.Math.max;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 
 import java.io.PrintStream;
 import java.util.List;
-
-import static java.lang.Math.max;
 
 /**
  * Produces tabulated output, adding padding to cells as necessary to align them into columns.

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Target.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Target.java
@@ -17,11 +17,11 @@
 
 package com.spotify.helios.cli;
 
+import com.spotify.helios.common.Resolver;
+
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-
-import com.spotify.helios.common.Resolver;
 
 import java.net.URI;
 import java.util.List;

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -17,18 +17,20 @@
 
 package com.spotify.helios.cli;
 
-import com.google.common.base.Function;
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
-import com.google.common.util.concurrent.ListenableFuture;
+import static java.lang.String.format;
 
 import com.spotify.helios.client.Endpoints;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.protocol.SetGoalResponse;
+
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -42,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
-import static java.lang.String.format;
 
 public class Utils {
 

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
@@ -17,10 +17,12 @@
 
 package com.spotify.helios.cli;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-
 import com.typesafe.config.ConfigException;
 
 import org.hamcrest.Matchers;
@@ -34,9 +36,6 @@ import java.io.FileOutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class CliConfigTest {
 

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -17,6 +17,10 @@
 
 package com.spotify.helios.cli;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -32,10 +36,6 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class CliParserTest {
 

--- a/helios-tools/src/test/java/com/spotify/helios/cli/OutputTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/OutputTest.java
@@ -17,8 +17,6 @@
 
 package com.spotify.helios.cli;
 
-import org.junit.Test;
-
 import static com.spotify.helios.cli.Output.humanDuration;
 import static org.hamcrest.Matchers.is;
 import static org.joda.time.Duration.standardDays;
@@ -26,6 +24,8 @@ import static org.joda.time.Duration.standardHours;
 import static org.joda.time.Duration.standardMinutes;
 import static org.joda.time.Duration.standardSeconds;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
 
 public class OutputTest {
 


### PR DESCRIPTION
Reviewer: @mattnworb 
Interested parties: @spotify/helios-devs 

This change also has the side effect of not writing rolling update tasks for machines that *did not* change since the last check. Previously we would queue tasks to update hosts that were already running the target job, and those tasks would be treated as no-ops.