### PR TITLE
try to fix flaky testRemovingAgentTagUndeploysJob

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -198,12 +198,15 @@ public class HostsResource {
       @PathParam("id") final String host,
       @QueryParam("status") @DefaultValue("") final String statusFilter) {
     final HostStatus status = model.getHostStatus(host);
+    final Optional<HostStatus> response;
     if (status != null &&
         (isNullOrEmpty(statusFilter) || statusFilter.equals(status.getStatus().toString()))) {
-      return Optional.of(status);
+      response = Optional.of(status);
     } else {
-      return Optional.absent();
+      response = Optional.absent();
     }
+    log.debug("hostStatus: host={}, statusFilter={}, returning: {}", host, statusFilter, response);
+    return response;
   }
 
   /**

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeregisterTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeregisterTest.java
@@ -23,7 +23,6 @@ import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
 import static com.spotify.helios.common.descriptors.TaskStatus.State.RUNNING;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import com.spotify.helios.TemporaryPorts;
 import com.spotify.helios.agent.AgentMain;
@@ -42,8 +41,6 @@ import com.spotify.helios.servicescommon.coordination.DefaultZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.Paths;
 
 import com.google.common.collect.ImmutableMap;
-
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -162,8 +159,7 @@ public class DeregisterTest extends SystemTestBase {
     // Wait for agent to come up
     awaitHostRegistered(client, host, LONG_WAIT_SECONDS, SECONDS);
     final HostStatus hostStatus1 =
-        awaitHostStatusWithLabels(client, host, UP, LONG_WAIT_SECONDS, SECONDS);
-    assertThat(hostStatus1.getLabels(), Matchers.hasEntry("num", "1"));
+        awaitHostStatusWithLabels(client, host, UP, ImmutableMap.of("num", "1"));
     // Wait for agent to be UP and report HostInfo
     awaitHostStatusWithHostInfo(client, host, UP, LONG_WAIT_SECONDS, SECONDS);
 
@@ -179,8 +175,7 @@ public class DeregisterTest extends SystemTestBase {
     // Check that the new host is registered
     awaitHostRegistered(client, host, LONG_WAIT_SECONDS, SECONDS);
     final HostStatus hostStatus2 =
-        awaitHostStatusWithLabels(client, host, UP, LONG_WAIT_SECONDS, SECONDS);
-    assertThat(hostStatus2.getLabels(), Matchers.hasEntry("num", "2"));
+        awaitHostStatusWithLabels(client, host, UP, ImmutableMap.of("num", "2"));
   }
 
   @Test(expected = TimeoutException.class)
@@ -238,9 +233,7 @@ public class DeregisterTest extends SystemTestBase {
 
     // Check that the new host is registered
     awaitHostRegistered(client, host, LONG_WAIT_SECONDS, SECONDS);
-    final HostStatus hostStatus2 =
-        awaitHostStatusWithLabels(client, host, UP, LONG_WAIT_SECONDS, SECONDS);
-    assertThat(hostStatus2.getLabels(), Matchers.hasEntry("num", "2"));
+    awaitHostStatusWithLabels(client, host, UP, ImmutableMap.of("num", "2"));
 
     // Check that the job we previously deployed is preserved
     awaitJobState(client, host, jobId, RUNNING, WAIT_TIMEOUT_SECONDS, SECONDS);


### PR DESCRIPTION
attempting to fix flakiness of testRemovingAgentTagUndeploysJob by
adjusting the logic of awaitHostStatusWithLabels in SystemTestBase

```
testRemovingAgentTagUndeploysJob - com.spotify.helios.system.DeploymentGroupTest
java.lang.AssertionError:
Expected: map containing ["another"->"label"]
     but: map was [<foo=bar>]
at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
at org.junit.Assert.assertThat(Assert.java:956)
at org.junit.Assert.assertThat(Assert.java:923)
at com.spotify.helios.system.DeploymentGroupTest.awaitUpWithLabel(DeploymentGroupTest.java:188)
at com.spotify.helios.system.DeploymentGroupTest.testRemovingAgentTagUndeploysJob(DeploymentGroupTest.java:243)
```

I am not positive if I actually changed anything of substance, besides adding better failure reasons when test assertions fail - but this commit has passed 3 of 4 runs in CircleCI (one timed out).