### PR TITLE
remove version check and use of docker tag -f

### DIFF
--- a/solo/helios-use
+++ b/solo/helios-use
@@ -30,14 +30,7 @@ if [ ! -z "$1" ]; then
   echo "Switching to $requested_version"
   docker pull "$REPO:$requested_version"
 
-  client_version=$(docker version --format '{{.Client.Version}}')
-  cv_arr=( ${client_version//./ } )  # replace periods and split into array
-  # Docker 1.12+ doesn't have the -f switch
-  if [ "${cv_arr[1]}" -ge "12" ]; then
-      docker tag "$REPO:$requested_version" "$REPO:latest"
-  else
-      docker tag -f "$REPO:$requested_version" "$REPO:latest"
-  fi
+  docker tag "$REPO:$requested_version" "$REPO:latest"
   echo
 
   new_version=$(get_helios_version)


### PR DESCRIPTION
The new docker version numbering scheme (`17.03.1-ce` etc) breaks the assumption in this script that it is safe to use `tag -f` if the second number in the version string is < 12.

To fix this, remove the version check altogether. Fixes #1106.