### PR TITLE
monitor how often zookeeper connection state changes

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ReportingZooKeeperClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ReportingZooKeeperClient.java
@@ -18,7 +18,6 @@
 package com.spotify.helios.servicescommon.coordination;
 
 import com.fasterxml.jackson.databind.JavaType;
-
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.transaction.CuratorTransactionResult;
 import org.apache.curator.framework.listen.Listenable;
@@ -202,6 +201,8 @@ public class ReportingZooKeeperClient implements ZooKeeperClient {
   @Override
   public void start() {
     client.start();
+    client.getConnectionStateListenable().addListener(
+        (client, newState) -> reporter.connectionStateChanged(newState));
   }
 
   @Override

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperModelReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperModelReporter.java
@@ -17,16 +17,18 @@
 
 package com.spotify.helios.servicescommon.coordination;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
+import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.codahale.metrics.Clock;
 import com.spotify.helios.servicescommon.NoOpRiemannClient;
 import com.spotify.helios.servicescommon.RiemannFacade;
 import com.spotify.helios.servicescommon.statistics.NoopZooKeeperMetrics;
 import com.spotify.helios.servicescommon.statistics.ZooKeeperMetrics;
 
+import com.codahale.metrics.Clock;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.curator.framework.state.ConnectionState;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.ConnectionLossException;
 import org.apache.zookeeper.KeeperException.OperationTimeoutException;
@@ -34,8 +36,6 @@ import org.apache.zookeeper.KeeperException.RuntimeInconsistencyException;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ZooKeeperModelReporter {
   private final RiemannFacade riemannFacade;
@@ -87,6 +87,10 @@ public class ZooKeeperModelReporter {
     } finally {
       metrics.updateTimer(name, clock.getTick() - startTime, TimeUnit.NANOSECONDS);
     }
+  }
+
+  public void connectionStateChanged(final ConnectionState newState) {
+    metrics.connectionStateChanged(newState);
   }
 
   public static ZooKeeperModelReporter noop() {

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/NoopZooKeeperMetrics.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/NoopZooKeeperMetrics.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.servicescommon.statistics;
 
+import org.apache.curator.framework.state.ConnectionState;
+
 import java.util.concurrent.TimeUnit;
 
 public class NoopZooKeeperMetrics implements ZooKeeperMetrics {
@@ -25,5 +27,9 @@ public class NoopZooKeeperMetrics implements ZooKeeperMetrics {
 
   @Override
   public void updateTimer(String name, long duration, TimeUnit timeUnit) {
+  }
+
+  @Override
+  public void connectionStateChanged(final ConnectionState newState) {
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetrics.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetrics.java
@@ -17,6 +17,8 @@
 
 package com.spotify.helios.servicescommon.statistics;
 
+import org.apache.curator.framework.state.ConnectionState;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -37,4 +39,6 @@ public interface ZooKeeperMetrics {
    * @param timeUnit Time unit of the duration.
    */
   void updateTimer(String name, long duration, TimeUnit timeUnit);
+
+  void connectionStateChanged(ConnectionState newState);
 }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetricsImpl.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/ZooKeeperMetricsImpl.java
@@ -17,7 +17,6 @@
 
 package com.spotify.helios.servicescommon.statistics;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
@@ -28,20 +27,17 @@ public class ZooKeeperMetricsImpl implements ZooKeeperMetrics {
   private static final String TYPE = "zookeeper";
 
   private final String prefix;
-  private final Counter transientErrorCounter;
   private final Meter transientErrorMeter;
   private final MetricRegistry registry;
 
   public ZooKeeperMetricsImpl(final String group, final MetricRegistry registry) {
     prefix = MetricRegistry.name(group, TYPE) + ".";
     this.registry = registry;
-    transientErrorCounter = registry.counter(prefix + "transient_error_count");
     transientErrorMeter = registry.meter(prefix + "transient_error_meter");
   }
 
   @Override
   public void zookeeperTransientError() {
-    transientErrorCounter.inc();
     transientErrorMeter.mark();
   }
 


### PR DESCRIPTION
Adds meters for how often the state of the zookeeper connection changes.

Intended to help monitor issues where the masters or agents continually disconnect/reconnect from Zookeeper (for example, if the masters are in a loop where they continually send bad or too-large requests to ZK, which causes the connection to be dropped by the ZK server).