### PR TITLE
replace deprecated Throwables.propagate(Throwable)

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/DefaultHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/DefaultHttpConnector.java
@@ -169,7 +169,7 @@ public class DefaultHttpConnector implements HttpConnector {
       methodField.setAccessible(true);
       methodField.set(delegate, method);
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -158,7 +158,7 @@ public class HeliosClient implements Closeable {
     try {
       return builder.build();
     } catch (URISyntaxException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/Json.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/Json.java
@@ -91,7 +91,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.writeValueAsBytes(value);
     } catch (JsonProcessingException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -119,7 +119,7 @@ public class Json {
     try {
       return asString(value);
     } catch (JsonProcessingException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -147,7 +147,7 @@ public class Json {
     try {
       return asPrettyString(value);
     } catch (JsonProcessingException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -176,7 +176,7 @@ public class Json {
     try {
       return asNormalizedString(value);
     } catch (JsonProcessingException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -212,7 +212,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.readValue(content, clazz);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -220,7 +220,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.readValue(content, typeReference);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -228,7 +228,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.readValue(content, javaType);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -236,7 +236,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.readValue(bytes, clazz);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -244,7 +244,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.readValue(bytes, typeReference);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -252,7 +252,7 @@ public class Json {
     try {
       return OBJECT_MAPPER.readValue(bytes, javaType);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -286,7 +286,7 @@ public class Json {
     try {
       return readTree(bytes);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -294,7 +294,7 @@ public class Json {
     try {
       return readTree(content);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -302,7 +302,7 @@ public class Json {
     try {
       return readTree(file);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/Resolver.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/Resolver.java
@@ -96,7 +96,7 @@ public abstract class Resolver {
     try {
       endpoint = new URI(protocol, null, host, port, null, null, null);
     } catch (URISyntaxException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     return endpoint;
   }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Descriptor.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Descriptor.java
@@ -37,7 +37,7 @@ public abstract class Descriptor {
     try {
       return Json.asBytes(this);
     } catch (JsonProcessingException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/Utils.java
@@ -96,7 +96,7 @@ public class Utils {
       final String json = new String(Files.readAllBytes(Paths.get(path)));
       node = Json.readTree(json);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     final JsonNode imageNode = node.get("image");
     return (imageNode == null || imageNode.getNodeType() != STRING) ? null : imageNode.asText();
@@ -122,7 +122,7 @@ public class Utils {
         final HostStatus hostStatus = client.hostStatus(hostName).get(10, TimeUnit.SECONDS);
         return hostStatus != null && hostStatus.getStatus() == HostStatus.Status.UP;
       } catch (InterruptedException | ExecutionException | TimeoutException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentService.java
@@ -142,7 +142,7 @@ public class AgentService extends AbstractIdleService implements Managed {
         Files.createDirectories(stateDirectory);
       } catch (IOException e) {
         log.error("Failed to create state directory: {}", stateDirectory, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 
@@ -158,7 +158,7 @@ public class AgentService extends AbstractIdleService implements Managed {
       throw new IllegalStateException("State lock file already locked: " + lockPath);
     } catch (IOException e) {
       log.error("Failed to take state lock: {}", lockPath, e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     final Path idPath = config.getStateDirectory().resolve("id");
@@ -172,7 +172,7 @@ public class AgentService extends AbstractIdleService implements Managed {
       }
     } catch (IOException e) {
       log.error("Failed to set up id file: {}", idPath, e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     // Configure metrics
@@ -249,7 +249,7 @@ public class AgentService extends AbstractIdleService implements Managed {
           new ZooKeeperAgentModel(zkClientProvider, config.getName(), stateDirectory, historyWriter,
               eventSenders, taskStatusEventTopic);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     // Set up service registrar
@@ -313,7 +313,7 @@ public class AgentService extends AbstractIdleService implements Managed {
                                                     JOBID_EXECUTIONS_MAP,
                                                     Suppliers.ofInstance(EMPTY_EXECUTIONS));
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     final Reaper reaper = new Reaper(dockerClient, namespace);
@@ -363,7 +363,7 @@ public class AgentService extends AbstractIdleService implements Managed {
       try {
         dockerCertificates = new DockerCertificates(dockerCertPath);
       } catch (DockerCertificateException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
 
       builder.dockerCertificates(dockerCertificates);

--- a/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
@@ -204,7 +204,7 @@ public final class HealthCheckerFactory {
         url = new URL("http", host, port, healthCheck.getPath());
       } catch (MalformedURLException e) {
         log.warn("MalformedURLException in http healthchecking containerId={}", containerId, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
 
       log.info("about to http healthcheck containerId={} with url={} for task={}",

--- a/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/ZooKeeperAgentModel.java
@@ -144,7 +144,7 @@ public class ZooKeeperAgentModel extends AbstractIdleService implements AgentMod
         final TaskStatus status = Json.read(entry.getValue(), TaskStatus.class);
         statuses.put(id, status);
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
     return statuses;
@@ -187,7 +187,7 @@ public class ZooKeeperAgentModel extends AbstractIdleService implements AgentMod
     try {
       return parse(data, TaskStatus.class);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -183,7 +183,7 @@ public class MasterService extends AbstractIdleService {
         Files.createDirectories(stateDirectory);
       } catch (IOException e) {
         log.error("Failed to create state directory: {}", stateDirectory, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -305,7 +305,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     } catch (NoNodeException e) {
       return emptyList();
     } catch (KeeperException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     final List<TaskStatusEvent> jsEvents = Lists.newArrayList();
@@ -317,7 +317,7 @@ public class ZooKeeperMasterModel implements MasterModel {
       } catch (NoNodeException e) {
         continue;
       } catch (KeeperException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
 
       for (final String event : events) {
@@ -328,7 +328,7 @@ public class ZooKeeperMasterModel implements MasterModel {
           jsEvents.add(new TaskStatusEvent(status, Long.valueOf(event), h));
         } catch (NoNodeException e) { // ignore, it went away before we read it
         } catch (KeeperException | IOException e) {
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
       }
     }
@@ -1409,7 +1409,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     try {
       return removeJob(jobId, Job.EMPTY_TOKEN);
     } catch (TokenVerificationException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -1480,7 +1480,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     try {
       deployJob(host, job, Job.EMPTY_TOKEN);
     } catch (TokenVerificationException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -1886,7 +1886,7 @@ public class ZooKeeperMasterModel implements MasterModel {
     try {
       return undeployJob(host, jobId, Job.EMPTY_TOKEN);
     } catch (TokenVerificationException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/PersistentAtomicReference.java
@@ -115,7 +115,7 @@ public class PersistentAtomicReference<T> {
     try {
       set(newValue);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCache.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/PersistentPathChildrenCache.java
@@ -205,7 +205,7 @@ public class PersistentPathChildrenCache<T> extends AbstractIdleService {
       } catch (KeeperException e) {
         throw e;
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
       newSnapshot.put(node, value);
     }
@@ -258,7 +258,8 @@ public class PersistentPathChildrenCache<T> extends AbstractIdleService {
     } catch (KeeperException e) {
       throw e;
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
 
     return newSnapshot;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperModelReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperModelReporter.java
@@ -77,7 +77,8 @@ public class ZooKeeperModelReporter {
       checkException(e, tag, name);
       throw e;
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     } finally {
       metrics.updateTimer(name, clock.getTick() - startTime, TimeUnit.NANOSECONDS);
     }

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectory.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/coordination/ZooKeeperUpdatingPersistentDirectory.java
@@ -140,7 +140,7 @@ public class ZooKeeperUpdatingPersistentDirectory extends AbstractIdleService {
       try {
         entries.set(ImmutableMap.copyOf(mutable));
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
     reactor.signal();
@@ -164,7 +164,7 @@ public class ZooKeeperUpdatingPersistentDirectory extends AbstractIdleService {
       try {
         entries.set(ImmutableMap.copyOf(mutable));
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
     reactor.signal();

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/LoggingTestWatcher.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/LoggingTestWatcher.java
@@ -115,7 +115,7 @@ final class LoggingTestWatcher extends TestWatcher {
     try {
       Files.createDirectories(directory);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     configureLogger("org.eclipse.jetty", Level.ERROR);

--- a/helios-testing-common/src/main/java/com/spotify/helios/TemporaryPorts.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/TemporaryPorts.java
@@ -80,7 +80,7 @@ public class TemporaryPorts extends ExternalResource {
     try {
       Files.createDirectories(lockDirectory);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -176,7 +176,7 @@ public class TemporaryPorts extends ExternalResource {
       try {
         s.close();
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 
@@ -215,7 +215,7 @@ public class TemporaryPorts extends ExternalResource {
       return null;
     } catch (IOException e) {
       log.error("Failed to take port lock: {}", path, e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingClusterManager.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingClusterManager.java
@@ -87,7 +87,7 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
       digestField.set(null, superDigest);
     } catch (NoSuchAlgorithmException | IllegalAccessException | NoSuchFieldException e) {
       // i mean, for real?
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -95,7 +95,7 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
     try {
       tempDir = Files.createTempDirectory("helios-zk");
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     start();
@@ -116,7 +116,8 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
       stop();
       deleteDirectory(tempDir.toFile());
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -174,7 +175,8 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
     try {
       start0();
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
 
     curator = createCurator(connectString(zkAddresses));
@@ -182,7 +184,7 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
     try {
       awaitUp(2, TimeUnit.MINUTES);
     } catch (TimeoutException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -191,7 +193,8 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
     try {
       cluster.stop();
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -209,7 +212,8 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
       cluster.start();
     } catch (Exception e) {
       stop();
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -241,7 +245,8 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
     try {
       zkServers.get(id).restart();
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -249,7 +254,8 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
     try {
       zkServers.get(id).stop();
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -264,7 +270,7 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
       FileUtils.deleteDirectory(peerDir.toFile());
       Files.createDirectory(peerDir);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -294,7 +300,7 @@ public class ZooKeeperTestingClusterManager implements ZooKeeperTestManager {
       try {
         Files.createDirectory(peerDir);
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
 
       final InstanceSpec spec = new InstanceSpec(

--- a/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingServerManager.java
+++ b/helios-testing-common/src/main/java/com/spotify/helios/ZooKeeperTestingServerManager.java
@@ -80,7 +80,7 @@ public class ZooKeeperTestingServerManager implements ZooKeeperTestManager {
       digestField.set(null, superDigest);
     } catch (NoSuchAlgorithmException | IllegalAccessException | NoSuchFieldException e) {
       // i mean, for real?
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -161,7 +161,8 @@ public class ZooKeeperTestingServerManager implements ZooKeeperTestManager {
       server = new TestingServer(port, dataDir);
       awaitUp(2, MINUTES);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -170,7 +171,7 @@ public class ZooKeeperTestingServerManager implements ZooKeeperTestManager {
     try {
       server.stop();
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -178,7 +179,7 @@ public class ZooKeeperTestingServerManager implements ZooKeeperTestManager {
     try {
       FileUtils.copyDirectory(dataDir, destination.toFile());
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -187,7 +188,7 @@ public class ZooKeeperTestingServerManager implements ZooKeeperTestManager {
       FileUtils.deleteDirectory(dataDir);
       FileUtils.copyDirectory(source.toFile(), dataDir);
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/DefaultDeployer.java
@@ -140,7 +140,7 @@ public class DefaultDeployer implements Deployer {
           fail("all hosts matching filter pattern are DOWN");
         }
       } catch (InterruptedException | ExecutionException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
   }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -124,7 +124,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
       dockerInfo = this.dockerClient.info();
     } catch (DockerException | InterruptedException e1) {
       // There's not a lot we can do if Docker is unreachable.
-      throw Throwables.propagate(e1);
+      throw new RuntimeException(e1);
     }
     this.containerDockerHost = Optional.fromNullable(builder.containerDockerHost)
         .or(containerDockerHost(dockerInfo));

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -391,7 +391,7 @@ public class TemporaryJobBuilder {
     try {
       return file.toURI().toURL();
     } catch (MalformedURLException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -133,7 +133,7 @@ public class TemporaryJobs implements TestRule {
         this.jobPrefixFile = JobPrefixFile.create(builder.jobPrefix, prefixDirectory);
       }
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     if (builder.reports == null) {
@@ -378,10 +378,10 @@ public class TemporaryJobs implements TestRule {
           for (int i = 0; i < failures.size(); i++) {
             log.error(format("MultipleFailureException %d:", i), failures.get(i));
           }
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         } catch (Throwable throwable) {
-          Throwables.propagateIfPossible(throwable, Exception.class);
-          throw Throwables.propagate(throwable);
+          Throwables.throwIfUnchecked(throwable);
+          throw new RuntimeException(throwable);
         }
         return null;
       }
@@ -398,7 +398,7 @@ public class TemporaryJobs implements TestRule {
       future.get();
     } catch (ExecutionException e) {
       final Throwable cause = (e.getCause() == null) ? e : e.getCause();
-      throw Throwables.propagate(cause);
+      throw new RuntimeException(cause);
     }
   }
 
@@ -615,7 +615,7 @@ public class TemporaryJobs implements TestRule {
           final URI uri = new URI(dockerHost);
           endpoints("http://" + uri.getHost() + ":5801");
         } catch (URISyntaxException e) {
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
       }
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
@@ -133,7 +133,7 @@ public abstract class ControlCommand implements CliCommand {
       if (cause instanceof TimeoutException) {
         err.println("Request timed out to master in " + target);
       } else {
-        throw Throwables.propagate(cause);
+        throw new RuntimeException(cause);
       }
       return false;
     } finally {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
@@ -73,7 +73,7 @@ public abstract class MultiTargetControlCommand implements CliCommand {
       if (cause instanceof TimeoutException) {
         err.println("Request timed out to master");
       } else {
-        throw Throwables.propagate(cause);
+        throw new RuntimeException(cause);
       }
       return 1;
     } finally {


### PR DESCRIPTION
This method was deprecated in Guava 20; see
https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate

No functional changes here (I hope), it just removes a ton of deprecation warnings.