### PR TITLE
add rolling-update --ignore-failures, skip over AWAIT_RUNNING

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DeploymentGroup.java
@@ -79,13 +79,13 @@ public class DeploymentGroup extends Descriptor {
   private final RollingUpdateReason reason;
 
   /**
-   * Create a Job.
+   * Create a DeploymentGroup.
    *
    * <p>Note that despite annotating jobId as @JsonProperty("job") in practice it's serialised as
    * "jobId" because we neglected to annotate the getter to match. The annotation has been left here
    * to ensure backwards compatibility.
    *
-   * @param name The docker name to use.
+   * @param name The deployment group name.
    * @param jobId The job ID for the deployment group.
    * @param hostSelectors The selectors that determine which agents are part of the deployment
    *                       group.

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
@@ -38,7 +38,8 @@ import org.jetbrains.annotations.Nullable;
  *   "parallelism": 2,
  *   "timeout": 1000,
  *   "overlap": true,
- *   "token": "insecure-access-token"
+ *   "token": "insecure-access-token",
+ *   "ignoreFailures": false
  * }
  * </pre>
  */
@@ -53,17 +54,20 @@ public class RolloutOptions {
   private final boolean migrate;
   private final boolean overlap;
   private final String token;
+  private final boolean ignoreFailures;
 
   public RolloutOptions(@JsonProperty("timeout") final long timeout,
                         @JsonProperty("parallelism") final int parallelism,
                         @JsonProperty("migrate") final boolean migrate,
                         @JsonProperty("overlap") boolean overlap,
-                        @JsonProperty("token") @Nullable String token) {
+                        @JsonProperty("token") @Nullable String token,
+                        @JsonProperty("ignoreFailures") boolean ignoreFailures) {
     this.timeout = timeout;
     this.parallelism = parallelism;
     this.migrate = migrate;
     this.overlap = overlap;
     this.token = Optional.fromNullable(token).or(EMPTY_TOKEN);
+    this.ignoreFailures = ignoreFailures;
   }
 
   public static Builder newBuilder() {
@@ -75,7 +79,8 @@ public class RolloutOptions {
         .setTimeout(timeout)
         .setParallelism(parallelism)
         .setMigrate(migrate)
-        .setToken(token);
+        .setToken(token)
+        .setIgnoreFailures(ignoreFailures);
   }
 
   public long getTimeout() {
@@ -96,6 +101,10 @@ public class RolloutOptions {
 
   public String getToken() {
     return token;
+  }
+
+  public boolean getIgnoreFailures() {
+    return ignoreFailures;
   }
 
   @Override
@@ -124,6 +133,9 @@ public class RolloutOptions {
     if (token != null ? !token.equals(that.token) : that.token != null) {
       return false;
     }
+    if (ignoreFailures != that.ignoreFailures) {
+      return false;
+    }
 
     return true;
   }
@@ -135,6 +147,7 @@ public class RolloutOptions {
     result = 31 * result + (migrate ? 1 : 0);
     result = 31 * result + (overlap ? 1 : 0);
     result = 31 * result + (token != null ? token.hashCode() : 0);
+    result = 31 * result + (ignoreFailures ? 1 : 0);
     return result;
   }
 
@@ -146,6 +159,7 @@ public class RolloutOptions {
            + ", migrate=" + migrate
            + ", overlap=" + overlap
            + ", token=" + token
+           + ", ignoreFailures=" + ignoreFailures
            + '}';
   }
 
@@ -156,6 +170,7 @@ public class RolloutOptions {
     private boolean migrate;
     private boolean overlap;
     private String token;
+    private boolean ignoreFailures;
 
     public Builder() {
       this.timeout = DEFAULT_TIMEOUT;
@@ -163,6 +178,7 @@ public class RolloutOptions {
       this.migrate = false;
       this.overlap = false;
       this.token = EMPTY_TOKEN;
+      this.ignoreFailures = false;
     }
 
 
@@ -191,8 +207,13 @@ public class RolloutOptions {
       return this;
     }
 
+    public Builder setIgnoreFailures(final boolean ignoreFailures) {
+      this.ignoreFailures = ignoreFailures;
+      return this;
+    }
+
     public RolloutOptions build() {
-      return new RolloutOptions(timeout, parallelism, migrate, overlap, token);
+      return new RolloutOptions(timeout, parallelism, migrate, overlap, token, ignoreFailures);
     }
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/RolloutOptionsTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/RolloutOptionsTest.java
@@ -1,0 +1,69 @@
+/*-
+ * -\-\-
+ * Helios Client
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.common.descriptors;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.spotify.helios.common.Json;
+import org.junit.Test;
+
+public class RolloutOptionsTest {
+
+  /**
+   * Test that a JSON representing a RolloutOptions instance prior to the addition of the
+   * ignoreFailures field can be deserialized properly.
+   */
+  @Test
+  public void testCanDeserializeWithoutIgnoreFailuresField() throws Exception {
+    final ObjectMapper mapper = new ObjectMapper();
+    final ObjectNode node = mapper.createObjectNode()
+        .put("migrate", false)
+        .put("parallalism", 2)
+        .put("timeout", 1000)
+        .put("overlap", true)
+        .put("token", "blah");
+
+    final RolloutOptions options = Json.read(node.toString(), RolloutOptions.class);
+
+    assertThat("RolloutOptions.ignoreFailures should default to false",
+        options.getIgnoreFailures(), is(false));
+  }
+}

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -621,8 +621,9 @@ public class ZooKeeperMasterModel implements MasterModel {
       throws DeploymentGroupDoesNotExistException, JobDoesNotExistException {
     checkNotNull(deploymentGroup, "deploymentGroup");
 
-    log.info("preparing to initiate rolling-update on deployment-group: name={}, jobId={}",
-        deploymentGroup.getName(), jobId);
+    log.info("preparing to initiate rolling-update on deployment-group: name={}, jobId={} "
+             + "with rolloutOptions={}",
+        deploymentGroup.getName(), jobId, options);
 
     final DeploymentGroup updated = deploymentGroup.toBuilder()
         .setJobId(jobId)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -62,6 +62,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
   private final Argument migrateArg;
   private final Argument overlapArg;
   private final Argument tokenArg;
+  private final Argument ignoreFailuresArg;
 
   public RollingUpdateCommand(final Subparser parser) {
     this(parser, new SleepFunction() {
@@ -131,6 +132,15 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         .setDefault(EMPTY_TOKEN)
         .help("Insecure access token meant to prevent accidental changes to your job "
               + "(e.g. undeploys).");
+
+    ignoreFailuresArg = parser.addArgument("--ignore-failures")
+        .setDefault(false)
+        .action(storeTrue())
+        .help("When specified, the rolling update will continue on to all hosts in the deployment "
+              + "group without waiting for the job to reach the RUNNING state on each host. "
+              + "Be *very* careful about using this option, as it has the potential to completely "
+              + "take down your service by rolling out a broken job to all of the hosts in your "
+              + "group.");
   }
 
   @Override
@@ -146,6 +156,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
     final boolean migrate = options.getBoolean(migrateArg.getDest());
     final boolean overlap = options.getBoolean(overlapArg.getDest());
     final String token = options.getString(tokenArg.getDest());
+    final boolean ignoreFailures = options.getBoolean(ignoreFailuresArg.getDest());
 
     checkArgument(timeout > 0, "Timeout must be greater than 0");
     checkArgument(parallelism > 0, "Parallelism must be greater than 0");
@@ -159,6 +170,7 @@ public class RollingUpdateCommand extends WildcardJobCommand {
         .setMigrate(migrate)
         .setOverlap(overlap)
         .setToken(token)
+        .setIgnoreFailures(ignoreFailures)
         .build();
     final RollingUpdateResponse response = client.rollingUpdate(name, jobId, rolloutOptions).get();
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/WildcardJobCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/WildcardJobCommand.java
@@ -34,6 +34,10 @@ import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 
+/**
+ * A ControlCommand that accepts as input a partial jobId argument. An error is returned if there
+ * are zero or more than one jobs in the cluster that match this partial jobId.
+ */
 abstract class WildcardJobCommand extends ControlCommand {
 
   private final Argument jobArg;

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -66,6 +66,12 @@ public class RollingUpdateCommandTest {
   private static final long TIMEOUT = 300;
   private static final String TOKEN = "my_token";
 
+  private static final RolloutOptions OPTIONS = RolloutOptions.newBuilder()
+      .setTimeout(TIMEOUT)
+      .setParallelism(PARALLELISM)
+      .setToken(TOKEN)
+      .build();
+
   private final Namespace options = mock(Namespace.class);
   private final HeliosClient client = mock(HeliosClient.class);
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -141,8 +147,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(0, ret);
 
     final String expected = (
@@ -169,8 +174,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(0, ret);
 
     final String expected =
@@ -203,8 +207,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
 
     final String expected =
@@ -236,8 +239,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
 
     final String expected =
@@ -268,8 +270,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
 
     final String expected =
@@ -301,8 +302,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -325,8 +325,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>of(
@@ -356,8 +355,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -388,8 +386,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -419,8 +416,7 @@ public class RollingUpdateCommandTest {
     final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
     final String output = baos.toString();
 
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, false, TOKEN));
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -449,8 +445,13 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     // Verify that rollingUpdate() was called with migrate=true
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, true, false, TOKEN));
+    final RolloutOptions rolloutOptions = RolloutOptions.newBuilder()
+        .setTimeout(TIMEOUT)
+        .setParallelism(PARALLELISM)
+        .setMigrate(true)
+        .setToken(TOKEN)
+        .build();
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, rolloutOptions);
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()
@@ -478,8 +479,13 @@ public class RollingUpdateCommandTest {
     final String output = baos.toString();
 
     // Verify that rollingUpdate() was called with migrate=true
-    verify(client).rollingUpdate(
-        GROUP_NAME, JOB_ID, new RolloutOptions(TIMEOUT, PARALLELISM, false, true, TOKEN));
+    final RolloutOptions rolloutOptions = RolloutOptions.newBuilder()
+        .setTimeout(TIMEOUT)
+        .setParallelism(PARALLELISM)
+        .setOverlap(true)
+        .setToken(TOKEN)
+        .build();
+    verify(client).rollingUpdate(GROUP_NAME, JOB_ID, rolloutOptions);
     assertEquals(0, ret);
 
     assertJsonOutputEquals(output, ImmutableMap.<String, Object>builder()


### PR DESCRIPTION
Internally at Spotify we have a use case where a deployment group with hundreds of hosts in the group frequently has trouble completing a `rolling-update` command successfully to deploy a new version of a job because of various issues with individual hosts out of the hundreds (and sometimes thousands) of hosts in the group that prevent a new job from successfully running. Issues we have seen have to do with unhealthy dockerd instances, etc.

This deployment group represents a critical service where the service owners want to ensure that the deploymentGroup's status is never `FAILED`, as it is necessary for SLA reasons to make sure that new/auto-scaled instances get the job assigned to the deployment group deployed to it.

To that end we have decided to add a `--ignore-failures` flag to the `helios rolling-update` command that should cause the rollout of the new image to continue to all hosts in the deployment group even if the deployment/rollout fails on any single host in the group. We picture that very few services will ever want to use this flag besides this particular use case.

This PR is one possible way that we could implement this behavior in the heliosmaster: by completely removing the `RolloutTask.Action.AWAIT_RUNNING` step from the list of rollout tasks when the rollout plan is generated (see `RollingUpdatePlanner`). 

This would mean in practice that a `helios rolling-update --ignore-failures` quickly rolls through every host in the group, undeploying the previous job and deploying the new job, without waiting for any host to even start the image pull / container creation / etc process.

There are probably other ways we could implement this beyond removing `RolloutTask.Action.AWAIT_RUNNING` from the list of rollout tasks; I'd be happy to discuss and review various other options.