### PR TITLE
Reduce use of host status more

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.master;
 
+import com.spotify.helios.common.descriptors.AgentInfo;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
@@ -48,6 +49,10 @@ public interface MasterModel {
    * Returns labels for {@code host}. Returns an empty map for hosts not found in the store.
    */
   Map<String, String> getHostLabels(String host);
+
+  boolean isHostUp(String host);
+
+  AgentInfo getAgentInfo(String host);
 
   void addJob(Job job) throws JobExistsException;
 

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -1728,6 +1728,17 @@ public class ZooKeeperMasterModel implements MasterModel {
     return labels == null ? emptyMap() : labels;
   }
 
+  @Override
+  public boolean isHostUp(final String host) {
+    final ZooKeeperClient client = provider.get("isHostUp");
+    return ZooKeeperRegistrarUtil.isHostRegistered(client, host) && checkHostUp(client, host);
+  }
+
+  @Override
+  public AgentInfo getAgentInfo(final String host) {
+    return getAgentInfo(provider.get("getAgentInfo"), host);
+  }
+
   private <T> T tryGetEntity(final ZooKeeperClient client, String path, TypeReference<T> type,
                              String name) {
     try {

--- a/helios-services/src/main/java/com/spotify/helios/master/reaper/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/reaper/DeadAgentReaper.java
@@ -20,7 +20,6 @@ package com.spotify.helios.master.reaper;
 import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.common.descriptors.AgentInfo;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.master.MasterModel;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -76,13 +75,12 @@ public class DeadAgentReaper extends RateLimitedService<String> {
   @Override
   void processItem(final String agent) {
     try {
-      final HostStatus hostStatus = masterModel.getHostStatus(agent);
-      if (hostStatus == null || hostStatus.getStatus() != HostStatus.Status.DOWN) {
-        // Host not found or host not DOWN -- nothing to do
+      if (masterModel.isHostUp(agent)) {
+        // Host UP -- nothing to do
         return;
       }
 
-      final AgentInfo agentInfo = hostStatus.getAgentInfo();
+      final AgentInfo agentInfo = masterModel.getAgentInfo(agent);
       if (agentInfo == null) {
         return;
       }

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUndeployPlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUndeployPlanner.java
@@ -20,15 +20,12 @@ package com.spotify.helios.rollingupdate;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class RollingUndeployPlanner implements RolloutPlanner {
 
@@ -43,14 +40,7 @@ public class RollingUndeployPlanner implements RolloutPlanner {
   }
 
   @Override
-  public List<RolloutTask> plan(final Map<String, HostStatus> hostsAndStatuses) {
-    // we only care about hosts that are UP
-    final List<String> hosts = hostsAndStatuses.entrySet()
-        .stream()
-        .filter(entry -> entry.getValue().getStatus().equals(HostStatus.Status.UP))
-        .map(entry -> entry.getKey())
-        .collect(Collectors.toList());
-
+  public List<RolloutTask> plan(final List<String> hosts) {
     // generate the rollout tasks
     final List<RolloutTask> rolloutTasks = Lists.newArrayList();
     final int parallelism = deploymentGroup.getRolloutOptions() != null

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdatePlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdatePlanner.java
@@ -20,14 +20,12 @@ package com.spotify.helios.rollingupdate;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.List;
-import java.util.Map;
 
 public class RollingUpdatePlanner implements RolloutPlanner {
 
@@ -42,15 +40,7 @@ public class RollingUpdatePlanner implements RolloutPlanner {
   }
 
   @Override
-  public List<RolloutTask> plan(final Map<String, HostStatus> hostsAndStatuses) {
-    // we only care about hosts that are UP
-    final List<String> hosts = Lists.newArrayList();
-    for (final Map.Entry<String, HostStatus> entry : hostsAndStatuses.entrySet()) {
-      if (entry.getValue().getStatus().equals(HostStatus.Status.UP)) {
-        hosts.add(entry.getKey());
-      }
-    }
-
+  public List<RolloutTask> plan(final List<String> hosts) {
     // generate the rollout tasks
     final List<RolloutTask> rolloutTasks = Lists.newArrayList();
     final int parallelism = deploymentGroup.getRolloutOptions() != null ?

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateService.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateService.java
@@ -22,7 +22,6 @@ import static com.spotify.helios.servicescommon.Reactor.Callback;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.master.HostMatcher;
 import com.spotify.helios.master.MasterModel;
 import com.spotify.helios.servicescommon.Reactor;
@@ -95,10 +94,7 @@ public class RollingUpdateService extends AbstractIdleService {
 
       // determine all hosts and their labels
       for (final String host : allHosts) {
-        final HostStatus hostStatus = masterModel.getHostStatus(host);
-        if (hostStatus != null) {
-          hostsToLabels.put(host, hostStatus.getLabels());
-        }
+        hostsToLabels.put(host, masterModel.getHostLabels(host));
       }
 
       final HostMatcher hostMatcher = new HostMatcher(hostsToLabels);

--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RolloutPlanner.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RolloutPlanner.java
@@ -17,12 +17,15 @@
 
 package com.spotify.helios.rollingupdate;
 
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
 import java.util.List;
-import java.util.Map;
 
 public interface RolloutPlanner {
-  List<RolloutTask> plan(final Map<String, HostStatus> hostsAndStatuses);
+
+  /**
+   * Returns a list of {@link RolloutTask}s.
+   * Caller is responsible for passing in a list of hosts that are up.
+   */
+  List<RolloutTask> plan(final List<String> hosts);
 }

--- a/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
@@ -22,6 +22,7 @@ import static com.spotify.helios.common.descriptors.DeploymentGroup.RollingUpdat
 import static com.spotify.helios.common.descriptors.DeploymentGroupStatus.State.DONE;
 import static com.spotify.helios.common.descriptors.DeploymentGroupStatus.State.FAILED;
 import static com.spotify.helios.servicescommon.coordination.ZooKeeperOperations.set;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
@@ -150,8 +151,8 @@ public class DeploymentGroupTest {
     // Setup some hosts
     final String oldHost = "host1";
     final String newHost = "host2";
-    final Map<String, HostStatus> undeployHostStatuses = mockHostStatus(masterModel, oldHost);
-    final Map<String, HostStatus> updateHostStatuses = mockHostStatus(masterModel, newHost);
+    client.ensurePath(Paths.statusHostUp(oldHost));
+    client.ensurePath(Paths.statusHostUp(newHost));
 
     // Give the deployment group a host.
     client.setData(
@@ -184,8 +185,8 @@ public class DeploymentGroupTest {
     // - Perform a rolling undeploy for the removed (old) host
     // - Perform a rolling update for the added (new) host and the unchanged host
     final List<RolloutTask> tasks = ImmutableList.<RolloutTask>builder()
-        .addAll(RollingUndeployPlanner.of(changed).plan(undeployHostStatuses))
-        .addAll(RollingUpdatePlanner.of(changed).plan(updateHostStatuses))
+        .addAll(RollingUndeployPlanner.of(changed).plan(singletonList(oldHost)))
+        .addAll(RollingUpdatePlanner.of(changed).plan(singletonList(newHost)))
         .build();
 
     final ZooKeeperOperation setDeploymentGroupTasks = set(

--- a/helios-services/src/test/java/com/spotify/helios/master/reaper/DeadAgentReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/reaper/DeadAgentReaperTest.java
@@ -21,16 +21,12 @@ import com.google.common.collect.Lists;
 
 import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.descriptors.AgentInfo;
-import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.HostStatus;
-import com.spotify.helios.common.descriptors.JobId;
-import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.master.MasterModel;
 
 import org.joda.time.Instant;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -85,16 +81,12 @@ public class DeadAgentReaperTest {
         datapoints.stream().map(input -> input.host).collect(Collectors.toList())));
 
     for (final Datapoint datapoint : datapoints) {
-      when(masterModel.getHostStatus(datapoint.host)).thenReturn(
-          HostStatus.newBuilder()
-              .setStatus(datapoint.status)
-              .setAgentInfo(AgentInfo.newBuilder()
+      when(masterModel.isHostUp(datapoint.host))
+          .thenReturn(HostStatus.Status.UP == datapoint.status);
+      when(masterModel.getAgentInfo(datapoint.host)).thenReturn(AgentInfo.newBuilder()
                                 .setStartTime(datapoint.startTime)
                                 .setUptime(datapoint.uptime)
-                                .build())
-              .setJobs(Collections.<JobId, Deployment>emptyMap())
-              .setStatuses(Collections.<JobId, TaskStatus>emptyMap())
-              .build());
+                                .build());
     }
 
     final DeadAgentReaper reaper = new DeadAgentReaper(masterModel, TIMEOUT_HOURS, clock, 100, 0);

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUndeployPlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUndeployPlannerTest.java
@@ -19,23 +19,22 @@ package com.spotify.helios.rollingupdate;
 
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Map;
 
 public class RollingUndeployPlannerTest {
+
+  private static final List<String> HOSTS =
+      ImmutableList.of("agent1", "agent2", "agent3", "agent4");
 
   @Test
   public void testSerialRollout() {
@@ -44,18 +43,10 @@ public class RollingUndeployPlannerTest {
                                .setParallelism(1)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUndeployPlanner.of(deploymentGroup);
 
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.FORCE_UNDEPLOY_JOBS, "agent1"),
@@ -81,18 +72,10 @@ public class RollingUndeployPlannerTest {
                                .setParallelism(2)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUndeployPlanner.of(deploymentGroup);
 
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.FORCE_UNDEPLOY_JOBS, "agent1"),
@@ -118,18 +101,10 @@ public class RollingUndeployPlannerTest {
                                .setParallelism(3)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUndeployPlanner.of(deploymentGroup);
 
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.FORCE_UNDEPLOY_JOBS, "agent1"),

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdatePlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdatePlannerTest.java
@@ -18,24 +18,23 @@
 package com.spotify.helios.rollingupdate;
 
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import com.spotify.helios.common.descriptors.DeploymentGroup;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.RolloutTask;
 
 import org.junit.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class RollingUpdatePlannerTest {
+
+  private static final List<String> HOSTS =
+      ImmutableList.of("agent1", "agent2", "agent3", "agent4");
 
   @Test
   public void testSerialRollout() {
@@ -44,18 +43,10 @@ public class RollingUpdatePlannerTest {
                                .setParallelism(1)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
 
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent1"),
@@ -81,18 +72,10 @@ public class RollingUpdatePlannerTest {
                                .setParallelism(2)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
 
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent1"),
@@ -118,18 +101,10 @@ public class RollingUpdatePlannerTest {
                                .setParallelism(3)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
 
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.UNDEPLOY_OLD_JOBS, "agent1"),
@@ -153,17 +128,9 @@ public class RollingUpdatePlannerTest {
     final DeploymentGroup deploymentGroup = DeploymentGroup.newBuilder()
         .setRolloutOptions(RolloutOptions.newBuilder().setOverlap(true).build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent1"),
@@ -190,17 +157,9 @@ public class RollingUpdatePlannerTest {
                                .setParallelism(2)
                                .build())
         .build();
-    final HostStatus statusUp = mock(HostStatus.class);
-    when(statusUp.getStatus()).thenReturn(HostStatus.Status.UP);
-    final Map<String, HostStatus> hostsAndStatuses = ImmutableMap.of(
-        "agent1", statusUp,
-        "agent2", statusUp,
-        "agent3", statusUp,
-        "agent4", statusUp
-    );
 
     final RolloutPlanner rolloutPlanner = RollingUpdatePlanner.of(deploymentGroup);
-    final List<RolloutTask> tasks = rolloutPlanner.plan(hostsAndStatuses);
+    final List<RolloutTask> tasks = rolloutPlanner.plan(HOSTS);
 
     final List<RolloutTask> expected = Lists.newArrayList(
         RolloutTask.of(RolloutTask.Action.DEPLOY_NEW_JOB, "agent1"),


### PR DESCRIPTION
Add `isHostUp()` and `getAgentInfo()` to `MasterModel`
so that `DeadAgentReaper` doesn't need to get the entire
`HostStatus`. This should alleviate pressure on ZK.