### PR TITLE
RFC: Add 'secret volume' integration.

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/SecretVolumeException.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/SecretVolumeException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common;
+
+public class SecretVolumeException extends HeliosException {
+
+  public SecretVolumeException(final String message) {
+    super(message);
+  }
+
+  public SecretVolumeException(final Throwable cause) {
+    super(cause);
+  }
+
+  public SecretVolumeException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/SecretVolume.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/SecretVolume.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a secret volume response from secret-volume.
+ *
+ * <pre>
+ *   {
+ *     "ID": "containerId",
+ *     "Source": "Talos",
+ *     "Tags": {}
+ *   }
+ * </pre>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecretVolume extends Descriptor {
+
+  protected final String id;
+  protected final Secrets.Source source;
+  protected final Map<String, List<String>> tags;
+
+  public SecretVolume(
+      @JsonProperty("ID") final String id,
+      @JsonProperty("Source") final Secrets.Source source,
+      @JsonProperty("Tags") final Map<String, List<String>> tags) {
+    this.id = id;
+    this.source = source;
+    this.tags = tags;
+  }
+
+  public Secrets.Source getSource() {
+    return this.source;
+  }
+
+  public String getId() {
+    return this.id;
+  }
+
+  public Map<String, List<String>> getTags() {
+    return this.tags;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final SecretVolume that = (SecretVolume) o;
+
+    return Objects.equals(this.id, that.id)
+           && Objects.equals(this.source, that.source)
+           && Objects.equals(this.tags, that.tags);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, source, tags);
+  }
+
+  @Override
+  public String toString() {
+    return "Secrets{"
+           + "source=" + source
+           + ", id=" + id
+           + ", tags=" + tags
+           + "} " + super.toString();
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/SecretVolumeRequest.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/SecretVolumeRequest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import static java.util.Collections.emptyMap;
+
+import com.spotify.helios.common.SecretVolumeException;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a secret volume request to secret-volume, i.e. a secret-volume response with an added
+ * KeyPair.
+ *
+ * <pre>
+ *   {
+ *     "ID": "containerId",
+ *     "Source": "Talos",
+ *     "Tags": {},
+ *     "KeyPair": {
+ *        "Certificate": "PEM encoded cert",
+ *        "PrivateKey": "Pem encoded private key"
+ *     }
+ *   }
+ * </pre>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecretVolumeRequest extends SecretVolume {
+
+  private final KeyPair keyPair;
+
+  public SecretVolumeRequest(
+      @JsonProperty("ID") final String id,
+      @JsonProperty("Source") final Secrets.Source source,
+      @JsonProperty("Tags") final Map<String, List<String>> tags,
+      @JsonProperty("KeyPair") final KeyPair keyPair) {
+    super(id, source, tags);
+    this.keyPair = keyPair;
+  }
+
+  public static SecretVolumeRequest create(final String id, final Secrets.Source source,
+                                           final String certData, final String keyData) {
+    // TODO(negz): Read tags from config, or agent labels?
+    final Map<String, List<String>> tags = emptyMap();
+    return new SecretVolumeRequest(id, source, tags, new KeyPair(certData, keyData));
+  }
+
+  private static String readToString(final String path) throws SecretVolumeException {
+    try {
+      return new String(Files.readAllBytes(Paths.get(path)), Charset.defaultCharset());
+    } catch (IOException e) {
+      throw new SecretVolumeException("cannot read secret volume keypair", e);
+    }
+  }
+
+  public KeyPair getKeyPair() {
+    return this.keyPair;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final SecretVolumeRequest that = (SecretVolumeRequest) o;
+
+    return Objects.equals(this.id, that.id)
+           && Objects.equals(this.source, that.source)
+           && Objects.equals(this.tags, that.tags)
+           && Objects.equals(this.keyPair, that.keyPair);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, source, tags, keyPair);
+  }
+
+  @Override
+  public String toString() {
+    return "Secrets{"
+           + "source=" + source
+           + ", id=" + id
+           + ", tags=" + tags
+           + ", keyPair=" + keyPair
+           + "} " + super.toString();
+  }
+
+  public static class KeyPair {
+    private final String certificate;
+    private final String privateKey;
+
+    /**
+     * An SSL keypair for authenticating to a secret source.
+     *
+     * Note that while this object is almost identical to Secrets.KeyPair it uses different JSON
+     * keys, and is intended to store PEM encoded private keypair data, as opposed to the path to
+     * the certificate and private key.
+     *
+     * @param certificate A PEM encoded certificate.
+     * @param privateKey A PEM encoded private key.
+     */
+    public KeyPair(@JsonProperty("Certificate") final String certificate,
+                   @JsonProperty("PrivateKey") final String privateKey) {
+      this.certificate = certificate;
+      this.privateKey = privateKey;
+    }
+
+    public String getCertificate() {
+      return this.certificate;
+    }
+
+    public String getPrivateKey() {
+      return this.privateKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final KeyPair that = (KeyPair) o;
+
+      return Objects.equals(this.certificate, that.certificate)
+             && Objects.equals(this.privateKey, that.privateKey);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(certificate, privateKey);
+    }
+
+    @Override
+    public String toString() {
+      return "KeyPair{"
+             + "certificate=" + certificate
+             + ", privateKey=" + privateKey
+             + "} " + super.toString();
+    }
+  }
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Secrets.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Secrets.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.security.KeyPair;
+import java.util.Objects;
+
+/**
+ * Configures automatic secrets procurement for a container.
+ *
+ * <pre>
+ *   {
+ *     "source": "Talos",
+ *     "path": "/secrets",
+ *     "keypairFromHost": {
+ *       "certificate": "/path/to/pem/cert/on/host",
+ *       "privateKey": "/path/to/pem/key/on/host"
+ *     }
+ *   }
+ * </pre>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Secrets extends Descriptor {
+  private final Source source;
+  private final String path;
+  private final KeyPair keyPairFromHost;
+
+  /**
+   * Automatic secret procurement configuration.
+   *
+   * @param source The source from which to procure secrets for this job.
+   * @param path The path inside the container at which to mount the secrets for this job.
+   * @param keyPairFromHost Optional keypair to use to authenticate to the secret source on behalf
+   *                        of this container.
+   */
+  public Secrets(@JsonProperty("source") final Source source,
+                 @JsonProperty("path") final String path,
+                 @JsonProperty("keyPairFromHost") @Nullable final KeyPair keyPairFromHost) {
+    // TODO(negz): Support tags. Inherit from agent labels, but allow override?
+    this.source = source;
+    this.path = path;
+    this.keyPairFromHost = keyPairFromHost;
+  }
+
+  /**
+   * Create a new secret procurement configuration.
+   *
+   * @param source The secret source (i.e. Talos)
+   * @param path The path inside the container at which to mount the secrets for this job.
+   * @param certPath The path on the host at which to find a certificate for secret authentication.
+   * @param keyPath The path on the host at which to find a private key for secret authentication.
+   * @return A new secret procurement configuration.
+   */
+  public static Secrets create(final Source source, final String path,
+                               final String certPath, final String keyPath) {
+    return new Secrets(source, path, new KeyPair(certPath, keyPath));
+  }
+
+  public Source getSource() {
+    return this.source;
+  }
+
+  public String getPath() {
+    return this.path;
+  }
+
+  @Nullable
+  public KeyPair getKeyPairFromHost() {
+    return this.keyPairFromHost;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final Secrets that = (Secrets) o;
+
+    return Objects.equals(this.source, that.source)
+           && Objects.equals(this.path, that.path)
+           && Objects.equals(this.keyPairFromHost, that.keyPairFromHost);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(source, path, keyPairFromHost);
+  }
+
+  @Override
+  public String toString() {
+    return "Secrets{"
+           + "source=" + source
+           + ", path=" + path
+           + ", keyPairFromHost=" + keyPairFromHost
+           + "} " + super.toString();
+  }
+
+  public enum Source {
+    UNKNOWN,
+    TALOS
+  }
+
+  public static class KeyPair {
+    private final String certificate;
+    private final String privateKey;
+
+    /**
+     * An SSL keypair for authenticating to a secret source.
+     *
+     * @param certificate A path to a PEM encoded certificate file.
+     * @param privateKey A path to a PEM encoded private key.
+     */
+    public KeyPair(@JsonProperty("certificate") final String certificate,
+                   @JsonProperty("privateKey") final String privateKey) {
+      this.certificate = certificate;
+      this.privateKey = privateKey;
+    }
+
+    public String getCertificate() {
+      return this.certificate;
+    }
+
+    public String getPrivateKey() {
+      return this.privateKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final KeyPair that = (KeyPair) o;
+
+      return Objects.equals(this.certificate, that.certificate)
+             && Objects.equals(this.privateKey, that.privateKey);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(certificate, privateKey);
+    }
+
+    @Override
+    public String toString() {
+      return "KeyPair{"
+             + "certificate=" + certificate
+             + ", privateKey=" + privateKey
+             + "} " + super.toString();
+    }
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -52,6 +52,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_RESOURCES;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECONDS_TO_WAIT;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_SECRETS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECURITY_OPT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_VOLUMES;
@@ -194,7 +195,8 @@ public class JobValidatorTest {
                             EMPTY_REGISTRATION, EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                             EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
                             EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
-                            EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_SECONDS_TO_WAIT);
+                            EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_SECONDS_TO_WAIT,
+                            EMPTY_SECRETS);
     final JobId recomputedId = job.toBuilder().build().getId();
     assertEquals(ImmutableSet.of("Id hash mismatch: " + job.getId().getHash()
         + " != " + recomputedId.getHash()), validator.validate(job));

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -15,6 +15,7 @@
     <masterImageName>helios-master:${project.version}</masterImageName>
     <agentImageName>helios-agent:${project.version}</agentImageName>
     <soloImageName>helios-solo:${project.version}</soloImageName>
+    <okhttp3.version>3.4.0</okhttp3.version>
   </properties>
 
   <profiles>
@@ -315,6 +316,11 @@
       <artifactId>jnr-unixsocket</artifactId>
       <version>0.8</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp3.version}</version>
+    </dependency>
 
     <!--test deps-->
     <dependency>
@@ -347,6 +353,12 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>${okhttp3.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -67,6 +67,8 @@ public class AgentConfig extends Configuration {
   private FastForwardConfig fastForwardConfig;
   private List<String> extraHosts;
   private boolean jobHistoryDisabled;
+  private InetSocketAddress secretVolumeManagerEndpoint;
+  private String secretVolumePath;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -377,4 +379,23 @@ public class AgentConfig extends Configuration {
     this.extraHosts = extraHosts;
     return this;
   }
+
+  public InetSocketAddress getSecretVolumeManagerEndpoint() {
+    return this.secretVolumeManagerEndpoint;
+  }
+
+  public AgentConfig setSecretVolumeManagerEndpoint(final InetSocketAddress endpoint) {
+    this.secretVolumeManagerEndpoint = endpoint;
+    return this;
+  }
+
+  public String getSecretVolumePath() {
+    return this.secretVolumePath;
+  }
+
+  public AgentConfig setSecretVolumePath(final String path) {
+    this.secretVolumePath = path;
+    return this;
+  }
+
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -296,7 +296,8 @@ public class AgentService extends AbstractIdleService implements Managed {
         metrics.getSupervisorMetrics(),
         namespace,
         config.getDomain(),
-        config.getDns());
+        config.getDns(),
+        secretVolumeManager(config));
 
     final ReactorFactory reactorFactory = new ReactorFactory();
 
@@ -345,6 +346,17 @@ public class AgentService extends AbstractIdleService implements Managed {
     }
     environment.lifecycle().manage(this);
   }
+
+  private SecretVolumeManager secretVolumeManager(final AgentConfig config) {
+    if (config.getSecretVolumeManagerEndpoint() != null
+        && config.getSecretVolumePath() != null) {
+      return new DefaultSecretVolumeManager(
+          DefaultSecretVolumeManager.urlFromAddr(config.getSecretVolumeManagerEndpoint()),
+          config.getSecretVolumePath());
+    }
+    return null;
+  }
+
 
   private DockerClient createDockerClient(final AgentConfig config,
                                           final RiemannFacade riemannFacade) {

--- a/helios-services/src/main/java/com/spotify/helios/agent/DefaultSecretVolumeManager.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/DefaultSecretVolumeManager.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+
+import com.spotify.helios.common.SecretVolumeException;
+import com.spotify.helios.common.descriptors.SecretVolumeRequest;
+import com.spotify.helios.common.descriptors.Secrets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Paths;
+
+import okhttp3.Call;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+
+public class DefaultSecretVolumeManager implements SecretVolumeManager {
+  private static final Logger log = LoggerFactory.getLogger(DefaultSecretVolumeManager.class);
+
+  private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+  private static final String SCHEME = "http";
+
+  private final OkHttpClient client;
+  private final SmallFileReader reader;
+  private final String baseUrl;
+  private final String path;
+
+  public DefaultSecretVolumeManager(final String baseUrl, final String path) {
+    this(new OkHttpClient(), new FsSmallFileReader(), baseUrl, path);
+  }
+
+  public DefaultSecretVolumeManager(final OkHttpClient client,
+                                    final SmallFileReader fileReader,
+                                    final String baseUrl,
+                                    final String path) {
+    this.client = client;
+    this.reader = fileReader;
+    this.baseUrl = baseUrl;
+    this.path = path;
+  }
+
+  public static String urlFromAddr(final InetSocketAddress addr) {
+    return new HttpUrl.Builder()
+        .scheme(SCHEME)
+        .host(addr.getHostString())
+        .port(addr.getPort())
+        .build()
+        .toString();
+  }
+
+  @Override
+  public String create(final String id, final Secrets secretsCfg) throws SecretVolumeException {
+    log.debug("Creating secret volume id {}", id);
+    final SecretVolumeRequest svr = secretVolumeRequest(id, secretsCfg);
+
+    final HttpUrl url = HttpUrl.parse(baseUrl)
+        .newBuilder()
+        .addEncodedPathSegment(id)
+        .build();
+
+    final Request request = new Request.Builder()
+        .url(url)
+        .post(RequestBody.create(JSON, svr.toJsonString()))
+        .build();
+
+    // TODO(negz): Is it okay to block on this call?
+    final Call call = client.newCall(request);
+    try (final Response response = call.execute()) {
+      if (!response.isSuccessful()) {
+        throw new SecretVolumeException(response.body().toString());
+      }
+    } catch (IOException e) {
+      throw new SecretVolumeException("unable to create secret volume", e);
+    }
+
+    return Paths.get(path, id).toString();
+  }
+
+  private SecretVolumeRequest secretVolumeRequest(final String id, final Secrets config)
+      throws SecretVolumeException {
+    if (config.getKeyPairFromHost() == null) {
+      throw new SecretVolumeException("must supply a path to a secret volume keypair");
+    }
+
+    try {
+      final String certData = reader.readToString(config.getKeyPairFromHost().getCertificate());
+      final String keyData = reader.readToString(config.getKeyPairFromHost().getPrivateKey());
+      return SecretVolumeRequest.create(id, config.getSource(), certData, keyData);
+    } catch (IOException e) {
+      throw new SecretVolumeException("Unable to read keypair file", e);
+    }
+  }
+
+  @Override
+  public void destroy(final String id) throws SecretVolumeException {
+    log.debug("Destroying secret volume id {}", id);
+    final HttpUrl url = HttpUrl.parse(baseUrl)
+        .newBuilder()
+        .addEncodedPathSegment(id)
+        .build();
+
+    final Request request = new Request.Builder()
+        .url(url)
+        .delete()
+        .build();
+
+    // TODO(negz): Is it okay to block on this call?
+    final Call call = client.newCall(request);
+    try (final Response response = call.execute()) {
+      if (!response.isSuccessful()) {
+        throw new SecretVolumeException(response.body().toString());
+      }
+    } catch (IOException e) {
+      throw new SecretVolumeException("unable to create secret volume", e);
+    }
+  }
+
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/FsSmallFileReader.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/FsSmallFileReader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class FsSmallFileReader implements SmallFileReader {
+
+  @Override
+  public String readToString(String path) throws IOException {
+    return new String(Files.readAllBytes(Paths.get(path)), Charset.defaultCharset());
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/SecretVolumeManager.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SecretVolumeManager.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+
+import com.spotify.helios.common.SecretVolumeException;
+import com.spotify.helios.common.descriptors.Secrets;
+
+
+public interface SecretVolumeManager {
+  String create(final String id, final Secrets secretsCfg) throws SecretVolumeException;
+
+  void destroy(final String id) throws SecretVolumeException;
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/SmallFileReader.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SmallFileReader.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+import java.io.IOException;
+
+
+public interface SmallFileReader {
+  String readToString(String path) throws IOException;
+}

--- a/helios-services/src/main/java/com/spotify/helios/agent/SupervisorFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/SupervisorFactory.java
@@ -49,6 +49,7 @@ public class SupervisorFactory {
   private final String defaultRegistrationDomain;
   private final List<String> dns;
   private final boolean agentRunningInContainer;
+  private final SecretVolumeManager secretVolumeManager;
 
   public SupervisorFactory(final AgentModel model, final DockerClient dockerClient,
                            final Map<String, String> envVars,
@@ -59,7 +60,8 @@ public class SupervisorFactory {
                            final SupervisorMetrics supervisorMetrics,
                            final String namespace,
                            final String defaultRegistrationDomain,
-                           final List<String> dns) {
+                           final List<String> dns,
+                           final SecretVolumeManager secretVolumeManager) {
     this.dockerClient = dockerClient;
     this.namespace = namespace;
     this.model = checkNotNull(model, "model");
@@ -73,6 +75,7 @@ public class SupervisorFactory {
                                                   "defaultRegistrationDomain");
     this.dns = checkNotNull(dns, "dns");
     this.agentRunningInContainer = checkIfAgentRunningInContainer();
+    this.secretVolumeManager = secretVolumeManager;
   }
 
   private static boolean checkIfAgentRunningInContainer() {
@@ -119,6 +122,7 @@ public class SupervisorFactory {
         .dockerClient(dockerClient)
         .healthChecker(healthChecker)
         .listener(taskMonitor)
+        .secretVolumeManager(secretVolumeManager)
         .build();
 
     return Supervisor.newBuilder()

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -35,6 +35,7 @@ import com.spotify.helios.common.descriptors.HttpHealthCheck;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.common.descriptors.Resources;
+import com.spotify.helios.common.descriptors.Secrets;
 import com.spotify.helios.common.descriptors.ServiceEndpoint;
 import com.spotify.helios.common.descriptors.ServicePortParameters;
 import com.spotify.helios.common.descriptors.ServicePorts;
@@ -302,6 +303,15 @@ public class TaskConfig {
     }
 
     return builder.build();
+  }
+
+  /**
+   * Get the secrets configuration for this task.
+   *
+   * @return The secrets configuration for the task, inherited from the job.
+   */
+  public Secrets secretsConfig() {
+    return job.getSecrets();
   }
 
   /**

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
@@ -39,6 +39,7 @@ public class TaskRunnerFactory {
   private final Optional<HealthChecker> healthChecker;
   private final ServiceRegistrar registrar;
   private final List<TaskRunner.Listener> listeners;
+  private final Optional<SecretVolumeManager> secretVolumeManager;
 
   public TaskRunnerFactory(final Builder builder) {
     this.taskConfig = checkNotNull(builder.config, "config");
@@ -46,6 +47,7 @@ public class TaskRunnerFactory {
     this.docker = checkNotNull(builder.docker, "docker");
     this.listeners = checkNotNull(builder.listeners, "listeners");
     this.healthChecker = Optional.fromNullable(builder.healthChecker);
+    this.secretVolumeManager = Optional.fromNullable(builder.secretVolumeManager);
   }
 
   public TaskRunner create(final long delay,
@@ -61,6 +63,7 @@ public class TaskRunnerFactory {
         .listener(new BroadcastingListener(concat(this.listeners, singletonList(listener))))
         .registrar(registrar)
         .secondsToWaitBeforeKill(secondsToWaitBeforeKill)
+        .secretVolumeManager(secretVolumeManager.orNull())
         .build();
   }
 
@@ -78,6 +81,7 @@ public class TaskRunnerFactory {
     private HealthChecker healthChecker;
     private ServiceRegistrar registrar;
     private List<TaskRunner.Listener> listeners = Lists.newArrayList();
+    private SecretVolumeManager secretVolumeManager;
 
     public Builder config(final TaskConfig config) {
       this.config = config;
@@ -101,6 +105,11 @@ public class TaskRunnerFactory {
 
     public Builder listener(final TaskRunner.Listener listener) {
       this.listeners.add(listener);
+      return this;
+    }
+
+    public Builder secretVolumeManager(final SecretVolumeManager manager) {
+      this.secretVolumeManager = manager;
       return this;
     }
 

--- a/helios-services/src/test/java/com/spotify/helios/agent/DefaultSecretVolumeManagerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/DefaultSecretVolumeManagerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.agent;
+
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import com.spotify.helios.common.descriptors.SecretVolumeRequest;
+import com.spotify.helios.common.descriptors.Secrets;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultSecretVolumeManagerTest {
+
+  private static OkHttpClient client = new OkHttpClient();
+  private static SmallFileReader reader = mock(SmallFileReader.class);
+  private static String path = "/host/secrets";
+
+  private final MockWebServer server = new MockWebServer();
+  private DefaultSecretVolumeManager manager;
+
+  @Before
+  public void setUp() throws Exception {
+    server.start();
+    manager = new DefaultSecretVolumeManager(client, reader, server.url("/").toString(), path);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.shutdown();
+  }
+
+  @Test
+  public void testCreate() throws Exception {
+    final String id = "derp";
+    final Secrets.Source source = Secrets.Source.TALOS;
+    final String pemData = "PEMPEMPEM";
+
+    doReturn(pemData).when(reader).readToString(anyString());
+
+    final String containerPath = "/container/secrets";
+    final Secrets secrets = Secrets.create(source, containerPath, "/cert", "/key");
+
+    server.enqueue(new MockResponse().setResponseCode(200));
+    assertEquals(path + '/' + id, manager.create(id, secrets));
+
+    final RecordedRequest request = server.takeRequest();
+    assertEquals("/" + id, request.getPath());
+    assertEquals("POST", request.getMethod());
+
+    final Map<String, List<String>> tags = emptyMap();
+    final SecretVolumeRequest svr = SecretVolumeRequest.create(id, source, pemData, pemData);
+    assertEquals(svr.toJsonString(), request.getBody().readUtf8());
+  }
+
+  @Test
+  public void testDestroy() throws Exception {
+    final String id = "derp";
+    server.enqueue(new MockResponse().setResponseCode(200));
+    manager.destroy(id);
+
+    final RecordedRequest request = server.takeRequest();
+    assertEquals("/" + id, request.getPath());
+    assertEquals("DELETE", request.getMethod());
+  }
+}

--- a/helios-services/src/test/resouces/logback-test.xml
+++ b/helios-services/src/test/resouces/logback-test.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright (c) 2016 Spotify AB.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.spotify.helios" level="debug"/>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
@@ -32,6 +32,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_RESOURCES;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECONDS_TO_WAIT;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_SECRETS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECURITY_OPT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_VOLUMES;
@@ -57,7 +58,7 @@ public class IdMismatchJobCreateTest extends SystemTestBase {
                 EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                 EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
                 EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
-                EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_SECONDS_TO_WAIT)
+                EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_SECONDS_TO_WAIT, EMPTY_SECRETS)
     ).get();
 
     // TODO (dano): Maybe this should be ID_MISMATCH but then JobValidator must become able to


### PR DESCRIPTION
# Overview

Allow Helios jobs to be configured to request a 'secret volume' be created containing the specific secrets for that job. Currently this is implemented by calling out to a sidecar service that actually procures and stores the secrets. The API of said sidecar service is explained [here](https://github.com/negz/secret-volume).
# The status quo

Currently at Spotify we typically run a script to procure secrets for a host from [Talos](https://github.com/spotify/talos) and then expose the directory containing those secrets by adding a bind volume to the relevant Helios job, i.e.:

``` json
"volumes" : {
  "/container/secrets:ro" : "/host/secrets"
}
```

Talos is a wrapper around Puppet's Hiera, and is typically used to store the secrets for a host, rather than a Helios job (i.e. container). Our client-side secrets procurement tooling follows this pattern, making it awkward to procure a different set of secrets per Helios job. This means secrets management tends to be one of the reasons we only deploy one container per host at Spotify, even if we might like to, for example, deploy a service in one container and supporting software like [ffwd](https://github.com/spotify/ffwd) in another with a different set of secrets exposed to each container.
# Proposal

This RFC proposes that Helios be able to procure secrets for each job that it runs. The actual job of downloading and storing the secrets is offloaded to a sidecar application. `secret-volume` is a reference implementation of such an application.

The Helios agent makes a 'create' API call to `secret-volume` specifying a unique identifier, a secret source like Talos, and a keypair to authenticate to said source. `secret-volume` authenticates to the secret source on behalf of a Helios job and stores its secrets in a `tmpfs` filesystem mounted at `/secrets/:id` on the filesystem of the Helios agent's host.

To make use of this functionality it must be enabled in both the Helios agent and Helios job. To enable it for the Helios agent first run `secret-volume` on the agent's host, then point the Helios agent at it:

```
$ export ADDR="127.0.0.1:10002"
$ export SECRETS="/secrets"
$ ./secret-volume --addr=${ADDR} --parent=${SECRETS} --talos-srv="_talos._tcp.example.org"
$ java com.spotify.helios.agent.AgentMain --secret-volume-manager=${ADDR} --secret-volume-path=${SECRETS} 
```

Once `secret-volume` and the Agent are running each job needs to be configured to enable secrets procurement. This is done by adding a clause to the job config:

``` json
"secrets" {
  "source": "Talos",
  "path": "/secrets",
  "keypairFromHost": {
    "certificate": "/path/to/pem/cert/on/host",
    "privateKey": "/path/to/pem/key/on/host"
  }
}
```

The above clause requests that Helios authenticate to Talos using the provided keypair on the Agent's host. The secrets will be automatically exposed inside the container at the path `/secrets`. Helios requests `secret-volume` procure and store secrets each time the `TaskRunner` tries to start a Docker container for a job, and requests the secrets be destroyed when the `TaskRunner` stops said Docker container.
# The future...

The aforementioned `keyPairFromHost` directive is included for compatibility with the status quo at Spotify. If rolled out at Spotify today this change would still use the Puppet host certificate to authenticate to Talos for each container - i.e. it would be functionally the same as the status quo - but it opens up the possibility to decouple authentication to Talos from the host's Puppet certificate, or to procure secrets from a different source altogether.
