### PR TITLE
simplify ZooKeeperHealthChecker by removing PathChildrenCache

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -328,10 +328,8 @@ public class AgentService extends AbstractIdleService implements Managed {
     this.agent = new Agent(model, supervisorFactory, reactorFactory, executions, portAllocator,
                            reaper);
 
-    final ZooKeeperHealthChecker zkHealthChecker = new ZooKeeperHealthChecker(zooKeeperClient,
-                                                                              Paths.statusHosts(),
-                                                                              riemannFacade,
-                                                                              TimeUnit.MINUTES, 2);
+    final ZooKeeperHealthChecker zkHealthChecker =
+        new ZooKeeperHealthChecker(zooKeeperClient, riemannFacade, TimeUnit.MINUTES, 2);
     environment.lifecycle().manage(zkHealthChecker);
 
     if (!config.getNoHttp()) {

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -207,7 +207,7 @@ public class MasterService extends AbstractIdleService {
             deploymentGroupEventTopic);
 
     final ZooKeeperHealthChecker zooKeeperHealthChecker = new ZooKeeperHealthChecker(
-        zooKeeperClient, Paths.statusMasters(), riemannFacade, TimeUnit.MINUTES, 2);
+        zooKeeperClient, riemannFacade, TimeUnit.MINUTES, 2);
 
     environment.lifecycle().manage(zooKeeperHealthChecker);
     environment.healthChecks().register("zookeeper", zooKeeperHealthChecker);

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthChecker.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthChecker.java
@@ -23,115 +23,104 @@ package com.spotify.helios.servicescommon.coordination;
 import com.codahale.metrics.health.HealthCheck;
 import com.spotify.helios.servicescommon.RiemannFacade;
 import io.dropwizard.lifecycle.Managed;
+import java.sql.Connection;
+import java.time.Instant;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
 
-public class ZooKeeperHealthChecker extends HealthCheck
-    implements Managed, PathChildrenCacheListener, Runnable {
-  private static final String UNKNOWN = "UNKNOWN";
+public class ZooKeeperHealthChecker extends HealthCheck implements Managed {
+
+  private final ZooKeeperClient zooKeeperClient;
+  private final ConnectionStateListener connectionStateListener;
+  private final RiemannFacade facade;
 
   private final ScheduledExecutorService scheduler;
-  private final PathChildrenCache cache;
-  private final RiemannFacade facade;
   private final TimeUnit timeUnit;
   private final long interval;
 
-  private AtomicReference<String> reasonString = new AtomicReference<>(UNKNOWN);
+  private AtomicReference<ConnectionState> connectionState = new AtomicReference<>();
+  private AtomicReference<Instant> changedAt = new AtomicReference<>();
 
-  public ZooKeeperHealthChecker(final ZooKeeperClient zooKeeperClient, final String path,
-                                final RiemannFacade facade, final TimeUnit timeUnit,
-                                final long interval) {
-    super();
+  public ZooKeeperHealthChecker(final ZooKeeperClient zooKeeperClient, final RiemannFacade facade,
+                                final TimeUnit timeUnit, final long interval) {
+
     this.scheduler = Executors.newScheduledThreadPool(2);
-    this.cache = new PathChildrenCache(zooKeeperClient.getCuratorFramework(), path, true, false,
-        scheduler);
     this.facade = facade.stack("zookeeper-connection");
+    this.zooKeeperClient = zooKeeperClient;
     this.timeUnit = timeUnit;
     this.interval = interval;
 
-    cache.getListenable().addListener(this);
-  }
-
-  @Override
-  public void run() {
-    final String reason = reasonString.get();
-    if (UNKNOWN.equals(reasonString.get())) {
-      return; // don't report anything until we get a known status
-    }
-
-    if (reason != null) {
-      facade.event()
-          .state("critical")
-          .metric(0.0)
-          .ttl(timeUnit.toSeconds(interval * 3))
-          .tags("zookeeper", "connection")
-          .description(reason)
-          .send();
-    } else {
-      facade.event()
-          .state("ok")
-          .metric(1.0)
-          .tags("zookeeper", "connection")
-          .ttl(timeUnit.toSeconds(interval * 3))
-          .send();
-    }
-  }
-
-  private void setState(String newState) {
-    if ((reasonString.get() == null) != (newState == null)) {
-      reasonString.set(newState);
-      run();
-    }
-  }
-
-  @Override
-  public void childEvent(CuratorFramework curator, PathChildrenCacheEvent event)
-      throws Exception {
-    switch (event.getType()) {
-      case INITIALIZED:
-      case CONNECTION_RECONNECTED:
-      case CHILD_ADDED:
-      case CHILD_REMOVED:
-      case CHILD_UPDATED:
-        // If we get any of these, clearly we're connected.
-        setState(null);
-        break;
-
-      case CONNECTION_LOST:
-        setState("CONNECTION_LOST");
-        break;
-      case CONNECTION_SUSPENDED:
-        setState("CONNECTION_SUSPENDED");
-        break;
-      default:
-        throw new IllegalStateException("Unrecognized event " + event.getType());
-    }
+    this.connectionStateListener = (client, newState) -> {
+      final ConnectionState oldState = connectionState.getAndSet(newState);
+      if (oldState != newState) {
+        changedAt.set(Instant.now());
+      }
+    };
   }
 
   @Override
   public void start() throws Exception {
-    cache.start();
+    zooKeeperClient.getConnectionStateListenable().addListener(connectionStateListener);
+    scheduler.scheduleAtFixedRate(this::reportState, 0, interval, timeUnit);
 
-    scheduler.scheduleAtFixedRate(this, 0, interval, timeUnit);
+    // call the listener in case Curator is already connected (as it won't fire a change then)
+    fireInitialEvent();
+  }
+
+  private void fireInitialEvent() throws KeeperException {
+    // the only Zookeeper.States value of interest is CONNECTED, the rest all signal a lack of
+    // fully established connection
+    final ZooKeeper.States state = zooKeeperClient.getState();
+    final ConnectionState interpretedState =
+        state == ZooKeeper.States.CONNECTED ? ConnectionState.CONNECTED : ConnectionState.LOST;
+
+    connectionStateListener.stateChanged(zooKeeperClient.getCuratorFramework(), interpretedState);
   }
 
   @Override
   public void stop() throws Exception {
-    scheduler.shutdownNow();
+    // probably irrelevant but remove the listener to be safe
+    zooKeeperClient.getConnectionStateListenable().removeListener(connectionStateListener);
+    scheduler.shutdown();
   }
 
   @Override
   protected Result check() throws Exception {
-    if (reasonString.get() == null) {
+    final ConnectionState state = this.connectionState.get();
+    if (state != null && state.isConnected()) {
       return Result.healthy();
     } else {
-      return Result.unhealthy(reasonString.get());
+      return Result.unhealthy(description());
     }
+  }
+
+  private String description() {
+    final ConnectionState connectionState = this.connectionState.get();
+    if (connectionState == null) {
+      return "unknown ConnectionState";
+    } else {
+      return "connection state is " + connectionState + ", state changed at " + this.changedAt;
+    }
+  }
+
+  private void reportState() {
+    final ConnectionState connectionState = this.connectionState.get();
+    if (connectionState == null) {
+      return; // don't report anything until we get a known status
+    }
+
+    facade.event()
+        .state(connectionState.isConnected() ? "ok" : "critical")
+        .metric(connectionState.isConnected() ? 1.0 : 0.0)
+        .ttl(timeUnit.toSeconds(interval * 3))
+        .tags("zookeeper", "connection")
+        .description(description())
+        .send();
   }
 }


### PR DESCRIPTION
It is not clear why this healthcheck creates and starts a PathChildrenCache for the purposes of knowing if zookeeper is connected or not - the PathChildrenCache proactively attempts to keep all children of a ZK path locally cached. This involves registering watches on those paths, responding to the events, keeping the data in-memory, etc.

Keeping the /status/hosts tree cached on the masters would be a pretty heavyweight operation - the cache kept by the healthcheck is updated every single time any host in the cluster has a status change, has a job deployed, etc.

Since the only thing that this healthcheck really cares about is the state of the zookeeper *connection* itself, and not the state of a tree, replace this with a ConnectionStateListener.