### PR TITLE
master: add 'hostPattern' parameter to GET /jobs

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterModel.java
@@ -45,6 +45,8 @@ public interface MasterModel {
 
   List<String> listHosts();
 
+  List<String> listHosts(String namePatternFilter);
+
   HostStatus getHostStatus(String host);
 
   /**

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -100,6 +100,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.BadVersionException;
@@ -198,6 +200,15 @@ public class ZooKeeperMasterModel implements MasterModel {
     } catch (KeeperException e) {
       throw new HeliosRuntimeException("listing hosts failed", e);
     }
+  }
+
+  @Override
+  public List<String> listHosts(final String namePatternFilter) {
+    Preconditions.checkNotNull(namePatternFilter, "namePatternFilter");
+    final Predicate<String> matchesPattern = Pattern.compile(namePatternFilter).asPredicate();
+    return listHosts().stream()
+        .filter(matchesPattern)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/resources/HostsResource.java
@@ -97,14 +97,7 @@ public class HostsResource {
   public List<String> list(@QueryParam("namePattern") final String namePattern,
                            @QueryParam("selector") final List<String> hostSelectors) {
 
-    List<String> hosts = model.listHosts();
-
-    if (namePattern != null) {
-      final Predicate<String> matchesPattern = Pattern.compile(namePattern).asPredicate();
-      hosts = hosts.stream()
-          .filter(matchesPattern)
-          .collect(Collectors.toList());
-    }
+    List<String> hosts = namePattern == null ? model.listHosts() : model.listHosts(namePattern);
 
     if (!hostSelectors.isEmpty()) {
       // check that all supplied selectors are parseable/valid
@@ -220,11 +213,11 @@ public class HostsResource {
       final List<String> hosts,
       @QueryParam("status") @DefaultValue("") final String statusFilter) {
     final Map<String, HostStatus> statuses = Maps.newHashMap();
-    for (final String current : hosts) {
-      final HostStatus status = model.getHostStatus(current);
+    for (final String host : hosts) {
+      final HostStatus status = model.getHostStatus(host);
       if (status != null) {
         if (isNullOrEmpty(statusFilter) || statusFilter.equals(status.getStatus().toString())) {
-          statuses.put(current, status);
+          statuses.put(host, status);
         }
       }
     }

--- a/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/ZooKeeperMasterModelIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -140,6 +141,27 @@ public class ZooKeeperMasterModelIntegrationTest {
 
     model.deregisterHost(HOST);
     assertThat(model.listHosts(), contains(secondHost));
+  }
+
+  @Test
+  public void testHostListingWithNamePatternFilter() throws Exception {
+    // sanity check that no hosts exist
+    assertThat(model.listHosts(), empty());
+
+    final String hostname = "host1";
+    model.registerHost(hostname, "foo");
+    for (int i = 1; i <= hostname.length(); i++) {
+      assertThat(model.listHosts(hostname.substring(0, i)), contains(hostname));
+    }
+    // negative match
+    assertThat(model.listHosts("host2"), is(empty()));
+
+    final String secondHost = "host2";
+    model.registerHost(secondHost, "bar");
+    assertThat(model.listHosts("host"), contains(hostname, secondHost));
+
+    model.deregisterHost(hostname);
+    assertThat(model.listHosts(secondHost), contains(secondHost));
   }
 
   @Test

--- a/helios-services/src/test/java/com/spotify/helios/master/resources/HostsResourceTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/resources/HostsResourceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.spotify.helios.master.MasterModel;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,8 +82,13 @@ public class HostsResourceTest {
 
   @Test
   public void listHostsNameFilter() {
+    when(model.listHosts("foo.example")).thenReturn(hosts);
     assertThat(resource.list("foo.example", NO_SELECTOR_ARG), equalTo(hosts));
+
+    when(model.listHosts("host1")).thenReturn(ImmutableList.of("host1.foo.example.com"));
     assertThat(resource.list("host1", NO_SELECTOR_ARG), contains("host1.foo.example.com"));
+
+    when(model.listHosts("host5")).thenReturn(ImmutableList.of());
     assertThat(resource.list("host5", NO_SELECTOR_ARG), empty());
   }
 
@@ -119,8 +125,10 @@ public class HostsResourceTest {
   // Test behavior when both a name pattern and selector list is specified.
   @Test
   public void listHostsNameAndSelectorFilter() {
+    when(model.listHosts("foo.example.com")).thenReturn(hosts);
     assertThat(resource.list("foo.example.com", ImmutableList.of("site=foo")), equalTo(hosts));
 
+    when(model.listHosts("host3")).thenReturn(ImmutableList.of("host3.foo.example.com"));
     assertThat(resource.list("host3", ImmutableList.of("index =2")), empty());
 
     assertThat(resource.list("host3", ImmutableList.of("index!=2")),

--- a/helios-services/src/test/java/com/spotify/helios/master/resources/JobsResourceTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/resources/JobsResourceTest.java
@@ -1,0 +1,121 @@
+/*-
+ * -\-\-
+ * Helios Services
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.master.resources;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Goal;
+import com.spotify.helios.common.descriptors.HostStatus;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.master.MasterModel;
+import com.spotify.helios.servicescommon.statistics.NoopMasterMetrics;
+import java.util.Map;
+import org.junit.Test;
+
+public class JobsResourceTest {
+
+  private final MasterModel model = mock(MasterModel.class);
+  private final ImmutableSet<String> capabilities = ImmutableSet.of();
+
+  private final JobsResource resource =
+      new JobsResource(model, new NoopMasterMetrics(), capabilities);
+
+  @Test
+  public void testListJobs() throws Exception {
+    final ImmutableMap<JobId, Job> jobs = ImmutableMap.of(
+        JobId.parse("foobar:1"), Job.newBuilder().build(),
+        JobId.parse("foobar:2"), Job.newBuilder().build(),
+        JobId.parse("foobar:3"), Job.newBuilder().build()
+    );
+
+    when(model.getJobs()).thenReturn(jobs);
+
+    assertThat(resource.list("", ""), is(jobs));
+  }
+
+  @Test
+  public void testListJobsWithJobNameFilter() throws Exception {
+    final JobId jobId1 = JobId.parse("foobar:1");
+    final JobId jobId2 = JobId.parse("foobar:2");
+    final Job job1 = Job.newBuilder().build();
+    final Job job2 = Job.newBuilder().build();
+
+    final ImmutableMap<JobId, Job> jobs = ImmutableMap.of(
+        jobId1, job1,
+        jobId2, job2,
+        JobId.parse("blah:3"), Job.newBuilder().build(),
+        JobId.parse("buzz:3"), Job.newBuilder().build()
+    );
+
+    when(model.getJobs()).thenReturn(jobs);
+
+    assertThat(resource.list("foobar", ""), is(
+        ImmutableMap.of(
+            jobId1, job1,
+            jobId2, job2
+        )
+    ));
+  }
+
+  @Test
+  public void testListJobsWithHostNameFilter() throws Exception {
+    // one host matches this name pattern
+    final String namePattern = "foo";
+    when(model.listHosts(namePattern)).thenReturn(ImmutableList.of("foobar.example.net"));
+
+    final JobId jobId1 = JobId.parse("foobar:1");
+    final JobId jobId2 = JobId.parse("foobat:2");
+
+    final Job job1 = Job.newBuilder().build();
+    final Job job2 = Job.newBuilder().build();
+
+    // and it has two jobs deployed to it
+    final HostStatus hostStatus = mockHostStatus(ImmutableMap.of(
+        jobId1, Deployment.of(jobId1, Goal.START),
+        jobId2, Deployment.of(jobId1, Goal.START)
+    ));
+    when(model.getHostStatus("foobar.example.net")).thenReturn(hostStatus);
+
+    when(model.getJob(jobId1)).thenReturn(job1);
+    when(model.getJob(jobId2)).thenReturn(job2);
+
+    assertThat(resource.list("", namePattern), is(
+        ImmutableMap.of(
+            jobId1, job1,
+            jobId2, job2
+        )
+    ));
+  }
+
+  private static HostStatus mockHostStatus(Map<JobId, Deployment> jobs) {
+    final HostStatus hostStatus = mock(HostStatus.class);
+    when(hostStatus.getJobs()).thenReturn(jobs);
+    return hostStatus;
+  }
+}


### PR DESCRIPTION
Add the ability to filter on the server-side the output from `GET /jobs`
to jobs deployed to specific hosts.

This is intended to improve the performance of the
`helios status --host` command, which currently runs throught the
following steps on the client-side in order to output the status of jobs
deployed on hosts that match the `--host` name pattern:

1. Get all jobs in the cluster (GET /jobs)
2. Get the job status of all these jobs (POST /statuses)
3. Filter the response to jobs deployed on hosts that match the filter

In a cluster with thousands of hosts, this is quite inefficient and
results in a lot of data being transferred that the CLI ends up
discarding. As an example, in a cluster with ~3000 jobs, the first
request ends up transferring more than 3MB of JSON, while the second
request transfers 14MB of JSON.

This can be improved by moving the filtering onto the server-side, so
that the CLI can simply ask for jobs that are deployed on a given host
name pattern in step 1 above. This also allows the server to not bother
to make thousands of zookeeper calls when finding the status of all
jobs.

I'll create a separate PR for using this new functionality in the HeliosClient
and in the CLI, so that we can merge and release these separately.