### PR TITLE
Use host status even less

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -17,6 +17,7 @@
 
 package com.spotify.helios.master;
 
+import com.spotify.helios.common.descriptors.AgentInfo;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.DeploymentGroupStatus;
@@ -48,6 +49,10 @@ public interface MasterModel {
    * Returns labels for {@code host}. Returns an empty map for hosts not found in the store.
    */
   Map<String, String> getHostLabels(String host);
+
+  boolean isHostUp(String host);
+
+  AgentInfo getAgentInfo(String host);
 
   void addJob(Job job) throws JobExistsException;
 

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -1728,6 +1728,17 @@ public class ZooKeeperMasterModel implements MasterModel {
     return labels == null ? emptyMap() : labels;
   }
 
+  @Override
+  public boolean isHostUp(final String host) {
+    final ZooKeeperClient client = provider.get("isHostUp");
+    return ZooKeeperRegistrarUtil.isHostRegistered(client, host) && checkHostUp(client, host);
+  }
+
+  @Override
+  public AgentInfo getAgentInfo(final String host) {
+    return getAgentInfo(provider.get("getAgentInfo"), host);
+  }
+
   private <T> T tryGetEntity(final ZooKeeperClient client, String path, TypeReference<T> type,
                              String name) {
     try {

--- a/helios-services/src/main/java/com/spotify/helios/master/reaper/DeadAgentReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/reaper/DeadAgentReaper.java
@@ -20,7 +20,6 @@ package com.spotify.helios.master.reaper;
 import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.SystemClock;
 import com.spotify.helios.common.descriptors.AgentInfo;
-import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.master.MasterModel;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -76,13 +75,12 @@ public class DeadAgentReaper extends RateLimitedService<String> {
   @Override
   void processItem(final String agent) {
     try {
-      final HostStatus hostStatus = masterModel.getHostStatus(agent);
-      if (hostStatus == null || hostStatus.getStatus() != HostStatus.Status.DOWN) {
-        // Host not found or host not DOWN -- nothing to do
+      if (masterModel.isHostUp(agent)) {
+        // Host UP -- nothing to do
         return;
       }
 
-      final AgentInfo agentInfo = hostStatus.getAgentInfo();
+      final AgentInfo agentInfo = masterModel.getAgentInfo(agent);
       if (agentInfo == null) {
         return;
       }

--- a/helios-services/src/test/java/com/spotify/helios/master/reaper/DeadAgentReaperTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/reaper/DeadAgentReaperTest.java
@@ -21,16 +21,12 @@ import com.google.common.collect.Lists;
 
 import com.spotify.helios.common.Clock;
 import com.spotify.helios.common.descriptors.AgentInfo;
-import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.HostStatus;
-import com.spotify.helios.common.descriptors.JobId;
-import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.master.MasterModel;
 
 import org.joda.time.Instant;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -85,16 +81,12 @@ public class DeadAgentReaperTest {
         datapoints.stream().map(input -> input.host).collect(Collectors.toList())));
 
     for (final Datapoint datapoint : datapoints) {
-      when(masterModel.getHostStatus(datapoint.host)).thenReturn(
-          HostStatus.newBuilder()
-              .setStatus(datapoint.status)
-              .setAgentInfo(AgentInfo.newBuilder()
+      when(masterModel.isHostUp(datapoint.host))
+          .thenReturn(HostStatus.Status.UP == datapoint.status);
+      when(masterModel.getAgentInfo(datapoint.host)).thenReturn(AgentInfo.newBuilder()
                                 .setStartTime(datapoint.startTime)
                                 .setUptime(datapoint.uptime)
-                                .build())
-              .setJobs(Collections.<JobId, Deployment>emptyMap())
-              .setStatuses(Collections.<JobId, TaskStatus>emptyMap())
-              .build());
+                                .build());
     }
 
     final DeadAgentReaper reaper = new DeadAgentReaper(masterModel, TIMEOUT_HOURS, clock, 100, 0);


### PR DESCRIPTION
Add `isHostUp()` and `getAgentInfo()` to `MasterModel`
so that `DeadAgentReaper` doesn't need to get the entire
`HostStatus`. This should alleviate pressure on ZK.