### PR TITLE
HeliosSoloDeployment: include host when executing curl against unix socket

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -322,9 +322,13 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     final List<String> cmd = new ArrayList<>(ImmutableList.of("curl", "-f"));
     switch (containerDockerHost.uri().getScheme()) {
       case "unix":
+        // A note on the URLs used below: since 7.50, curl requires a hostname when
+        // using unix-sockets. See https://github.com/curl/curl/issues/936 and
+        // https://github.com/docker/docker/pull/27640. The hostname we use does not matter since
+        // curl is establishing a connection to the unix socket anyway.
         cmd.addAll(ImmutableList.of(
                 "--unix-socket", containerDockerHost.uri().getSchemeSpecificPart(),
-                "http:/containers/" + probeName + "/json"));
+                "http://docker/containers/" + probeName + "/json"));
         break;
       case "https":
         cmd.addAll(ImmutableList.of(


### PR DESCRIPTION
Since 7.50, curl requires a hostname when using unix-sockets.

HeliosSoloDeployment is executing something like

```
curl --unix-socket/var/run/docker.sock http:/containers/:id/json
```

when probing the docker environment, expecting to read the
`/containers/:id/json` endpoint in the docker remote API.

With curl 7.50 (which onescience/alpine seems to have been upgraded to
in the past few days), this is interpreted differently:

```
root@/ > curl -v --unix-socket /var/run/docker.sock http:/containers
* Unwillingly accepted illegal URL using 1 slash!
* Rebuilt URL to: http://containers/
*   Trying /var/run/docker.sock...
* Connected to containers (/var/run/docker.sock) port 80 (#0)
> GET / HTTP/1.1
> Host: containers
> User-Agent: curl/7.50.3
> Accept: */*
>
< HTTP/1.1 404 Not Found
```

(note the Host header)

To fix this, use a URL with curl that sets a hostname and path properly.