### PR TITLE
Expose docker connection pool size as agent argument

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -66,6 +66,7 @@ public class AgentConfig extends CommonConfiguration<AgentConfig> {
   private FastForwardConfig fastForwardConfig;
   private List<String> extraHosts;
   private boolean jobHistoryDisabled;
+  private int connectionPoolSize;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -357,6 +358,15 @@ public class AgentConfig extends CommonConfiguration<AgentConfig> {
 
   public AgentConfig setExtraHosts(final List<String> extraHosts) {
     this.extraHosts = extraHosts;
+    return this;
+  }
+
+  public int getConnectionPoolSize() {
+    return connectionPoolSize;
+  }
+
+  public AgentConfig setConnectionPoolSize(final int connectionPoolSize) {
+    this.connectionPoolSize = connectionPoolSize;
     return this;
   }
 }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -70,6 +70,7 @@ public class AgentParser extends ServiceParser {
   private Argument zkAclMasterDigest;
   private Argument zkAclAgentPassword;
   private Argument disableJobHistory;
+  private Argument connectionPoolSize;
 
   public AgentParser(final String... args) throws ArgumentParserException {
     super("helios-agent", "Spotify Helios Agent", args);
@@ -145,7 +146,8 @@ public class AgentParser extends ServiceParser {
         .setPubsubPrefixes(getPubsubPrefixes())
         .setLabels(labels)
         .setFfwdConfig(ffwdConfig(options))
-        .setJobHistoryDisabled(options.getBoolean(disableJobHistory.getDest()));
+        .setJobHistoryDisabled(options.getBoolean(disableJobHistory.getDest()))
+        .setConnectionPoolSize(options.getInt(connectionPoolSize.getDest()));
 
     final String explicitId = options.getString(agentIdArg.getDest());
     if (explicitId != null) {
@@ -273,6 +275,11 @@ public class AgentParser extends ServiceParser {
         .action(storeTrue())
         .setDefault(false)
         .help("If specified, the agent won't write job histories to ZooKeeper.");
+
+    connectionPoolSize = parser.addArgument("--connection-pool-size")
+            .type(Integer.class)
+            .setDefault(100)
+            .help("Size of the Docker socket connection pool.");
   }
 
   public AgentConfig getAgentConfig() {

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentParser.java
@@ -20,6 +20,7 @@
 
 package com.spotify.helios.agent;
 
+import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.io.BaseEncoding.base16;
 import static com.spotify.helios.cli.Utils.argToStringMap;
 import static net.sourceforge.argparse4j.impl.Arguments.append;
@@ -147,7 +148,7 @@ public class AgentParser extends ServiceParser {
         .setLabels(labels)
         .setFfwdConfig(ffwdConfig(options))
         .setJobHistoryDisabled(options.getBoolean(disableJobHistory.getDest()))
-        .setConnectionPoolSize(options.getInt(connectionPoolSize.getDest()));
+        .setConnectionPoolSize(fromNullable(options.getInt(connectionPoolSize.getDest())).or(-1));
 
     final String explicitId = options.getString(agentIdArg.getDest());
     if (explicitId != null) {
@@ -276,9 +277,8 @@ public class AgentParser extends ServiceParser {
         .setDefault(false)
         .help("If specified, the agent won't write job histories to ZooKeeper.");
 
-    connectionPoolSize = parser.addArgument("--connection-pool-size")
+    connectionPoolSize = parser.addArgument("--docker-connection-pool-size")
             .type(Integer.class)
-            .setDefault(100)
             .help("Size of the Docker socket connection pool.");
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -349,8 +349,11 @@ public class AgentService extends AbstractIdleService implements Managed {
 
   private DockerClient createDockerClient(final AgentConfig config) {
     final DefaultDockerClient.Builder builder = DefaultDockerClient.builder()
-            .uri(config.getDockerHost().uri())
-            .connectionPoolSize(config.getConnectionPoolSize());
+            .uri(config.getDockerHost().uri());
+
+    if (config.getConnectionPoolSize() != -1) {
+      builder.connectionPoolSize(config.getConnectionPoolSize());
+    }
 
     if (!isNullOrEmpty(config.getDockerHost().dockerCertPath())) {
       final Path dockerCertPath = java.nio.file.Paths.get(config.getDockerHost().dockerCertPath());

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -42,6 +42,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificates;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
@@ -347,10 +348,11 @@ public class AgentService extends AbstractIdleService implements Managed {
   }
 
   private DockerClient createDockerClient(final AgentConfig config) {
-    final DockerClient dockerClient;
-    if (isNullOrEmpty(config.getDockerHost().dockerCertPath())) {
-      dockerClient = new PollingDockerClient(config.getDockerHost().uri());
-    } else {
+    final DefaultDockerClient.Builder builder = DefaultDockerClient.builder()
+            .uri(config.getDockerHost().uri())
+            .connectionPoolSize(config.getConnectionPoolSize());
+
+    if (!isNullOrEmpty(config.getDockerHost().dockerCertPath())) {
       final Path dockerCertPath = java.nio.file.Paths.get(config.getDockerHost().dockerCertPath());
       final DockerCertificates dockerCertificates;
       try {
@@ -359,10 +361,10 @@ public class AgentService extends AbstractIdleService implements Managed {
         throw Throwables.propagate(e);
       }
 
-      dockerClient = new PollingDockerClient(config.getDockerHost().uri(), dockerCertificates);
+      builder.dockerCertificates(dockerCertificates);
     }
 
-    return dockerClient;
+    return new PollingDockerClient(builder);
   }
 
   /**

--- a/helios-services/src/main/java/com/spotify/helios/agent/PollingDockerClient.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/PollingDockerClient.java
@@ -44,6 +44,10 @@ public class PollingDockerClient extends DefaultDockerClient {
     super(uri);
   }
 
+  public PollingDockerClient(final DefaultDockerClient.Builder builder) {
+    super(builder);
+  }
+
   public PollingDockerClient(final URI uri, DockerCertificates dockerCertificates) {
     super(uri, dockerCertificates);
   }


### PR DESCRIPTION
This PR makes it possible to set the Docker client connection pool size in a Helios Agent command line argument. The default value has been left unchanged.

We need this as we're running enough containers on each host to exhaust the default number (100).