### PR TITLE
Fix for pull request #1022, set default report writer

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
@@ -46,7 +46,9 @@ public class TemporaryJobJsonReports extends TemporaryJobReports {
 
   public TemporaryJobJsonReports(final Path outputDir) {
     this.outputDir = outputDir;
-    this.outputDir.toFile().mkdirs();
+    if (!this.outputDir.toFile().mkdirs()) {
+      throw new IllegalStateException(format("failed to create directory \"%s\"", outputDir));
+    }
   }
 
   public ReportWriter getWriterForTest(final Description testDescription) {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
@@ -81,9 +81,8 @@ public class TemporaryJobJsonReports extends TemporaryJobReports {
         jg.writeStartArray();
       } catch (IOException e) {
         log.error("exception creating event log: {} - {}", logFile.getAbsolutePath(), e);
-      } finally {
-        this.jg = jg;
       }
+      this.jg = jg;
     }
 
     private JsonReportWriter(final OutputStream outputStream) {
@@ -95,9 +94,8 @@ public class TemporaryJobJsonReports extends TemporaryJobReports {
         jg = new JsonFactory().createGenerator(outputStream, JsonEncoding.UTF8);
       } catch (IOException e) {
         log.error("exception creating event log: {}", e);
-      } finally {
-        this.jg = jg;
       }
+      this.jg = jg;
     }
 
     public Step step(final String step) {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
@@ -46,7 +46,8 @@ public class TemporaryJobJsonReports extends TemporaryJobReports {
 
   public TemporaryJobJsonReports(final Path outputDir) {
     this.outputDir = outputDir;
-    if (!this.outputDir.toFile().mkdirs()) {
+    final File path  = this.outputDir.toFile();
+    if (!path.mkdirs() && !path.isDirectory()) {
       throw new IllegalStateException(format("failed to create directory \"%s\"", outputDir));
     }
   }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobJsonReports.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.testing;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.spotify.helios.common.Json;
+import com.spotify.helios.testing.descriptors.TemporaryJobEvent;
+
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * Reports a stream of TemporaryJobEvent events to a JSON file.
+ */
+public class TemporaryJobJsonReports extends TemporaryJobReports {
+
+  private static final Logger log = LoggerFactory.getLogger(TemporaryJobJsonReports.class);
+
+  private final Path outputDir;
+
+  public TemporaryJobJsonReports(final Path outputDir) {
+    this.outputDir = outputDir;
+    this.outputDir.toFile().mkdirs();
+  }
+
+  public ReportWriter getWriterForTest(final Description testDescription) {
+    return new JsonReportWriter(
+        outputDir, testDescription.getClassName(), testDescription.getMethodName());
+  }
+
+  public ReportWriter getDefaultWriter() {
+    return new JsonReportWriter(System.err);
+  }
+
+  private static class JsonReportWriter extends ReportWriter {
+
+    private final JsonGenerator jg;
+
+    private final String testClassName;
+    private final String testName;
+
+    private JsonReportWriter(
+        final Path outputDir, final String testClassName, final String testName) {
+      this.testClassName = testClassName;
+      this.testName = testName;
+
+      final String logFilename = format("%s.%s.json", testClassName, testName).replace('$', '_');
+      final File logFile = outputDir.resolve(logFilename).toFile();
+
+      JsonGenerator jg = null;
+      try {
+        jg = new JsonFactory().createGenerator(logFile, JsonEncoding.UTF8);
+        jg.writeStartArray();
+      } catch (IOException e) {
+        log.error("exception creating event log: {} - {}", logFile.getAbsolutePath(), e);
+      } finally {
+        this.jg = jg;
+      }
+    }
+
+    private JsonReportWriter(final OutputStream outputStream) {
+      this.testClassName = null;
+      this.testName = null;
+
+      JsonGenerator jg = null;
+      try {
+        jg = new JsonFactory().createGenerator(outputStream, JsonEncoding.UTF8);
+      } catch (IOException e) {
+        log.error("exception creating event log: {}", e);
+      } finally {
+        this.jg = jg;
+      }
+    }
+
+    public Step step(final String step) {
+      return new Step(this, step);
+    }
+
+    protected void writeEvent(final String step, final double timestamp, final double duration,
+                              final Boolean success, final Map<String, Object> tags) {
+      final TemporaryJobEvent event = new TemporaryJobEvent(
+          timestamp,
+          duration,
+          testClassName,
+          testName,
+          step,
+          success,
+          tags
+      );
+
+      writeEvent(event);
+    }
+
+    private void writeEvent(final TemporaryJobEvent event) {
+      if (jg == null) {
+        return;
+      }
+
+      try {
+        Json.writer().writeValue(jg, event);
+      } catch (IOException e) {
+        log.error("exception writing event to log: {} - {}", event, e);
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (jg != null) {
+        jg.close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
ReportWriter does not have any public constructors, so
it was impossible to use.

This changeset refactores TemporaryJobReports into one
abstract class which does not do any IO, and one TemporaryJobJsonReports
which is used by default.

TemporaryJobs builder was changed to allow setting TemporaryJobsReports
instead of just default writer for greater controll.