### PR TITLE
include docker version in ffwd-reported metrics

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/DockerVersionSupplier.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/DockerVersionSupplier.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.servicescommon.statistics;
+
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+
+import java.util.function.Supplier;
+
+/**
+ * Returns the version from the DockerClient, formatted as a String so that exceptions can be
+ * propogated by returning special String values.
+ */
+public class DockerVersionSupplier implements Supplier<String> {
+
+  private final DockerClient dockerClient;
+
+  public DockerVersionSupplier(final DockerClient dockerClient) {
+    this.dockerClient = dockerClient;
+  }
+
+  @Override
+  public String get() {
+    try {
+      return dockerClient.version().version();
+    } catch (DockerException | InterruptedException e) {
+      return "n/a";
+    }
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/statistics/FastForwardReporterTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/statistics/FastForwardReporterTest.java
@@ -72,7 +72,7 @@ public class FastForwardReporterTest {
    * A matcher that matches when the actual object contains all of the given attributes
    * (note that the reverse isn't necessarily true; this is a partial matcher).
    */
-  private static CustomTypeSafeMatcher<Metric> containsAttributes(Map<String, String> attributes) {
+  private static Matcher<Metric> containsAttributes(Map<String, String> attributes) {
 
     final String description = String.format("a metric containing attributes=%s", attributes);
 
@@ -84,7 +84,7 @@ public class FastForwardReporterTest {
     };
   }
 
-  private static CustomTypeSafeMatcher<Metric> containsAttributes(String... strings) {
+  private static Matcher<Metric> containsAttributes(String... strings) {
     final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     for (int i = 0; i < strings.length; i += 2) {
       builder.put(strings[i], strings[i + 1]);
@@ -92,7 +92,7 @@ public class FastForwardReporterTest {
     return containsAttributes(builder.build());
   }
 
-  private static CustomTypeSafeMatcher<Metric> hasValue(double value) {
+  private static Matcher<Metric> hasValue(double value) {
     return new CustomTypeSafeMatcher<Metric>("a metric with value=" + value) {
       @Override
       protected boolean matchesSafely(final Metric item) {
@@ -101,7 +101,7 @@ public class FastForwardReporterTest {
     };
   }
 
-  private static CustomTypeSafeMatcher<Metric> hasKey(String key) {
+  private static Matcher<Metric> hasKey(String key) {
     return new CustomTypeSafeMatcher<Metric>("a metric with key=" + key) {
       @Override
       protected boolean matchesSafely(final Metric item) {


### PR DESCRIPTION
Allow the FastForwardReporter to be configured with additional attributes (key-value pairs to send in each metric) that might change at runtime.

Set up the AgentService to report the version of Docker via the docker-client as an additional attribute in FastForwardReporter.