### PR TITLE
    Add docker daemon health check to agent

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -61,7 +61,6 @@ import com.spotify.helios.servicescommon.ServiceUtil;
 import com.spotify.helios.servicescommon.ZooKeeperRegistrarService;
 import com.spotify.helios.servicescommon.coordination.CuratorClientFactoryImpl;
 import com.spotify.helios.servicescommon.coordination.DefaultZooKeeperClient;
-import com.spotify.helios.servicescommon.coordination.Paths;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClient;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperClientProvider;
 import com.spotify.helios.servicescommon.coordination.ZooKeeperHealthChecker;
@@ -321,11 +320,14 @@ public class AgentService extends AbstractIdleService implements Managed {
                            reaper);
 
     final ZooKeeperHealthChecker zkHealthChecker = new ZooKeeperHealthChecker(zooKeeperClient);
+    final DockerDaemonHealthChecker dockerDaemonHealthChecker =
+        new DockerDaemonHealthChecker(dockerClient);
 
     if (!config.getNoHttp()) {
 
       environment.healthChecks().register("docker", dockerHealthChecker);
       environment.healthChecks().register("zookeeper", zkHealthChecker);
+      environment.healthChecks().register("dockerd", dockerDaemonHealthChecker);
 
       // Report health checks as a gauge metric
       environment.healthChecks().getNames().forEach(

--- a/helios-services/src/main/java/com/spotify/helios/agent/DockerDaemonHealthChecker.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/DockerDaemonHealthChecker.java
@@ -1,0 +1,46 @@
+/*-
+ * -\-\-
+ * Helios Services
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.agent;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.spotify.docker.client.DockerClient;
+
+/**
+ * Checks if helios-agent can talk to Docker daemon.
+ */
+class DockerDaemonHealthChecker extends HealthCheck {
+
+  private final DockerClient dockerClient;
+
+  DockerDaemonHealthChecker(final DockerClient dockerClient) {
+    this.dockerClient = dockerClient;
+  }
+
+  @Override
+  protected Result check() throws Exception {
+    try {
+      dockerClient.ping();
+      return Result.healthy();
+    } catch (final Exception ex) {
+      return Result.unhealthy(ex);
+    }
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/agent/DockerDaemonHealthCheckerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/DockerDaemonHealthCheckerTest.java
@@ -1,0 +1,60 @@
+/*-
+ * -\-\-
+ * Helios Services
+ * --
+ * Copyright (C) 2016 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.agent;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerRequestException;
+
+import java.net.URI;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DockerDaemonHealthCheckerTest {
+
+  private DockerClient dockerClient;
+
+  @Before
+  public void setUp() throws Exception {
+    dockerClient = mock(DockerClient.class);
+  }
+
+  @Test
+  public void testHealthy() throws Exception {
+    final DockerDaemonHealthChecker checker = new DockerDaemonHealthChecker(dockerClient);
+    final HealthCheck.Result result = checker.check();
+    assertThat(result.isHealthy(), is(true));
+  }
+
+  @Test
+  public void testUnhealthy() throws Exception {
+    when(dockerClient.ping()).thenThrow(new DockerRequestException("GET", new URI("/ping")));
+    final DockerDaemonHealthChecker checker = new DockerDaemonHealthChecker(dockerClient);
+    final HealthCheck.Result result = checker.check();
+    assertThat(result.isHealthy(), is(false));
+  }
+}


### PR DESCRIPTION
    This health check tests if the agent process can talk to the Docker
    daemon.

    Before:

    ```
    curl -s 'http://localhost:5804/healthcheck' | jq .

    {
      "zookeeper": {
        "healthy": true
      },
      "docker": {
        "healthy": true
      },
      "deadlocks": {
        "healthy": true
      }
    }
    ```

    After:

    ```
    curl -s 'http://localhost:5804/healthcheck' | jq .

    {
      "zookeeper": {
        "healthy": true
      },
      "docker": {
        "healthy": true
      },
      "dockerd": {
        "healthy": true
      },
      "deadlocks": {
        "healthy": true
      }
    }
    ```