### PR TITLE
upgrade docker-maven-plugin to latest

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -33,7 +33,7 @@
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.13</version>
             <configuration>
               <labels>
                 <label>com.spotify.helios.version="${project.version}"</label>
@@ -111,7 +111,7 @@
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.4.1</version>
+            <version>0.4.13</version>
             <configuration>
               <labels>
                 <label>com.spotify.helios.version="${project.version}"</label>


### PR DESCRIPTION
0.4.1 doesn't support building on docker for mac