### PR TITLE
don't assign default values to PortMapping.ip

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/PortMapping.java
@@ -46,7 +46,6 @@ import org.jetbrains.annotations.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PortMapping extends Descriptor {
 
-  public static final String WILDCARD_ADDRESS = "0.0.0.0";
   public static final String TCP = "tcp";
   public static final String UDP = "udp";
 
@@ -59,9 +58,9 @@ public class PortMapping extends Descriptor {
                      @JsonProperty("internalPort") final int internalPort,
                      @JsonProperty("externalPort") @Nullable final Integer externalPort,
                      @JsonProperty("protocol") @Nullable final String protocol) {
-    this.ip = Optional.fromNullable(ip).or(WILDCARD_ADDRESS);
+    this.ip = ip;
     // Validate IP here instead of in PortMappingParser to guaruntee every instance has a valid IP
-    if (!InetAddresses.isInetAddress(this.ip)) {
+    if (ip != null && !InetAddresses.isInetAddress(this.ip)) {
       throw new IllegalArgumentException(ip + " is not a valid IP address.");
     }
 
@@ -71,15 +70,15 @@ public class PortMapping extends Descriptor {
   }
 
   public PortMapping(final int internalPort, final Integer externalPort) {
-    this(WILDCARD_ADDRESS, internalPort, externalPort, TCP);
+    this(null, internalPort, externalPort, TCP);
   }
 
   public PortMapping(final int internalPort) {
-    this(WILDCARD_ADDRESS, internalPort, null, TCP);
+    this(null, internalPort, null, TCP);
   }
 
   private PortMapping(final Builder builder) {
-    this(checkNotNull(builder.ip), builder.internalPort, builder.externalPort,
+    this(builder.ip, builder.internalPort, builder.externalPort,
         checkNotNull(builder.protocol));
   }
 
@@ -119,15 +118,15 @@ public class PortMapping extends Descriptor {
 
   public static PortMapping of(final int internalPort, final Integer externalPort,
                                final String protocol) {
-    return new PortMapping(WILDCARD_ADDRESS, internalPort, externalPort, protocol);
+    return new PortMapping(null, internalPort, externalPort, protocol);
   }
 
   public static PortMapping of(final int internalPort, final String protocol) {
-    return new PortMapping(WILDCARD_ADDRESS, internalPort, null, protocol);
+    return new PortMapping(null, internalPort, null, protocol);
   }
 
   public static Builder builder() {
-    return new Builder().ip(WILDCARD_ADDRESS).protocol(TCP);
+    return new Builder().protocol(TCP);
   }
 
   public static class Builder {

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/PortMappingTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/PortMappingTest.java
@@ -24,16 +24,14 @@ import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.io.Resources.getResource;
 import static com.spotify.helios.common.descriptors.PortMapping.TCP;
 import static com.spotify.helios.common.descriptors.PortMapping.UDP;
-import static com.spotify.helios.common.descriptors.PortMapping.WILDCARD_ADDRESS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.io.Resources;
 import com.spotify.helios.common.Json;
-
 import java.io.IOException;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -58,7 +56,6 @@ public class PortMappingTest {
   public void testJsonDeserializationFromPartial() throws Exception {
     final PortMapping pm = portMappingFromResource("portmapping-partial.json");
     assertThat(pm, equalTo(PortMapping.builder()
-        .ip(WILDCARD_ADDRESS)
         .externalPort(123)
         .internalPort(456)
         .protocol(TCP)
@@ -69,7 +66,6 @@ public class PortMappingTest {
   public void testJsonDeserializationFromInternalPortOnly() throws Exception {
     final PortMapping pm = portMappingFromResource("portmapping-internal-port-only.json");
     assertThat(pm, equalTo(PortMapping.builder()
-        .ip(WILDCARD_ADDRESS)
         .internalPort(456)
         .protocol(TCP)
         .build()));
@@ -85,7 +81,6 @@ public class PortMappingTest {
   public void testJsonDeserializationUnknownFields() throws Exception {
     final PortMapping pm = portMappingFromResource("portmapping-unknown-fields.json");
     assertThat(pm, equalTo(PortMapping.builder()
-        .ip(WILDCARD_ADDRESS)
         .internalPort(456)
         .externalPort(123)
         .protocol(TCP)
@@ -100,8 +95,13 @@ public class PortMappingTest {
         .externalPort(123)
         .protocol(UDP)
         .build();
-    final String json = Json.asPrettyString(pm);
+    final String json = toJson(pm);
     assertThat(json, equalTo(stringFromResource("portmapping-full.json")));
+  }
+
+  private static String toJson(final PortMapping pm) throws JsonProcessingException {
+    // ensure that we use the normalizing writer that is also used when computing a Job.hash
+    return Json.asNormalizedString(pm);
   }
 
   @Test
@@ -110,7 +110,7 @@ public class PortMappingTest {
         .internalPort(456)
         .externalPort(123)
         .build();
-    final String json = Json.asPrettyString(pm);
+    final String json = toJson(pm);
     assertThat(json, equalTo(stringFromResource("portmapping-defaults.json")));
   }
 
@@ -119,7 +119,7 @@ public class PortMappingTest {
     final PortMapping pm = PortMapping.builder()
         .internalPort(456)
         .build();
-    final String json = Json.asPrettyString(pm);
+    final String json = toJson(pm);
     assertThat(json, equalTo(stringFromResource("portmapping-serialized-internal-port-only.json")));
   }
 

--- a/helios-client/src/test/resources/portmapping-defaults.json
+++ b/helios-client/src/test/resources/portmapping-defaults.json
@@ -1,6 +1,1 @@
-{
-  "externalPort" : 123,
-  "internalPort" : 456,
-  "ip" : "0.0.0.0",
-  "protocol" : "tcp"
-}
+{"externalPort":123,"internalPort":456,"protocol":"tcp"}

--- a/helios-client/src/test/resources/portmapping-full.json
+++ b/helios-client/src/test/resources/portmapping-full.json
@@ -1,6 +1,1 @@
-{
-  "externalPort" : 123,
-  "internalPort" : 456,
-  "ip" : "1.2.3.4",
-  "protocol" : "udp"
-}
+{"externalPort":123,"internalPort":456,"ip":"1.2.3.4","protocol":"udp"}

--- a/helios-client/src/test/resources/portmapping-serialized-internal-port-only.json
+++ b/helios-client/src/test/resources/portmapping-serialized-internal-port-only.json
@@ -1,6 +1,1 @@
-{
-  "externalPort" : null,
-  "internalPort" : 456,
-  "ip" : "0.0.0.0",
-  "protocol" : "tcp"
-}
+{"internalPort":456,"protocol":"tcp"}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/PortMappingParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/PortMappingParser.java
@@ -22,14 +22,11 @@ package com.spotify.helios.cli.command;
 
 import static com.google.common.base.Optional.fromNullable;
 import static com.spotify.helios.common.descriptors.PortMapping.TCP;
-import static com.spotify.helios.common.descriptors.PortMapping.WILDCARD_ADDRESS;
 import static java.util.regex.Pattern.compile;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.common.net.InetAddresses;
 import com.spotify.helios.common.descriptors.PortMapping;
-
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -56,7 +53,7 @@ class PortMappingParser {
     }
 
     final String name = matcher.group("n");
-    final String ip = fromNullable(matcher.group("ip")).or(WILDCARD_ADDRESS);
+    final String ip = matcher.group("ip");
     final int internal = Integer.parseInt(matcher.group("i"));
     final Integer external = nullOrInteger(matcher.group("e"));
     final String protocol = fromNullable(matcher.group("p")).or(TCP);


### PR DESCRIPTION
We can't assign default values from within the POJO class to any
"descriptors" that are reachable from the Job class. When the Job
builder computes the JobId.hash, it takes all of the Job parameters that
are not meta parameters (username, create time), serializes them to
JSON, and then computes a sha1 hash for that string.

If we change things so that a client running an older version of the
code does not have the same default values for fields that the server
does, then the JobId.hash computed on the server-side will be different
than what the client computed.

One way that this will surface itself is via users of helios-testing and
TemporaryJobs; since HeliosSoloDeployment always pulls
`spotify/helios-solo:latest`, regardless of what version of
helios-testing is being used.

Another possible way this problem would express itself is if an older
helios-cli user tried to create a job against a newer helios master.

The PortMapping.ip field was added in #1065 