### PR TITLE
CLI: increase the default HTTP timeout

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -320,17 +320,25 @@ public class CliParser {
                 + "Useful when using -z flag to connect directly to a master using HTTPS which "
                 + "presents a certificate whose subject does not match the actual hostname.");
 
+      // for http-timeout and retry-timeout, do not set a default value in the argument, so that
+      // envrionment variables can be inspected in the Utils client factory.
       addArgument("--http-timeout")
           .type(Integer.class)
-          .setDefault(10)
-          .help("Timeout (in seconds) for each HTTP/S request to the master.");
+          .help("Timeout (in seconds) for each HTTP/S request to the master. "
+                + "If this flag is not set, the value in the environment variable "
+                + Utils.HTTP_TIMEOUT_ENV_VAR + " will be used. "
+                + "If this environment variable is not set, then the default is "
+                + Utils.DEFAULT_HTTP_TIMEOUT_SECS + " seconds.");
 
       addArgument("--retry-timeout")
           .type(Integer.class)
-          .setDefault(60)
           .help("Total timeout (in seconds) for all of the requests that helios makes to the "
                 + "master. If an individual request fails, helios will retry the request again "
-                + "until successful or until this timeout elapses.");
+                + "until successful or until this timeout elapses. "
+                + "If this flag is not set, the value in the environment variable "
+                + Utils.TOTAL_TIMEOUT_ENV_VAR + " will be used. "
+                + "If this environment variable is not set, then the default is "
+                + Utils.DEFAULT_TOTAL_TIMEOUT_SECS + " seconds.");
     }
 
     private Argument addArgument(final String... nameOrFlags) {


### PR DESCRIPTION
With one of our largest clusters at Spotify (~2000 agents), users of the
CLI often see http timeouts due to the fact that some API requests (list
jobs, job status, list hosts) are `O(number of agents in cluster)` with
respect to the number of zookeeper operations involved in generating the
API response.

For example, fetching the status of a deployment group involves
`5 + 7 * num_hosts + 2 * num_hosts * jobs_per_hosts` Zookeeper queries.

The default timeout of 10 seconds is too short of a timeout for these
API methods to realistically respond within.

This change will increase the default CLI timeout to 30 seconds to make
the timeouts seen at the CLI less frequent.

For any user who wants a shorter timeout and doesn't want to specify
`--http-timeout` on every CLI command, the environment variable
`HELIOS_CLI_HTTP_TIMEOUT` can be set. Only when the `--http-timeout`
argument and the environment variable are not set is the new default of
30 seconds used.

The same change is made for `--retry-timeout`, for which an environment
variable named `HELIOS_CLI_TOTAL_TIMEOUT` will be used as a fallback
before using the new default of 120 seconds.