### PR TITLE
Handle unparseable JSON when reading hosts

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -74,6 +74,7 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperOperation;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Function;
@@ -1229,7 +1230,7 @@ public class ZooKeeperMasterModel implements MasterModel {
   private List<String> getHosts(final ZooKeeperClient client, final String path) {
     try {
       return Json.read(client.getNode(path).getBytes(), STRING_LIST_TYPE);
-    } catch (JsonMappingException | NoNodeException e) {
+    } catch (JsonMappingException | JsonParseException | NoNodeException e) {
       return Collections.emptyList();
     } catch (KeeperException | IOException e) {
       throw new HeliosRuntimeException("failed to read deployment group hosts from " + path, e);


### PR DESCRIPTION
https://github.com/spotify/helios/pull/986 seems to have introduced this bug, which is currently causing all `HOSTS_CHANGED` rolling updates to fail.

```
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]: error processing hosts update for deployment group: prex - {}
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      com.spotify.helios.common.HeliosRuntimeException: failed to read deployment group hosts from /status/deployment-groups/prex/removed
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.master.ZooKeeperMasterModel.getHosts(ZooKeeperMasterModel.java:1235)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.master.ZooKeeperMasterModel.updateDeploymentGroupHosts(ZooKeeperMasterModel.java:535)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.rollingupdate.RollingUpdateService$UpdateDeploymentGroupHosts.run(RollingUpdateService.java:110)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.servicescommon.DefaultReactor.run(DefaultReactor.java:100)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.google.common.util.concurrent.AbstractExecutionThreadService$1$2.run(AbstractExecutionThreadService.java:60)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.google.common.util.concurrent.Callables$3.run(Callables.java:95)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at java.lang.Thread.run(Thread.java:745)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      Caused by: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('.' (code 46)): Expected space separating root-level values
 at [Source: [B@6f31a997; line: 1, column: 8]
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1576)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:533)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:462)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.base.ParserMinimalBase._reportMissingRootWS(ParserMinimalBase.java:478)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._verifyRootSpace(UTF8StreamJsonParser.java:1635)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._parseFloat(UTF8StreamJsonParser.java:1602)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._parsePosNumber(UTF8StreamJsonParser.java:1370)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._nextTokenNotInObject(UTF8StreamJsonParser.java:839)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:737)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:3742)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3687)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2824)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.common.Json.read(Json.java:202)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.master.ZooKeeperMasterModel.getHosts(ZooKeeperMasterModel.java:1231)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.master.ZooKeeperMasterModel.updateDeploymentGroupHosts(ZooKeeperMasterModel.java:535)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.rollingupdate.RollingUpdateService$UpdateDeploymentGroupHosts.run(RollingUpdateService.java:110)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.spotify.helios.servicescommon.DefaultReactor.run(DefaultReactor.java:100)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.google.common.util.concurrent.AbstractExecutionThreadService$1$2.run(AbstractExecutionThreadService.java:60)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at com.google.common.util.concurrent.Callables$3.run(Callables.java:95)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
2016-10-12T16:26:05.224+00:00 sjc1-heliosmaster-a1.sjc1.spotify.net helios[17667]:      at java.lang.Thread.run(Thread.java:745)
```