### PR TITLE
Improve rolling-update logging

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/ListViewer.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/ListViewer.java
@@ -1,0 +1,58 @@
+/*-
+ * -\-\-
+ * Helios Client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.common;
+
+import static java.util.Collections.singletonList;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Utility methods for viewing large Lists.
+ */
+public class ListViewer {
+
+  /**
+   * Returns an immutable local view of the list based on the index and context.
+   * Useful if you have a large list and want to print a local view of it.
+   */
+  public static <T> List<T> localSublist(final int index,
+                                         final int context,
+                                         final List<T> list) {
+    Preconditions.checkNotNull(list);
+    if (list.isEmpty()) {
+      return list;
+    } else if (context < 0) {
+      throw new IllegalArgumentException("context has to be a non-negative integer.");
+    } else if (context == 0) {
+      return singletonList(list.get(index));
+    } else if (list.size() < (context * 2 + 1)) {
+      return list;
+    }
+
+    final int lowerIndex = Math.max(0, index - context - 1);
+    final int upperIndex = Math.min(list.size(), index + context + 1);
+    return ImmutableList.copyOf(list.subList(lowerIndex, upperIndex));
+  }
+
+}

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupTasks.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroupTasks.java
@@ -21,9 +21,12 @@
 package com.spotify.helios.common.descriptors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.spotify.helios.common.ListViewer.localSublist;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.spotify.helios.common.ListViewer;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -110,6 +113,18 @@ public class DeploymentGroupTasks extends Descriptor {
   public String toString() {
     return "DeploymentGroupTasks{"
            + "rolloutTasks=" + rolloutTasks
+           + ", taskIndex=" + taskIndex
+           + ", deploymentGroup=" + deploymentGroup
+           + '}';
+  }
+
+  /**
+   * Returns a string of an instance of this class that gives a local view of the
+   * {@link RolloutTask}s based on the taskIndex. Useful if there are many {@link RolloutTask}s.
+   */
+  public String toSummaryString() {
+    return "DeploymentGroupTasks{"
+           + "rolloutTasks=..., " + localSublist(taskIndex, 5, rolloutTasks) + ", ..."
            + ", taskIndex=" + taskIndex
            + ", deploymentGroup=" + deploymentGroup
            + '}';

--- a/helios-client/src/test/java/com/spotify/helios/common/ListViewerTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/ListViewerTest.java
@@ -1,0 +1,91 @@
+/*-
+ * -\-\-
+ * Helios Client
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ListViewerTest {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private static final List<Integer> LIST_OF_TEN = ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+  private static final List<Integer> EMPTY_LIST = Collections.emptyList();
+
+  @Test
+  public void testLowerBound() throws Exception {
+    final List<Integer> localSublist = ListViewer.localSublist(0, 3, LIST_OF_TEN);
+    assertThat(localSublist, contains(0, 1, 2, 3));
+  }
+
+  @Test
+  public void testUpperBound() throws Exception {
+    final List<Integer> localSublist = ListViewer.localSublist(10, 3, LIST_OF_TEN);
+    assertThat(localSublist, contains(6, 7, 8, 9));
+  }
+
+  @Test
+  public void testListSmallerThanContext() throws Exception {
+    final List<Integer> list = ImmutableList.of(0, 1, 2);
+    final List<Integer> localSublist = ListViewer.localSublist(1, 3, list);
+    assertThat(localSublist, contains(0, 1, 2));
+  }
+
+  @Test
+  public void testListLargerThanContext() throws Exception {
+    final List<Integer> list = ImmutableList.of(0, 1, 2, 3, 4);
+    final List<Integer> localSublist = ListViewer.localSublist(1, 1, list);
+    assertThat(localSublist, contains(0, 1, 2));
+  }
+
+  @Test
+  public void testContextIs0() throws Exception {
+    final List<Integer> localSublist = ListViewer.localSublist(4, 0, LIST_OF_TEN);
+    assertThat(localSublist, contains(4));
+  }
+
+  @Test
+  public void testContextLessThan0() throws Exception {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("context has to be a non-negative integer.");
+    ListViewer.localSublist(1, -1, LIST_OF_TEN);
+  }
+
+  @Test
+  public void testEmptyList() throws Exception {
+    List<Integer> localSublist = ListViewer.localSublist(1, 3, EMPTY_LIST);
+    assertThat(localSublist, equalTo(EMPTY_LIST));
+
+    localSublist = ListViewer.localSublist(1, 0, EMPTY_LIST);
+    assertThat(localSublist, equalTo(EMPTY_LIST));
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -774,8 +774,10 @@ public class ZooKeeperMasterModel implements MasterModel {
       final VersionedValue<DeploymentGroupTasks> versionedTasks = entry.getValue();
       final DeploymentGroupTasks tasks = versionedTasks.value();
 
-      log.info("rolling-update step on deployment-group: name={}, tasks={}",
-          deploymentGroupName, tasks);
+      log.info("rolling-update step on deployment-group {}. Doing taskIndex {} of {}. "
+               + "DeploymentGroupTasks={}",
+          deploymentGroupName, tasks.getTaskIndex(), tasks.getRolloutTasks().size(),
+          tasks.toSummaryString());
 
       try {
         final RollingUpdateOpFactory opFactory = new RollingUpdateOpFactory(


### PR DESCRIPTION
Logging for large deployment groups is unreadable because there
are so many `RolloutTasks` in a `DeploymentGroupTask`.

Return a local view of the `RolloutTasks` in `DeploymentGroupTask`
based on the current task index.