### PR TITLE
add maven-enforcer-plugin rule to ban netty-* <= 4.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.3</version>
+        <version>2.9.2</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -258,11 +258,6 @@
           </exclusion>
         </exclusions>
       </dependency>
-      <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>2.0.3</version>
-      </dependency>
       <!--
       We don't actually use netty directly in this project, but we've added a dependency here
       to try to ensure that 4.1.5 is the version used by grpc and pubsub.
@@ -302,6 +297,51 @@
         </exclusions>
       </dependency>
 
+      <!--
+      versions that we have to manage to avoid requireUpperBoundDeps violations due to
+      conflicting versions in use from google-cloud-*
+      -->
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>1.22.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api-client</groupId>
+        <artifactId>google-api-client</artifactId>
+        <version>1.22.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.oauth-client</groupId>
+        <artifactId>google-oauth-client</artifactId>
+        <version>1.22.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>1.22.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-credentials</artifactId>
+        <version>0.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>0.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+
       <!--test deps-->
       <dependency>
         <groupId>junit</groupId>
@@ -331,6 +371,12 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>2.0.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>2.1</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -646,24 +692,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.2</version>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <configuration>
-                <rules>
-                  <requireUpperBoundDeps />
-                </rules>
-              </configuration>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.4</version>
           <configuration>
@@ -776,6 +804,37 @@
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <linkXRef>false</linkXRef>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps />
+                <!--
+                netty 4.1.3.Final and below has a memory leak when used with grpc.
+                See https://github.com/grpc/grpc-java/issues/2358
+                -->
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>io.netty:netty-*:(,4.1.3.Final]</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- this rule does not apply to the tcnative library, which we don't use anyway -->
+                    <include>io.netty:netty-tcnative-*</include>
+                  </includes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Enforces that any netty dependencies with the memory leak (see commit
6c7e030) are not used/included.

Also moves the maven-enforcer-plugin configuration from the
pluginManagement section of the parent pom to the plugins section, so
that it actually runs and applies to each submodule.

Now that maven-enforcer-plugin is running for each submodule as
intended, we have a few requireUpperBoundDeps violations that have to be
fixed as well.