### PR TITLE
add retries to flaky test HeliosSoloIT.testServiceDiscovery

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -97,7 +97,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/helios-integration-tests/pom.xml
+++ b/helios-integration-tests/pom.xml
@@ -36,6 +36,16 @@
       <artifactId>jsr305</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -333,7 +333,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -115,7 +115,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -48,7 +48,7 @@
     <!--test deps-->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>com.spotify</groupId>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>1.9.5</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
The test can fail because it tries to connect immediately to the socket of
the alpine container. Need to give the `apk install` being run as the
command of the container time to finish.