### PR TITLE
simplify ZooKeeperHealthChecker

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -321,7 +321,6 @@ public class AgentService extends AbstractIdleService implements Managed {
                            reaper);
 
     final ZooKeeperHealthChecker zkHealthChecker = new ZooKeeperHealthChecker(zooKeeperClient);
-    environment.lifecycle().manage(zkHealthChecker);
 
     if (!config.getNoHttp()) {
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -199,7 +199,6 @@ public class MasterService extends AbstractIdleService {
     final ZooKeeperHealthChecker zooKeeperHealthChecker =
         new ZooKeeperHealthChecker(zooKeeperClient);
 
-    environment.lifecycle().manage(zooKeeperHealthChecker);
     environment.healthChecks().register("zookeeper", zooKeeperHealthChecker);
 
     // Report health checks as a gauge metric

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthChecker.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthChecker.java
@@ -21,75 +21,22 @@
 package com.spotify.helios.servicescommon.coordination;
 
 import com.codahale.metrics.health.HealthCheck;
-import io.dropwizard.lifecycle.Managed;
-import java.sql.Connection;
-import java.time.Instant;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicReference;
-import org.apache.curator.framework.state.ConnectionState;
-import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.ZooKeeper;
+import org.apache.curator.CuratorZookeeperClient;
 
-public class ZooKeeperHealthChecker extends HealthCheck implements Managed {
+public class ZooKeeperHealthChecker extends HealthCheck {
 
-  private final ZooKeeperClient zooKeeperClient;
-  private final ConnectionStateListener connectionStateListener;
-
-  private AtomicReference<ConnectionState> connectionState = new AtomicReference<>();
-  private AtomicReference<Instant> changedAt = new AtomicReference<>();
+  private final CuratorZookeeperClient client;
 
   public ZooKeeperHealthChecker(final ZooKeeperClient zooKeeperClient) {
-    this.zooKeeperClient = zooKeeperClient;
-    this.connectionStateListener = (client, newState) -> {
-      final ConnectionState oldState = connectionState.getAndSet(newState);
-      if (oldState != newState) {
-        changedAt.set(Instant.now());
-      }
-    };
-  }
-
-  @Override
-  public void start() throws Exception {
-    zooKeeperClient.getConnectionStateListenable().addListener(connectionStateListener);
-
-    // call the listener in case Curator is already connected (as it won't fire a change then)
-    fireInitialEvent();
-  }
-
-  private void fireInitialEvent() throws KeeperException {
-    // the only Zookeeper.States value of interest is CONNECTED, the rest all signal a lack of
-    // fully established connection
-    final ZooKeeper.States state = zooKeeperClient.getState();
-    final ConnectionState interpretedState =
-        state == ZooKeeper.States.CONNECTED ? ConnectionState.CONNECTED : ConnectionState.LOST;
-
-    connectionStateListener.stateChanged(zooKeeperClient.getCuratorFramework(), interpretedState);
-  }
-
-  @Override
-  public void stop() throws Exception {
-    // probably irrelevant but remove the listener to be safe
-    zooKeeperClient.getConnectionStateListenable().removeListener(connectionStateListener);
+    this.client = zooKeeperClient.getCuratorFramework().getZookeeperClient();
   }
 
   @Override
   protected Result check() throws Exception {
-    final ConnectionState state = this.connectionState.get();
-    if (state != null && state.isConnected()) {
+    if (client.isConnected()) {
       return Result.healthy();
     } else {
-      return Result.unhealthy(description());
-    }
-  }
-
-  private String description() {
-    final ConnectionState connectionState = this.connectionState.get();
-    if (connectionState == null) {
-      return "unknown ConnectionState";
-    } else {
-      return "connection state is " + connectionState + ", state changed at " + this.changedAt;
+      return Result.unhealthy("CuratorZookeeperClient reports that it is not conencted");
     }
   }
 }

--- a/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthCheckerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/servicescommon/coordination/ZooKeeperHealthCheckerTest.java
@@ -51,7 +51,6 @@ public class ZooKeeperHealthCheckerTest {
     final DefaultZooKeeperClient client = new DefaultZooKeeperClient(zk.curatorWithSuperAuth());
 
     healthCheck = new ZooKeeperHealthChecker(client);
-    healthCheck.start();
 
     // Start in our garden of eden where everything travaileth together in harmony....
     awaitHealthy(1, MINUTES);


### PR DESCRIPTION
Instead of deriving if the zookeeper client is connected or not based on
listening to ConnectionState change events, simply ask the
CuratorZookeeperClient if it is connected or not.

This is an attempt to alleviate issues we see in production where this
healthcheck on a master node will report something like `connection
state is SUSPENDED, state changed at 2017-02-08T17:07:31.029Z` - for
many days (6 at current count) - even though normal API operations on
the master that involve querying zookeeper are successful.

If there is some problem where the ConnectionStateListenable is not
firing in certain cases, of course it is possible that the
`isConnected()` method would suffer from the same problem - but it also
might be more accurate, with less moving pieces in the Healthcheck code.