### PR TITLE
Improve rolling-update logging

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -773,14 +773,16 @@ public class ZooKeeperMasterModel implements MasterModel {
       final String deploymentGroupName = entry.getKey();
       final VersionedValue<DeploymentGroupTasks> versionedTasks = entry.getValue();
       final DeploymentGroupTasks tasks = versionedTasks.value();
+      final int taskIndex = tasks.getTaskIndex();
 
-      log.info("rolling-update step on deployment-group: name={}, tasks={}",
-          deploymentGroupName, tasks);
+      log.info("rolling-update step on deployment-group {}. Doing taskIndex {} of {}: {}. ",
+          deploymentGroupName, taskIndex, tasks.getRolloutTasks().size(),
+          tasks.getRolloutTasks().get(taskIndex));
 
       try {
         final RollingUpdateOpFactory opFactory = new RollingUpdateOpFactory(
             tasks, DEPLOYMENT_GROUP_EVENT_FACTORY);
-        final RolloutTask task = tasks.getRolloutTasks().get(tasks.getTaskIndex());
+        final RolloutTask task = tasks.getRolloutTasks().get(taskIndex);
         final RollingUpdateOp op = processRollingUpdateTask(
             client, opFactory, task, tasks.getDeploymentGroup());
 


### PR DESCRIPTION
Logging for large deployment groups is unreadable because there
are so many `RolloutTasks` in a `DeploymentGroupTask`.

Instead of logging the entire `DeploymentGroupTask` which includes
the entire list of `RolloutTask`s, just log the current `RolloutTask`.