### PR TITLE
reduce log noise from HeliosSoloLogService

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloLogService.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloLogService.java
@@ -29,6 +29,7 @@ import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.TaskStatus;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -83,44 +84,64 @@ class HeliosSoloLogService extends AbstractScheduledService {
     try {
       // fetch all the jobs running on the solo deployment
       for (final String host : get(heliosClient.listHosts())) {
-        final HostStatus hostStatus = get(heliosClient.hostStatus(host));
-        final Map<JobId, TaskStatus> statuses = hostStatus.getStatuses();
-
-        for (final TaskStatus status : statuses.values()) {
+        final Optional<Map<JobId, TaskStatus>> statuses = getHostStatus(host);
+        if (!statuses.isPresent()) {
+          continue;
+        }
+        for (final TaskStatus status : statuses.get().values()) {
           final JobId jobId = status.getJob().getId();
           final String containerId = status.getContainerId();
           if (isNullOrEmpty(containerId)) {
             continue;
           }
 
+          // for any containers we're not already tracking, attach to their stdout/stderr
           if (!logFutures.containsKey(containerId)) {
-            // for any containers we're not already tracking, attach to their stdout/stderr
-            final Future<?> future = this.executor().submit(new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  final LogStream logStream = dockerClient.logs(containerId, stdout(), stderr(),
-                                                                follow());
-
-                  log.info("attaching stdout/stderr for job={}, container={}", jobId, containerId);
-                  logStream.attach(logStreamProvider.getStdoutStream(jobId, containerId),
-                                   logStreamProvider.getStderrStream(jobId, containerId));
-                } catch (final InterruptedException e) {
-                  // we're shutting down, no need to log anything
-                } catch (final Exception e) {
-                  log.warn("error streaming log for job={}, container={} - {}", jobId, containerId,
-                           e);
-                }
-              }
-            });
-
+            final Future<?> future = attachToContainerLogs(jobId, containerId);
             logFutures.put(containerId, future);
           }
         }
       }
     } catch (Exception e) {
-      log.warn("Caught exception, will ignore", e);
+      log.debug("Caught exception, will ignore", e);
     }
+  }
+
+  private Future<?> attachToContainerLogs(final JobId jobId, final String containerId) {
+    return this.executor().submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final LogStream logStream = dockerClient.logs(
+              containerId, stdout(), stderr(), follow());
+
+          log.info("attaching stdout/stderr for job={}, container={}", jobId, containerId);
+          logStream.attach(logStreamProvider.getStdoutStream(jobId, containerId),
+                           logStreamProvider.getStderrStream(jobId, containerId));
+        } catch (final InterruptedException e) {
+          // we're shutting down, no need to log anything
+        } catch (final Exception e) {
+          log.warn("error streaming log for job={}, container={} - {}", jobId, containerId,
+                   e);
+        }
+      }
+    });
+  }
+
+  /** Fetch the host status, wrapping any failures in an empty Optional */
+  private Optional<Map<JobId, TaskStatus>> getHostStatus(final String host) {
+    final HostStatus hostStatus;
+    try {
+      hostStatus = get(heliosClient.hostStatus(host));
+
+    } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+      log.debug("Could not get hostStatus due to exception: {}", ex.toString());
+      return Optional.absent();
+    }
+    if (hostStatus == null) {
+      return Optional.absent();
+    }
+    return Optional.fromNullable(hostStatus.getStatuses());
   }
 
   @Override


### PR DESCRIPTION
when helios-solo is first starting up, sometimes HeliosSoloLogService
will log exceptions like:

> 13:51:45.112 [HeliosSoloLogService RUNNING] WARN c.s.h.testing.HeliosSoloLogService - Caught exception, will ignore
> java.lang.NullPointerException: null
>  at com.spotify.helios.testing.HeliosSoloLogService.runOneIteration(HeliosSoloLogService.java:87)

or

> 13:51:46.457 [HeliosSoloLogService RUNNING] WARN c.s.h.testing.HeliosSoloLogService - Caught exception, will ignore
> java.util.concurrent.TimeoutException: Timeout waiting for task.
>   at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:269) ~[guava-18.0.jar:na]
>   at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:96) ~[guava-18.0.jar:na]
>   at com.spotify.helios.testing.HeliosSoloLogService.get(HeliosSoloLogService.java:69) ~[helios-testing-0.9.45.jar:0.9.45]

These are harmless as the LogService will keep retrying until it can
attach to the container.

To cut down on noise, explicitly check for null or for timed-out
requests, and reduce the log level to debug.