### PR TITLE
Use Docker syslog driver instead of syslog-redirector

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ Other Software You Might Want To Consider
 Here are a few other things you probably want to consider using alongside
 Helios:
 * [docker-gc](https://github.com/spotify/docker-gc) Garbage collects dead containers and removes unused images.
-* [syslog-redirector](https://github.com/spotify/syslog-redirector) Can be used by Helios agents to redirect the standard out/err of containers to syslog.
 * [helios-skydns](https://github.com/spotify/helios-skydns) Makes it so you can auto register services in SkyDNS.  If you use leading underscores in your SRV record names, let us know, we have a patch for etcd which disables the "hidden" node feature which makes this use case break.
 * [skygc](https://github.com/spotify/skygc)  When using SkyDNS, especially if you're using the Helios Testing Framework, can leave garbage in the skydns tree within etcd.  This will clean out dead stuff.
 * [docker-maven-plugin](https://github.com/spotify/docker-maven-plugin)  Simplifies the building of Docker containers if you're using Maven (and most likely Java).

--- a/helios-services/src/main/java/com/spotify/helios/agent/AddExtraHostContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AddExtraHostContainerDecorator.java
@@ -38,7 +38,7 @@ public class AddExtraHostContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateHostConfig(final Optional<String> dockerVersion,
+  public void decorateHostConfig(final Job job, final Optional<String> dockerVersion,
                                  final HostConfig.Builder hostConfig) {
     hostConfig.extraHosts(this.extraHosts);
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AddExtraHostContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AddExtraHostContainerDecorator.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.InetAddresses;
 
@@ -37,12 +38,14 @@ public class AddExtraHostContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateHostConfig(final HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(final Optional<String> dockerVersion,
+                                 final HostConfig.Builder hostConfig) {
     hostConfig.extraHosts(this.extraHosts);
   }
 
   @Override
   public void decorateContainerConfig(final Job job, final ImageInfo imageInfo,
+                                      final Optional<String> dockerVersion,
                                       final ContainerConfig.Builder containerConfig) {
     //do nothing
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/BindVolumeContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/BindVolumeContainerDecorator.java
@@ -65,7 +65,8 @@ public class BindVolumeContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(Job job, Optional<String> dockerVersion,
+                                 HostConfig.Builder hostConfig) {
     final List<String> b = Lists.newArrayList();
 
     if (hostConfig.binds() != null) {

--- a/helios-services/src/main/java/com/spotify/helios/agent/BindVolumeContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/BindVolumeContainerDecorator.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -64,7 +65,7 @@ public class BindVolumeContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateHostConfig(HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig) {
     final List<String> b = Lists.newArrayList();
 
     if (hostConfig.binds() != null) {
@@ -77,7 +78,7 @@ public class BindVolumeContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateContainerConfig(Job job, ImageInfo imageInfo,
+  public void decorateContainerConfig(Job job, ImageInfo imageInfo, Optional<String> dockerVersion,
                                       ContainerConfig.Builder containerConfig) {
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/ContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ContainerDecorator.java
@@ -31,7 +31,7 @@ import com.spotify.helios.common.descriptors.Job;
  */
 public interface ContainerDecorator {
 
-  void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig);
+  void decorateHostConfig(Job job, Optional<String> dockerVersion, HostConfig.Builder hostConfig);
 
   void decorateContainerConfig(Job job, ImageInfo imageInfo, Optional<String> dockerVersion,
                                ContainerConfig.Builder containerConfig);

--- a/helios-services/src/main/java/com/spotify/helios/agent/ContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ContainerDecorator.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.ImageInfo;
@@ -30,8 +31,8 @@ import com.spotify.helios.common.descriptors.Job;
  */
 public interface ContainerDecorator {
 
-  void decorateHostConfig(HostConfig.Builder hostConfig);
+  void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig);
 
-  void decorateContainerConfig(Job job, ImageInfo imageInfo,
+  void decorateContainerConfig(Job job, ImageInfo imageInfo, Optional<String> dockerVersion,
                                ContainerConfig.Builder containerConfig);
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/NoOpContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/NoOpContainerDecorator.java
@@ -29,7 +29,8 @@ import com.spotify.helios.common.descriptors.Job;
 public class NoOpContainerDecorator implements ContainerDecorator {
 
   @Override
-  public void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(Job job, Optional<String> dockerVersion,
+                                 HostConfig.Builder hostConfig) {
     //noop
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/NoOpContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/NoOpContainerDecorator.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.ImageInfo;
@@ -28,12 +29,12 @@ import com.spotify.helios.common.descriptors.Job;
 public class NoOpContainerDecorator implements ContainerDecorator {
 
   @Override
-  public void decorateHostConfig(HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig) {
     //noop
   }
 
   @Override
-  public void decorateContainerConfig(Job job, ImageInfo imageInfo,
+  public void decorateContainerConfig(Job job, ImageInfo imageInfo, Optional<String> dockerVersion,
                                       ContainerConfig.Builder containerConfig) {
     //noop
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
@@ -42,7 +42,7 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(Job job, Optional<String> dockerVersion,
     final List<String> binds = Lists.newArrayList();
     if (hostConfig.binds() != null) {
       binds.addAll(hostConfig.binds());

--- a/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
@@ -18,12 +18,14 @@
 package com.spotify.helios.agent;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.ImageInfo;
+import com.spotify.docker.client.messages.LogConfig;
 import com.spotify.helios.common.descriptors.Job;
 
 import java.util.List;
@@ -43,17 +45,33 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
 
   @Override
   public void decorateHostConfig(Job job, Optional<String> dockerVersion,
-    final List<String> binds = Lists.newArrayList();
-    if (hostConfig.binds() != null) {
-      binds.addAll(hostConfig.binds());
+                                 HostConfig.Builder hostConfig) {
+    if (useSyslogRedirector(dockerVersion)) {
+      final List<String> binds = Lists.newArrayList();
+      if (hostConfig.binds() != null) {
+        binds.addAll(hostConfig.binds());
+      }
+      binds.add("/usr/lib/helios:/helios:ro");
+      hostConfig.binds(binds);
+    } else {
+      final ImmutableMap.Builder<String, String> logOpts = ImmutableMap.builder();
+
+      logOpts.put("syslog-address", "udp://" + syslogHostPort);
+      logOpts.put("syslog-facility", "local0"); // match the behavior of syslog-redirector
+
+      logOpts.put("tag", job.getId().toString());
+
+      hostConfig.logConfig(LogConfig.create("syslog", logOpts.build()));
     }
-    binds.add("/usr/lib/helios:/helios:ro");
-    hostConfig.binds(binds);
   }
 
   @Override
   public void decorateContainerConfig(Job job, ImageInfo imageInfo, Optional<String> dockerVersion,
                                       ContainerConfig.Builder containerConfig) {
+    if (!useSyslogRedirector(dockerVersion)) {
+      return;
+    }
+
     final ContainerConfig imageConfig = imageInfo.config();
 
     // Inject syslog-redirector in the entrypoint to capture std out/err
@@ -82,5 +100,21 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
     }
     volumes.add("/helios");
     containerConfig.volumes(volumes);
+  }
+
+  private boolean useSyslogRedirector(Optional<String> dockerVersion) {
+    if (!dockerVersion.isPresent()) {
+      // always use syslog-redirector if we can't figure out the version
+      return true;
+    } else {
+      final String version = dockerVersion.get();
+
+      if (version.startsWith("1.6.") || version.startsWith("1.7.") || version.startsWith("1.8.")) {
+        // old version that doesn't have the builtin syslog configurability we need
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SyslogRedirectingContainerDecorator.java
@@ -42,7 +42,7 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateHostConfig(HostConfig.Builder hostConfig) {
+  public void decorateHostConfig(Optional<String> dockerVersion, HostConfig.Builder hostConfig) {
     final List<String> binds = Lists.newArrayList();
     if (hostConfig.binds() != null) {
       binds.addAll(hostConfig.binds());
@@ -52,7 +52,7 @@ public class SyslogRedirectingContainerDecorator implements ContainerDecorator {
   }
 
   @Override
-  public void decorateContainerConfig(Job job, ImageInfo imageInfo,
+  public void decorateContainerConfig(Job job, ImageInfo imageInfo, Optional<String> dockerVersion,
                                       ContainerConfig.Builder containerConfig) {
     final ContainerConfig imageConfig = imageInfo.config();
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -298,7 +298,7 @@ public class TaskConfig {
     builder.capDrop(ImmutableList.copyOf(job.getDropCapabilities()));
 
     for (final ContainerDecorator decorator : containerDecorators) {
-      decorator.decorateHostConfig(dockerVersion, builder);
+      decorator.decorateHostConfig(job, dockerVersion, builder);
     }
 
     return builder.build();

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -99,7 +100,8 @@ public class TaskConfig {
    * @param imageInfo The ImageInfo object.
    * @return The ContainerConfig object.
    */
-  public ContainerConfig containerConfig(final ImageInfo imageInfo) {
+  public ContainerConfig containerConfig(final ImageInfo imageInfo,
+      final Optional<String> dockerVersion) {
     final ContainerConfig.Builder builder = ContainerConfig.builder();
 
     builder.image(job.getImage());
@@ -110,7 +112,7 @@ public class TaskConfig {
     builder.volumes(volumes());
 
     for (final ContainerDecorator decorator : containerDecorators) {
-      decorator.decorateContainerConfig(job, imageInfo, builder);
+      decorator.decorateContainerConfig(job, imageInfo, dockerVersion, builder);
     }
 
     return builder.build();
@@ -275,7 +277,7 @@ public class TaskConfig {
    * Create a container host configuration for the job.
    * @return The host configuration.
    */
-  public HostConfig hostConfig() {
+  public HostConfig hostConfig(final Optional<String> dockerVersion) {
     final List<String> securityOpt = job.getSecurityOpt();
     final HostConfig.Builder builder = HostConfig.builder()
         .binds(binds())
@@ -296,7 +298,7 @@ public class TaskConfig {
     builder.capDrop(ImmutableList.copyOf(job.getDropCapabilities()));
 
     for (final ContainerDecorator decorator : containerDecorators) {
-      decorator.decorateHostConfig(builder);
+      decorator.decorateHostConfig(dockerVersion, builder);
     }
 
     return builder.build();

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -245,10 +245,10 @@ class TaskRunner extends InterruptingExecutionThreadService {
       pullImage(image);
     }
 
-    return startContainer(image);
+    return startContainer(image, dockerVersion);
   }
 
-  private String startContainer(final String image)
+  private String startContainer(final String image, final Optional<String> dockerVersion)
       throws InterruptedException, DockerException {
 
     // Get container image info
@@ -258,8 +258,8 @@ class TaskRunner extends InterruptingExecutionThreadService {
     }
 
     // Create container
-    final HostConfig hostConfig = config.hostConfig();
-    final ContainerConfig containerConfig = config.containerConfig(imageInfo)
+    final HostConfig hostConfig = config.hostConfig(dockerVersion);
+    final ContainerConfig containerConfig = config.containerConfig(imageInfo, dockerVersion)
         .toBuilder()
         .hostConfig(hostConfig)
         .build();

--- a/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
@@ -39,7 +39,7 @@ public class AddExtraHostContainerDecoratorTest {
     final AddExtraHostContainerDecorator decorator = new AddExtraHostContainerDecorator(hosts);
 
     final HostConfig.Builder hostBuilder = HostConfig.builder();
-    decorator.decorateHostConfig(Optional.absent(), hostBuilder);
+    decorator.decorateHostConfig(null, Optional.absent(), hostBuilder);
 
     final HostConfig config = hostBuilder.build();
     assertThat(config.extraHosts(), equalTo(hosts));

--- a/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
 import com.spotify.docker.client.messages.HostConfig;
@@ -38,7 +39,7 @@ public class AddExtraHostContainerDecoratorTest {
     final AddExtraHostContainerDecorator decorator = new AddExtraHostContainerDecorator(hosts);
 
     final HostConfig.Builder hostBuilder = HostConfig.builder();
-    decorator.decorateHostConfig(hostBuilder);
+    decorator.decorateHostConfig(Optional.absent(), hostBuilder);
 
     final HostConfig config = hostBuilder.build();
     assertThat(config.extraHosts(), equalTo(hosts));

--- a/helios-services/src/test/java/com/spotify/helios/agent/SyslogRedirectingContainerDecoratorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/SyslogRedirectingContainerDecoratorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import com.google.common.base.Optional;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.ImageInfo;
+import com.spotify.docker.client.messages.LogConfig;
+import com.spotify.helios.common.descriptors.Job;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SyslogRedirectingContainerDecoratorTest {
+
+  private static final String SYSLOG_HOST_PORT = "fun:123";
+
+  private static final Job JOB = Job.newBuilder()
+      .setName("myjob").setImage("abc").setVersion("x").build();
+
+  private ImageInfo imageInfo;
+
+  @Before
+  public void setUp() {
+    imageInfo = mock(ImageInfo.class);
+    when(imageInfo.config()).thenReturn(mock(ContainerConfig.class));
+  }
+
+  @Test
+  public void testWithDockerVersionPre1_9() {
+    final Optional<String> dockerVersion = Optional.of("1.6.0");
+
+    final SyslogRedirectingContainerDecorator decorator =
+        new SyslogRedirectingContainerDecorator(SYSLOG_HOST_PORT);
+
+    final HostConfig.Builder hostBuilder = HostConfig.builder();
+    decorator.decorateHostConfig(JOB, dockerVersion, hostBuilder);
+
+    final ContainerConfig.Builder containerBuilder = ContainerConfig.builder();
+    decorator.decorateContainerConfig(JOB, imageInfo, dockerVersion, containerBuilder);
+
+    final ContainerConfig containerConfig = containerBuilder.build();
+    assertThat(containerConfig.entrypoint(), hasItem("/helios/syslog-redirector"));
+
+    final HostConfig hostConfig = hostBuilder.build();
+    assertNull(hostConfig.logConfig());
+    assertFalse(hostConfig.binds().isEmpty());
+  }
+
+  @Test
+  public void testWithDockerVersionPost1_9() {
+    final Optional<String> dockerVersion = Optional.of("1.12.1");
+
+    final SyslogRedirectingContainerDecorator decorator =
+        new SyslogRedirectingContainerDecorator(SYSLOG_HOST_PORT);
+
+    final HostConfig.Builder hostBuilder = HostConfig.builder();
+    decorator.decorateHostConfig(JOB, dockerVersion, hostBuilder);
+
+    final ContainerConfig.Builder containerBuilder = ContainerConfig.builder();
+    decorator.decorateContainerConfig(JOB, imageInfo, dockerVersion, containerBuilder);
+
+    final ContainerConfig containerConfig = containerBuilder.build();
+    assertThat(containerConfig.entrypoint(), not(hasItem("/helios/syslog-redirector")));
+
+    final HostConfig hostConfig = hostBuilder.build();
+    final LogConfig logConfig = hostConfig.logConfig();
+    assertEquals("syslog", logConfig.logType());
+    assertEquals(JOB.getId().toString(), logConfig.logOptions().get("tag"));
+    assertEquals("udp://" + SYSLOG_HOST_PORT, logConfig.logOptions().get("syslog-address"));
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 
 import com.spotify.docker.client.messages.HostConfig;
@@ -116,7 +117,7 @@ public class TaskConfigTest {
         .job(JOB)
         .build();
 
-    final HostConfig hostConfig = taskConfig.hostConfig();
+    final HostConfig hostConfig = taskConfig.hostConfig(Optional.absent());
     assertThat(ImmutableSet.copyOf(hostConfig.capAdd()), equalTo(CAP_ADDS));
     assertThat(ImmutableSet.copyOf(hostConfig.capDrop()), equalTo(CAP_DROPS));
   }


### PR DESCRIPTION
In Docker v1.12+, we can just have Docker log directly to syslog instead of
mounting and using the syslog-redirector.