### PR TITLE
More robust cleanup of removed hosts for deployment groups

### DIFF
--- a/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
@@ -151,6 +151,8 @@ public class DeploymentGroupTest {
     // Setup some hosts
     final String oldHost = "host1";
     final String newHost = "host2";
+    client.ensurePath(Paths.configHost(oldHost));
+    client.ensurePath(Paths.configHost(newHost));
     client.ensurePath(Paths.statusHostUp(oldHost));
     client.ensurePath(Paths.statusHostUp(newHost));
 


### PR DESCRIPTION
Instead of the previous method where we would try to undeploy from hosts
that were no longer registered, instead just apply a straightforward filter
to the removed hosts list.

This is clearer and works without generating a bunch of unnecessary tasks.
Also, the previous version would only work if the set of UP hosts for the
deployment group changed. This version doesn't have that flaw.

This reverts commit 6412fc02d1c18915e3f6f31f1817b9cfc030e309.