### PR TITLE
add a metric that reports total agent health

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/metrics/TotalHealthCheckGauge.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/metrics/TotalHealthCheckGauge.java
@@ -1,0 +1,61 @@
+/*-
+ * -\-\-
+ * Helios Services
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import java.util.SortedMap;
+
+/**
+ * Run all healthchecks, and report a healthy gauge value if and only if every healthcheck passes.
+ */
+public class TotalHealthCheckGauge implements Gauge<Integer> {
+
+  private final HealthCheckRegistry registry;
+
+  public TotalHealthCheckGauge(final HealthCheckRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public Integer getValue() {
+    final SortedMap<String, HealthCheck.Result> results = registry.runHealthChecks();
+    return results.values().stream().allMatch(HealthCheck.Result::isHealthy) ? 1 : 0;
+  }
+}

--- a/helios-services/src/test/java/com/spotify/helios/master/metrics/TotalHealthCheckGaugeTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/master/metrics/TotalHealthCheckGaugeTest.java
@@ -1,0 +1,87 @@
+/*-
+ * -\-\-
+ * Helios Services
+ * --
+ * Copyright (C) 2016 - 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+/*
+ * Copyright (c) 2017 Spotify AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.helios.master.metrics;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import org.junit.Test;
+
+public class TotalHealthCheckGaugeTest {
+
+  @Test
+  public void testAllHealthy() {
+    final HealthCheckRegistry registry = new HealthCheckRegistry();
+    registry.register("pass1", stubHealthCheck(HealthCheck.Result.healthy()));
+    registry.register("pass2", stubHealthCheck(HealthCheck.Result.healthy()));
+
+    final TotalHealthCheckGauge gauge = new TotalHealthCheckGauge(registry);
+    assertThat(gauge.getValue(), is(1));
+  }
+
+  @Test
+  public void testOneFails() {
+    final HealthCheckRegistry registry = new HealthCheckRegistry();
+    registry.register("pass1", stubHealthCheck(HealthCheck.Result.healthy()));
+    registry.register("fail1", stubHealthCheck(HealthCheck.Result.unhealthy("error")));
+
+    final TotalHealthCheckGauge gauge = new TotalHealthCheckGauge(registry);
+    assertThat(gauge.getValue(), is(0));
+  }
+
+  @Test
+  public void testAllFail() {
+    final HealthCheckRegistry registry = new HealthCheckRegistry();
+    registry.register("fail1", stubHealthCheck(HealthCheck.Result.unhealthy("error")));
+    registry.register("fail2", stubHealthCheck(HealthCheck.Result.unhealthy("error")));
+
+    final TotalHealthCheckGauge gauge = new TotalHealthCheckGauge(registry);
+    assertThat(gauge.getValue(), is(0));
+  }
+
+  private static HealthCheck stubHealthCheck(HealthCheck.Result result) {
+    return new HealthCheck() {
+      @Override
+      protected Result check() throws Exception {
+        return result;
+      }
+    };
+  }
+}


### PR DESCRIPTION
When monitoring Helios agents internally at Spotify, we query our
metrics systems for all metrics in
`[helios.docker.ok, helios.dockerd.ok, helios.deadlocks.ok]` and then do
an aggregation that is `min value by host`.

Because this needs to return 3 time series for every agent we have in
our backend, the query hits an upper limit of how many time series the
monitoring system can return.

To be able to have more efficient queries, and to avoid the monitoring
queries from having to keep track of which metric names are the ones to
monitor for "health", this change introduces a new metric named
`helios.healthy` that reports a 1 if all healthchecks are OK, and a 0 if
any single healthcheck (or all) fails.