### PR TITLE
Upgrade logback for faster CLI startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.21</version>
+        <version>1.7.22</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -195,17 +195,17 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.11</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.11</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-access</artifactId>
-        <version>1.1.3</version>
+        <version>1.1.11</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.argparse4j</groupId>


### PR DESCRIPTION
logback calls `InetAddress.getLocalHost()`, which is painfully slow on
some versions of macOS (i.e., 4-5 seconds). Since this happens when
logging is being configured, it potentially adds seconds to every
`helios` CLI invocation.

To address this, we upgrade to a newer version of logback that includes
a fix to evaluate the hostname lazily and not block startup:
https://jira.qos.ch/browse/LOGBACK-1221