### PR TITLE
remove extra quote from volume format example

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -348,7 +348,7 @@ container path to mount a file or directory from the host.
 The container path can be suffixed with "rw" or "ro" to create a read-write or
 read-only volume, respectively.
 
-Format: `[container-path]:[rw|ro]":[host-path]`.
+Format: `[container-path]:[rw|ro]:[host-path]`.
 
 
 ### Health Checks


### PR DESCRIPTION
I am not sure if there is supposed to be more characters here in the format, but this single double-quote on its own doesn't seem to make any sense.