### PR TITLE
remove misleading log line in DeadAgentReaper

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/reaper/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/reaper/DeadAgentReaper.java
@@ -75,7 +75,6 @@ public class DeadAgentReaper extends RateLimitedService<String> {
 
   @Override
   void processItem(final String agent) {
-    log.info("Deciding whether to reap dead agent {}", agent);
     try {
       final HostStatus hostStatus = masterModel.getHostStatus(agent);
       if (hostStatus == null || hostStatus.getStatus() != HostStatus.Status.DOWN) {


### PR DESCRIPTION
The log statement reads as if it has already been decided that the agent
with the given name is down, but this log line is occuring before the
check to see if the agent is up or down.

Since we log something at INFO when reaping the dead agent, remove this
line altogether to reduce noise or confusion.