### PR TITLE
Prevent accidental undeploys by deployment groups

### DIFF
--- a/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
@@ -181,11 +181,11 @@ public class DeploymentGroupTest {
         changed);
 
     // Ensure ZK tasks are written to:
-    // - Perform a rolling update for the added (new) host and the unchanged host
     // - Perform a rolling undeploy for the removed (old) host
+    // - Perform a rolling update for the added (new) host and the unchanged host
     final List<RolloutTask> tasks = ImmutableList.<RolloutTask>builder()
-        .addAll(RollingUpdatePlanner.of(changed).plan(updateHostStatuses))
         .addAll(RollingUndeployPlanner.of(changed).plan(undeployHostStatuses))
+        .addAll(RollingUpdatePlanner.of(changed).plan(updateHostStatuses))
         .build();
 
     final ZooKeeperOperation setDeploymentGroupTasks = set(


### PR DESCRIPTION
Fix `ZooKeeperMasterModel.getInitRollingUpdateOps()` so that if both
`updateHosts` and `undeployHosts` have host Strings in common, we don't
generate unnecessary rollout tasks that undeploy from a host.

Remove hosts that are in `updateHosts` from `undeployHosts`.

Just to be safe, we list the undeploy tasks first as well.