### PR TITLE
add logically-equal comparison test for HostSelectors

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostSelector.java
@@ -186,12 +186,12 @@ public class HostSelector extends Descriptor {
       return false;
     }
 
-    return isInAndEqualsWithSameValue(a, b) || isInAndEqualsWithSameValue(b, a);
+    return isEquivalentOperatorWithSameValue(a, b) || isEquivalentOperatorWithSameValue(b, a);
   }
 
-  private static boolean isInAndEqualsWithSameValue(HostSelector a, HostSelector b) {
-    return a.operator == Operator.IN &&
-           b.operator == Operator.EQUALS &&
+  private static boolean isEquivalentOperatorWithSameValue(HostSelector a, HostSelector b) {
+    return (a.operator == Operator.IN && b.operator == Operator.EQUALS ||
+            a.operator == Operator.NOT_IN && b.operator == Operator.NOT_EQUALS) &&
            a.operand instanceof List &&
            ((List) a.operand).size() == 1 &&
            ((List) a.operand).get(0).equals(b.operand);

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/HostSelectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/HostSelectorTest.java
@@ -17,14 +17,18 @@
 
 package com.spotify.helios.common.descriptors;
 
-import com.spotify.helios.common.Json;
-
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import com.spotify.helios.common.Json;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.Collection;
 
 public class HostSelectorTest {
 
@@ -222,5 +226,94 @@ public class HostSelectorTest {
   public void testToPrettyString() {
     assertEquals("A != B", HostSelector.parse("A!=B").toPrettyString());
     assertEquals("A = B", HostSelector.parse("A=B").toPrettyString());
+  }
+
+  @Test
+  public void testLogicallyEqual() {
+    final HostSelector fooInX = HostSelector.parse("foo in (x)");
+    final HostSelector fooEqX = HostSelector.parse("foo = x");
+    final HostSelector fooNotEqX = HostSelector.parse("foo != x");
+
+    final HostSelector fooInXorY = HostSelector.parse("foo in (x, y)");
+    final HostSelector fooInY = HostSelector.parse("foo in (y)");
+    final HostSelector fooEqY = HostSelector.parse("foo = y");
+
+    final HostSelector barInX = HostSelector.parse("bar in (x)");
+    final HostSelector barEqX = HostSelector.parse("bar = x");
+    final HostSelector barNotEqX = HostSelector.parse("bar != x");
+
+    final HostSelector barInY = HostSelector.parse("bar in (y)");
+    final HostSelector barEqY = HostSelector.parse("bar = y");
+    final HostSelector barNotEqY = HostSelector.parse("bar != y");
+
+    // foo in x, foo = x; and the reverse
+    assertTrue(HostSelector.isLogicallyEqual(fooInX, fooEqX));
+    assertTrue(HostSelector.isLogicallyEqual(fooEqX, fooInX));
+
+    // same arguments
+    assertTrue(HostSelector.isLogicallyEqual(fooInX, fooInX));
+    assertTrue(HostSelector.isLogicallyEqual(fooEqX, fooEqX));
+
+    final HostSelector[] lhs = {fooInX, fooEqX};
+    final HostSelector[] rhs = {fooInXorY, fooNotEqX, fooInY, fooEqY,
+                                barInX, barEqX, barNotEqX,
+                                barInY, barEqY, barNotEqY};
+
+    for (final HostSelector s1 : lhs) {
+      for (final HostSelector s2 : rhs) {
+        assertFalse(
+            s1.toPrettyString() + " should not be logically equal to " + s2.toPrettyString(),
+            HostSelector.isLogicallyEqual(s1, s2)
+        );
+      }
+    }
+  }
+
+  @Test
+  public void testCollectionLogicallyEqual() {
+    // self test
+    assertTrue(HostSelector.isLogicallyEqual(
+        parseList("foo = bar", "pool = a"),
+        parseList("foo = bar", "pool = a")
+    ));
+
+    // test that a list and it's reversed self are logically equal
+    assertTrue(HostSelector.isLogicallyEqual(
+        parseList("foo = bar", "pool = a"),
+        parseList("pool = a", "foo = bar")
+    ));
+
+    // foo in (a) and foo = a
+    assertTrue(HostSelector.isLogicallyEqual(
+        parseList("foo = bar", "pool = a"),
+        parseList("foo in (bar)", "pool = a")
+    ));
+
+    // previous test reversed
+    assertTrue(HostSelector.isLogicallyEqual(
+        parseList("foo = bar", "pool = a"),
+        parseList("pool = a", "foo in (bar)")
+    ));
+
+    // unequal lists
+    assertFalse(HostSelector.isLogicallyEqual(
+        parseList("foo = bar", "pool = a", "c = x"),
+        parseList("pool = a", "foo in (bar)")
+    ));
+
+    // unequal comparisons
+    assertFalse(HostSelector.isLogicallyEqual(
+        parseList("foo = bar"),
+        parseList("foo != bar")
+    ));
+  }
+
+  private static Collection<HostSelector> parseList(String... strings) {
+    return Lists.transform(Lists.newArrayList(strings), new Function<String, HostSelector>() {
+      @Override
+      public HostSelector apply(final String input) {
+        return HostSelector.parse(input);
+      }
+    });
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/DeploymentGroupResource.java
@@ -17,13 +17,12 @@
 
 package com.spotify.helios.master.resources;
 
-import com.google.common.collect.Lists;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Timed;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
+import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -37,10 +36,13 @@ import com.spotify.helios.master.DeploymentGroupExistsException;
 import com.spotify.helios.master.JobDoesNotExistException;
 import com.spotify.helios.master.MasterModel;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.Lists;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
@@ -50,8 +52,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/deployment-group")
 public class DeploymentGroupResource {
@@ -88,7 +88,8 @@ public class DeploymentGroupResource {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
       }
 
-      if (!Objects.equals(existing.getHostSelectors(), deploymentGroup.getHostSelectors())) {
+      if (!HostSelector.isLogicallyEqual(
+          existing.getHostSelectors(), deploymentGroup.getHostSelectors())) {
         return Response.ok(DEPLOYMENT_GROUP_ALREADY_EXISTS_RESPONSE).build();
       }
 


### PR DESCRIPTION
This adds a test to compare HostSelectors and Collections of
HostSelectors to find out if they are "logically equal". Currently the
only logically equal selectors are `foo = bar` and `foo in (bar)`.

This is intended to  remove an error message about conflicting host
selectors if a user tries to create a deployment group with selectors
`[foo in (bar), pool = a]` when a deployment group already exists
with selectors `[foo = bar, pool = a]`.
