### PR TITLE
Fix HostListcommand output for no hosts

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -151,10 +151,10 @@ public class HostListCommand extends ControlCommand {
     final boolean full = options.getBoolean(fullArg.getDest());
     final boolean quiet = options.getBoolean(quietArg.getDest());
 
-    if (!isNullOrEmpty(pattern) && hosts.isEmpty()) {
+    if (hosts.isEmpty()) {
       if (json) {
-        out.println(Json.asPrettyStringUnchecked(hosts));
-      } else if (!quiet) {
+        out.println("{ }");
+      } else if (!quiet && !isNullOrEmpty(pattern)) {
         out.printf("host pattern %s matched no hosts%n", pattern);
       }
       return 1;


### PR DESCRIPTION
    `helios hosts --json` returned an empty JSON object,
    but `helios hosts foo --json` returned an empty JSON array.
    Make them both return empty objects.
    
    This fixes a race condition in `Labeltest.testCliHosts()`.
