### PR TITLE
Fix image names with hyphens being reported as invalid

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -62,6 +62,9 @@ public class JobValidator {
   private static final Pattern NAME_COMPONENT_PATTERN = Pattern.compile("^([a-z0-9._-]+)$");
   private static final int REPO_NAME_MAX_LENGTH = 255;
 
+  // taken from https://github.com/docker/distribution/blob/3150937b9f2b1b5b096b2634d0e7c44d4a0f89fb/reference/regexp.go#L36-L37
+  private static final Pattern TAG_PATTERN = Pattern.compile("[\\w][\\w.-]{0,127}");
+
   private static final Pattern DIGIT_PERIOD = Pattern.compile("^[0-9.]+$");
 
   private static final Pattern PORT_MAPPING_PROTO_PATTERN = compile("(tcp|udp)");
@@ -364,16 +367,15 @@ public class JobValidator {
   }
 
   private boolean validateTag(final String tag, final Collection<String> errors) {
-    boolean valid = true;
     if (tag.isEmpty()) {
       errors.add("Tag cannot be empty");
-      valid = false;
+      return false;
     }
-    if (tag.contains("/") || tag.contains(":")) {
-      errors.add(format("Illegal tag: \"%s\"", tag));
-      valid = false;
+    if (!TAG_PATTERN.matcher(tag).matches()) {
+      errors.add(format("Illegal tag: \"%s\", must match %s", tag, TAG_PATTERN));
+      return false;
     }
-    return valid;
+    return true;
   }
 
   private boolean validateDigest(final String digest, final Collection<String> errors) {

--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -436,14 +436,14 @@ public class JobValidator {
       repo = nameParts[0];
       name = nameParts[1];
     }
-    if (!NAMESPACE_PATTERN.matcher(repo).matches()) {
-      errors.add(
-          format("Invalid namespace name (%s), only [a-z0-9_] are allowed, size between 4 and 30",
-                 repo));
+    if (!REPO_PATTERN.matcher(repo).matches()) {
+      errors.add(format("Invalid repository name (%s), only [a-z0-9-_.] are allowed", repo));
       valid = false;
     }
-    if (!REPO_PATTERN.matcher(name).matches()) {
-      errors.add(format("Invalid repository name (%s), only [a-z0-9-_.] are allowed", name));
+    if (!NAMESPACE_PATTERN.matcher(name).matches()) {
+      errors.add(
+        format("Invalid namespace name (%s), only [a-z0-9_] are allowed, size between 4 and 30",
+               name));
       valid = false;
     }
     return valid;

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -40,7 +40,9 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_SECONDS_TO_WAIT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECURITY_OPT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_VOLUMES;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
@@ -456,7 +458,7 @@ public class JobValidatorTest {
   @Test
   public void testImageNamespaceWithHyphens() {
     final Job job = VALID_JOB.toBuilder()
-        .setImage("b.gcr.io/cloudsql-docker/gce-proxy:1.05 ")
+        .setImage("b.gcr.io/cloudsql-docker/gce-proxy:1.05")
         .build();
 
     assertThat(validator.validate(job), is(empty()));
@@ -465,10 +467,21 @@ public class JobValidatorTest {
   @Test
   public void testImageNameWithManyNameComponents() {
     final Job job = VALID_JOB.toBuilder()
-        .setImage("b.gcr.io/cloudsql-docker/and/more/components/gce-proxy:1.05 ")
+        .setImage("b.gcr.io/cloudsql-docker/and/more/components/gce-proxy:1.05")
         .build();
 
     assertThat(validator.validate(job), is(empty()));
+  }
+
+  @Test
+  public void testImageNameInvalidTag() {
+    final Job job = VALID_JOB.toBuilder()
+        .setImage("foo/bar:a b c")
+        .build();
+
+    assertThat(validator.validate(job), contains(
+        containsString("Illegal tag: \"a b c\"")
+    ));
   }
 
 }


### PR DESCRIPTION
Replaces #1068. Will fix #1070.

It seems like at some point Docker changed the format of image names to
be less restrictive: the image name can have multiple slash-separated
name components (with no bound on the number of components):

> The image name which is made up of slash-separated name components...
> Name components may contain lowercase characters, digits and
> separators. A separator is defined as a period, one or two
> underscores, or one or more dashes. A name component may not start or
> end with a separator.

This commits removes the regexes in JobValidator that check the
"namespace" and "repoName" separately along with the limits on how long
each portion can be. It now validates that each slash-seperated name
component contains only the allowed characters and that the entire
repository name is below the limit of 255 characters.

See:
docker/docker@ea98cf7
https://github.com/docker/distribution/blob/master/reference/reference.go
https://github.com/docker/distribution/blob/master/reference/regexp.go