### PR TITLE
Upgrade netty to 4.1.5 with exclusion for google-cloud

### DIFF
--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -233,13 +233,6 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <version>0.5.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -270,8 +263,7 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>3.8.0.Final</version>
+      <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/helios-system-tests/pom.xml
+++ b/helios-system-tests/pom.xml
@@ -87,8 +87,7 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>3.8.0.Final</version>
+      <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,29 @@
         <artifactId>jsr305</artifactId>
         <version>2.0.3</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-pubsub</artifactId>
+        <version>0.5.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <!-- This version is used because google-cloud-pubsub uses a version with a memory leak. -->
+        <!-- See https://groups.google.com/forum/#!topic/grpc-io/4wHa_fxaT-Q -->
+        <!-- and https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1433 -->
+        <version>4.1.5.Final</version>
+      </dependency>
 
       <!--test deps-->
       <dependency>


### PR DESCRIPTION
The version of netty pulled in by pubsub has a memory leak.

* https://groups.google.com/forum/#!topic/grpc-io/4wHa_fxaT-Q
* https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1433