### PR TITLE
use same pubsub topic in healthchecks as the EventSender

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -24,6 +24,7 @@ import static com.spotify.helios.servicescommon.ZooKeeperAclProviders.digest;
 import static com.spotify.helios.servicescommon.ZooKeeperAclProviders.heliosAclProvider;
 
 import com.spotify.helios.common.HeliosRuntimeException;
+import com.spotify.helios.common.descriptors.TaskStatusEvent;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.HealthCheckGauge;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;
@@ -200,11 +201,14 @@ public class MasterService extends AbstractIdleService {
       }
     }
 
+    final String deploymentGroupEventTopic = TaskStatusEvent.TASK_STATUS_EVENT_TOPIC;
+
     final List<EventSender> eventSenders =
-        EventSenderFactory.build(environment, config, metricsRegistry);
+        EventSenderFactory.build(environment, config, metricsRegistry, deploymentGroupEventTopic);
 
     final ZooKeeperMasterModel model =
-        new ZooKeeperMasterModel(zkClientProvider, config.getName(), eventSenders);
+        new ZooKeeperMasterModel(zkClientProvider, config.getName(), eventSenders,
+            deploymentGroupEventTopic);
 
     final ZooKeeperHealthChecker zooKeeperHealthChecker = new ZooKeeperHealthChecker(
         zooKeeperClient, Paths.statusMasters(), riemannFacade, TimeUnit.MINUTES, 2);

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -89,8 +89,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-
-import java.util.stream.Collectors;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.BadVersionException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
@@ -111,6 +109,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * The Helios Master's view into ZooKeeper.
@@ -146,14 +145,13 @@ public class ZooKeeperMasterModel implements MasterModel {
       STRING_LIST_TYPE =
       new TypeReference<List<String>>() {};
 
-  private static final String DEPLOYMENT_GROUP_EVENT_TOPIC = "HeliosDeploymentGroupEvents";
   private static final DeploymentGroupEventFactory DEPLOYMENT_GROUP_EVENT_FACTORY =
       new DeploymentGroupEventFactory();
 
   private final ZooKeeperClientProvider provider;
   private final String name;
   private final List<EventSender> eventSenders;
-
+  private final String deploymentGroupEventTopic;
   /**
    * Constructor
    * @param provider         {@link ZooKeeperClientProvider}
@@ -162,10 +160,12 @@ public class ZooKeeperMasterModel implements MasterModel {
    */
   public ZooKeeperMasterModel(final ZooKeeperClientProvider provider,
                               final String name,
-                              final List<EventSender> eventSenders) {
+                              final List<EventSender> eventSenders,
+                              final String deploymentGroupEventTopic) {
     this.provider = Preconditions.checkNotNull(provider);
     this.name = Preconditions.checkNotNull(name);
     this.eventSenders = Preconditions.checkNotNull(eventSenders);
+    this.deploymentGroupEventTopic = deploymentGroupEventTopic;
   }
 
   /**
@@ -584,7 +584,7 @@ public class ZooKeeperMasterModel implements MasterModel {
           groupName, deploymentGroup.getJobId(), ops);
 
       client.transaction(ops);
-      emitEvents(DEPLOYMENT_GROUP_EVENT_TOPIC, events);
+      emitEvents(deploymentGroupEventTopic, events);
     } catch (BadVersionException e) {
       // some other master beat us in processing this host update. not exceptional.
       // ideally we would check the path in the exception, but curator doesn't provide a path
@@ -633,7 +633,7 @@ public class ZooKeeperMasterModel implements MasterModel {
 
       client.transaction(operations);
 
-      emitEvents(DEPLOYMENT_GROUP_EVENT_TOPIC, op.events());
+      emitEvents(deploymentGroupEventTopic, op.events());
       log.info("initiated rolling-update on deployment-group: name={}, jobId={}",
           deploymentGroup.getName(), jobId);
     } catch (final NoNodeException e) {
@@ -786,7 +786,7 @@ public class ZooKeeperMasterModel implements MasterModel {
 
           try {
             client.transaction(ops);
-            emitEvents(DEPLOYMENT_GROUP_EVENT_TOPIC, op.events());
+            emitEvents(deploymentGroupEventTopic, op.events());
           } catch (BadVersionException e) {
             // some other master beat us in processing this rolling update step. not exceptional.
             // ideally we would check the path in the exception, but curator doesn't provide a path

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/EventSenderFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/EventSenderFactory.java
@@ -42,7 +42,7 @@ public final class EventSenderFactory {
   public static List<EventSender> build(
       final Environment environment,
       final CommonConfiguration<?> config,
-      final MetricRegistry metricRegistry) {
+      final MetricRegistry metricRegistry, final String pubsubHealthcheckTopic) {
 
     final List<EventSender> senders = new ArrayList<>();
 
@@ -66,8 +66,13 @@ public final class EventSenderFactory {
               .build()
       );
 
+      // choose an arbitrary prefix to use in the healthcheck. we assume if we can connect to
+      // one we can connect to all
+      final String topicToHealthcheck =
+          config.getPubsubPrefixes().iterator().next() + pubsubHealthcheckTopic;
+
       final GooglePubSubSender.DefaultHealthChecker healthchecker =
-          new GooglePubSubSender.DefaultHealthChecker(pubsub, "health.canary", executor,
+          new GooglePubSubSender.DefaultHealthChecker(pubsub, topicToHealthcheck, executor,
               Duration.ofMinutes(5));
 
       metricRegistry.register("pubsub-health", (Gauge<Boolean>) healthchecker::isHealthy);

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskHistoryWriterTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskHistoryWriterTest.java
@@ -17,8 +17,15 @@
 
 package com.spotify.helios.agent;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import static com.spotify.helios.Polling.await;
+import static com.spotify.helios.common.descriptors.Goal.START;
+import static org.apache.zookeeper.KeeperException.ConnectionLossException;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import com.spotify.helios.Polling;
 import com.spotify.helios.ZooKeeperTestManager;
@@ -36,6 +43,8 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperModelReporter;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import org.apache.zookeeper.KeeperException;
 import org.junit.After;
 import org.junit.Before;
@@ -50,16 +59,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.spotify.helios.Polling.await;
-import static com.spotify.helios.common.descriptors.Goal.START;
-import static org.apache.zookeeper.KeeperException.ConnectionLossException;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.AdditionalAnswers.delegatesTo;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 
 public class TaskHistoryWriterTest {
 
@@ -98,7 +97,8 @@ public class TaskHistoryWriterTest {
 
     final List<EventSender> eventSenders = Collections.emptyList();
 
-    masterModel = new ZooKeeperMasterModel(zkProvider, "test", eventSenders);
+    masterModel = new ZooKeeperMasterModel(zkProvider, "test", eventSenders,
+        TaskStatusEvent.TASK_STATUS_EVENT_TOPIC);
 
     client.ensurePath(Paths.configJobs());
     client.ensurePath(Paths.configJobRefs());

--- a/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/DeploymentGroupTest.java
@@ -56,8 +56,6 @@ import com.spotify.helios.servicescommon.coordination.ZooKeeperModelReporter;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperOperation;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -78,7 +76,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @RunWith(Theories.class)
 public class DeploymentGroupTest {
@@ -112,11 +109,12 @@ public class DeploymentGroupTest {
     zkServer.close();
   }
 
-  private Map<String, HostStatus> mockHostStatus(final MasterModel model, final String host) {
-    final HostStatus statusUp = mock(HostStatus.class);
-    doReturn(HostStatus.Status.UP).when(statusUp).getStatus();
-    doReturn(statusUp).when(model).getHostStatus(host);
-    return ImmutableMap.of(host, statusUp);
+  private ZooKeeperMasterModel newMasterModel(final ZooKeeperClient client) {
+    return new ZooKeeperMasterModel(
+        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop()),
+        getClass().getName(),
+        Collections.emptyList(),
+        "");
   }
 
   // A test that ensures healthy deployment groups will perform a rolling update when their hosts
@@ -124,10 +122,7 @@ public class DeploymentGroupTest {
   @Test
   public void testUpdateDeploymentGroupHosts() throws Exception {
     final ZooKeeperClient client = spy(this.client);
-    final ZooKeeperMasterModel masterModel = spy(new ZooKeeperMasterModel(
-        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop()),
-        getClass().getName(),
-        Collections.emptyList()));
+    final ZooKeeperMasterModel masterModel = spy(newMasterModel(client));
 
     // Return a job so we can add a real deployment group.
     final Job job = Job.newBuilder()
@@ -206,10 +201,7 @@ public class DeploymentGroupTest {
   @Test
   public void testUpdateFailedHostsChangedDeploymentGroupHosts() throws Exception {
     final ZooKeeperClient client = spy(this.client);
-    final ZooKeeperMasterModel masterModel = spy(new ZooKeeperMasterModel(
-        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop()),
-        getClass().getName(),
-        Collections.emptyList()));
+    final ZooKeeperMasterModel masterModel = spy(newMasterModel(client));
 
     // Return a job so we can add a real deployment group.
     final Job job = Job.newBuilder()
@@ -262,10 +254,7 @@ public class DeploymentGroupTest {
   @Test
   public void testUpdateFailedManualDeploymentGroupHosts() throws Exception {
     final ZooKeeperClient client = spy(this.client);
-    final ZooKeeperMasterModel masterModel = spy(new ZooKeeperMasterModel(
-        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop()),
-        getClass().getName(),
-        Collections.emptyList()));
+    final ZooKeeperMasterModel masterModel = spy(newMasterModel(client));
 
     // Return a job so we can add a real deployment group.
     final Job job = Job.newBuilder()
@@ -336,10 +325,7 @@ public class DeploymentGroupTest {
     when(client.exists(Paths.statusDeploymentGroupTasks(GROUP_NAME)))
         .thenReturn(tasksExist ? mock(Stat.class) : null);
 
-    final ZooKeeperMasterModel masterModel = new ZooKeeperMasterModel(
-        new ZooKeeperClientProvider(client, ZooKeeperModelReporter.noop()),
-        getClass().getName(),
-        Collections.emptyList());
+    final ZooKeeperMasterModel masterModel = newMasterModel(client);
 
     if (dgExists) {
       final DeploymentGroup dg = DeploymentGroup.newBuilder()

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/UndeployFilteringTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/UndeployFilteringTest.java
@@ -56,7 +56,6 @@ public class UndeployFilteringTest extends SystemTestBase {
   private static final String TEST_HOST = "testhost";
 
   private CuratorFramework curator;
-  private ZooKeeperClientProvider zkcp;
   private ZooKeeperMasterModel zkMasterModel;
   private AgentMain agent;
   private HeliosClient client;
@@ -74,12 +73,12 @@ public class UndeployFilteringTest extends SystemTestBase {
     // make zookeeper interfaces
     curator = zk().curatorWithSuperAuth();
 
-    zkcp = new ZooKeeperClientProvider(
+    final ZooKeeperClientProvider zkcp = new ZooKeeperClientProvider(
         new DefaultZooKeeperClient(curator), ZooKeeperModelReporter.noop());
 
     final List<EventSender> eventSenders = Collections.emptyList();
 
-    zkMasterModel = new ZooKeeperMasterModel(zkcp, getClass().getName(), eventSenders);
+    zkMasterModel = new ZooKeeperMasterModel(zkcp, getClass().getName(), eventSenders, "");
     startDefaultMaster();
 
     agent = startDefaultAgent(TEST_HOST);


### PR DESCRIPTION
Previously the EventSenderFactory is passing a hardcoded `health.canary`
topic name to GooglePubSubSender$DefaultHealthChecker. The assumption
here was that if the client could successfully access the Cloud PubSub
API then it could check to see if any topic existed.

However it is possible for the PubSub credentials to be limited to only
publish and even *see* certain topics within a project. This would cause
the healthchecker to get `PERMISSION_DENIED` when checking if the
healthcheck topic existed.

To fix this, use the same topic name in the healthchecker as what will
eventually be published to.

Refactored the ZooKeeperAgentModel/MasterModel so that the topic name to
publish to is passed in as a constructor argument rather than being
hardcoded, so that the Agent/MasterService that constructs the Model
class can control that the same topic is used both in the healthchecker
and the eventSender.