### PR TITLE
use more efficient API for job status with host filter in CLI and client

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
@@ -111,7 +111,6 @@ public abstract class ControlCommand implements CliCommand {
 
   /**
    * Execute against a cluster at a specific endpoint.
-   * @param stdin TODO
    */
   private boolean run(final Namespace options, final Target target, final PrintStream out,
                       final PrintStream err, final String username, final boolean json,


### PR DESCRIPTION
Uses the new API method introduced in #1095 in HeliosClient and in
JobStatusCommand so that `helios status --host foo` does not need to
fetch all jobs, the job status for all jobs, and then filter by hostname
within the CLI. The filtering is all server-side as of #1095.