### PR TITLE
Make toString() better for various classes

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Deployment.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Deployment.java
@@ -127,7 +127,7 @@ public class Deployment extends Descriptor {
            ", deployerUser='" + deployerUser + '\'' +
            ", deployerMaster='" + deployerMaster + '\'' +
            ", deploymentGroupName='" + deploymentGroupName + '\'' +
-           "} " + super.toString();
+           '}';
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupStatus.java
@@ -100,7 +100,7 @@ public class DeploymentGroupStatus extends Descriptor {
     return "DeploymentGroupStatus{" +
            "state=" + state +
            ", error='" + error + '\'' +
-           "} " + super.toString();
+           "}";
   }
 
   public static class Builder {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupTasks.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupTasks.java
@@ -110,7 +110,7 @@ public class DeploymentGroupTasks extends Descriptor {
            "rolloutTasks=" + rolloutTasks +
            ", taskIndex=" + taskIndex +
            ", deploymentGroup=" + deploymentGroup +
-           "} " + super.toString();
+           '}';
   }
 
   public static class Builder {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HealthCheck.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HealthCheck.java
@@ -92,4 +92,11 @@ public abstract class HealthCheck extends Descriptor {
   public static TcpHealthCheck.Builder newTcpHealthCheck() {
     return TcpHealthCheck.newBuilder();
   }
+
+  @Override
+  public String toString() {
+    return "HealthCheck{" +
+           "type='" + type + '\'' +
+           '}';
+  }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
@@ -301,7 +301,7 @@ public class HostInfo extends Descriptor {
            ", dockerVersion=" + dockerVersion +
            ", dockerHost='" + dockerHost + '\'' +
            ", dockerCertPath='" + dockerCertPath + '\'' +
-           "} " + super.toString();
+           '}';
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -436,7 +436,7 @@ public class Job extends Descriptor implements Comparable<Job> {
            ", addCapabilities=" + addCapabilities +
            ", dropCapabilities=" + dropCapabilities +
            ", secondsToWaitBeforeKill=" + secondsToWaitBeforeKill +
-           "} " + super.toString();
+           '}';
   }
 
   public Builder toBuilder() {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
@@ -144,6 +144,6 @@ public class PortMapping extends Descriptor {
            "internalPort=" + internalPort +
            ", externalPort=" + externalPort +
            ", protocol='" + protocol + '\'' +
-           "} " + super.toString();
+           '}';
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Resources.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Resources.java
@@ -114,6 +114,6 @@ public class Resources extends Descriptor {
            ", memorySwap=" + memorySwap +
            ", cpuShares=" + cpuShares +
            ", cpuset='" + cpuset + '\'' +
-           "} " + super.toString();
+           '}';
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutTask.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutTask.java
@@ -69,7 +69,7 @@ public class RolloutTask extends Descriptor {
     return "RolloutTask{" +
            "action=" + action +
            ", target='" + target + '\'' +
-           "} " + super.toString();
+           '}';
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePortParameters.java
@@ -92,6 +92,6 @@ public class ServicePortParameters extends Descriptor {
   public String toString() {
     return "ServicePortParameters{" +
            "tags=" + tags +
-           "} " + super.toString();
+           '}';
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/ServicePorts.java
@@ -77,7 +77,7 @@ public class ServicePorts extends Descriptor {
   public String toString() {
     return "ServicePorts{" +
            "ports=" + ports +
-           "} " + super.toString();
+           '}';
   }
 
   public static ServicePorts of(final String... ports) {

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Task.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Task.java
@@ -121,6 +121,6 @@ public class Task extends Descriptor {
            ", deployerUser='" + deployerUser + '\'' +
            ", deployerMaster='" + deployerMaster + '\'' +
            ", deploymentGroupName='" + deploymentGroupName + '\'' +
-           "} " + super.toString();
+           '}';
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
@@ -186,7 +186,7 @@ public class TaskStatus extends Descriptor {
            ", ports=" + ports +
            ", env=" + env +
            ", containerError='" + containerError + '\'' +
-           "} " + super.toString();
+           '}';
   }
 
   @Override

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatusEvent.java
@@ -74,6 +74,6 @@ public class TaskStatusEvent extends Descriptor {
            "status=" + status +
            ", timestamp=" + timestamp +
            ", host='" + host + '\'' +
-           "} " + super.toString();
+           '}';
   }
 }


### PR DESCRIPTION
The class name at the end is useless.

Before:

`RolloutTask{action=UNDEPLOY_OLD_JOBS,
target='gew1-accesspoint-a-r915.gew1.spotify.net'}
com.spotify.helios.common.descriptors.RolloutTask@8d6f646c`

After:
`RolloutTask{action=UNDEPLOY_OLD_JOBS,
target='gew1-accesspoint-a-r915.gew1.spotify.net'}`