### PR TITLE
Fix for pull request #1022, set default report writer

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobReports.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobReports.java
@@ -99,6 +99,13 @@ public class TemporaryJobReports {
       }
     }
 
+    protected ReportWriter() {
+      jg = null;
+      testClassName = null;
+      testName = null;
+    }
+
+
     public Step step(final String step) {
       return new Step(this, step);
     }
@@ -118,7 +125,7 @@ public class TemporaryJobReports {
       writeEvent(event);
     }
 
-    private void writeEvent(final TemporaryJobEvent event) {
+    protected void writeEvent(final TemporaryJobEvent event) {
       if (jg == null) {
         return;
       }


### PR DESCRIPTION
ReportWriter does not have any public constructors, so
it was impossible to use the set default report writer option.

This adds protected constructor and protected writeEvent
method so ReportWriter can be inherited.
