### PR TITLE
update dependencies to fix issues with google-cloud-pubsub

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -239,10 +239,6 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -365,6 +361,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- google pubsub client requires protobuf v3 -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>18.0</version>
+        <version>19.0</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
the pubsub client requires v3 of protobuf and also uses methods in Guava that are only available after version 19 (such as`Futures.catching(..)`).

Note that it is possible that these changes break something else in the master, so let's hope the automated tests catch this (I have not yet run them myself).