### PR TITLE
JobValidator: fix NPE if Job has malformed registration

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -136,6 +136,11 @@ public class JobValidator {
     // Verify service registrations
     for (final ServiceEndpoint registration : job.getRegistration().keySet()) {
       final ServicePorts servicePorts = job.getRegistration().get(registration);
+      if (servicePorts == null || servicePorts.getPorts() == null) {
+        errors.add(format("registration for '%s' is malformed: does not have a port mapping",
+            registration.getName()));
+        continue;
+      }
       for (final String portName : servicePorts.getPorts().keySet()) {
         if (!job.getPorts().containsKey(portName)) {
           errors.add(format("Service registration refers to missing port mapping: %s=%s",

--- a/helios-client/src/test/resources/com/spotify/helios/common/job-with-bad-registration.json
+++ b/helios-client/src/test/resources/com/spotify/helios/common/job-with-bad-registration.json
@@ -1,0 +1,20 @@
+{
+  "id": "job-with-bad-registration:1:4ee3a68429951bb9603b753c73fcefab27420dbe",
+  "image": "example.net/foo/bar",
+  "ports": {
+    "http": {
+      "internalPort": 8080,
+      "protocol": "tcp"
+    }
+  },
+  "registration": {
+    "my-cool-service/http": {
+      "ports": {
+        "http": {}
+      }
+    },
+    "volumes": {
+      "/some/path:ro": "/another/path"
+    }
+  }
+}


### PR DESCRIPTION
Inspired by a real-life example where someone accidentally included the
`volumes` section in the `registration` section. The JobValidator does
not check that each `registration` entry has a non-null `getPorts()`
Map.