### PR TITLE
Fix helios-use crash with Docker 1.12+

### DIFF
--- a/solo/helios-use
+++ b/solo/helios-use
@@ -29,7 +29,7 @@ if [ ! -z "$1" ]; then
 
   echo "Switching to $requested_version"
   docker pull "$REPO:$requested_version"
-  docker tag -f "$REPO:$requested_version" "$REPO:latest"
+  docker tag "$REPO:$requested_version" "$REPO:latest"
   echo
 
   new_version=$(get_helios_version)


### PR DESCRIPTION
The -f tag on docker tag has been removed in Docker 1.12 and causes a crash.

https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag