### PR TITLE
print warning message from SysV scripts if upstart is installed

### DIFF
--- a/src/deb/helios-agent/init
+++ b/src/deb/helios-agent/init
@@ -19,6 +19,12 @@ DEFAULTFILE=/etc/default/helios-agent
 # If the daemon is not there, then exit.
 test -x $DAEMON || exit 5
 
+# upstart should be used to control the daemon if available
+if which initctl >/dev/null && initctl version | grep -q upstart; then
+ log_failure_msg "Upstart should be used to control $NAME (sudo initctl stop/start $NAME)!"
+ exit 5
+fi
+
 case $1 in
  start)
   # Checked the PID file exists and check the actual status of process

--- a/src/deb/helios-master/init
+++ b/src/deb/helios-master/init
@@ -19,6 +19,12 @@ DEFAULTFILE=/etc/default/helios-master
 # If the daemon is not there, then exit.
 test -x $DAEMON || exit 5
 
+# upstart should be used to control the daemon if available
+if which initctl >/dev/null && initctl version | grep -q upstart; then
+ log_failure_msg "Upstart should be used to control $NAME (sudo initctl stop/start $NAME)!"
+ exit 5
+fi
+
 case $1 in
  start)
   # Checked the PID file exists and check the actual status of process


### PR DESCRIPTION
the helios-agent and helios-master packages ship both an
/etc/init.d/ script and an /etc/init job config for Upstart.

If Upstart is used to control helios-agent/master, then the SysV
(/etc/init.d) scripts are not useful and don't actually work - they will
claim to have stopped or started a non-existant process.

(This sometimes confuses internal users who try to restart the
helios-agent daemon with `sudo /etc/init.d/helios-agent ...`)

To avoid confusion, have the SysV scripts print out a warning and fail
if the system has Upstart installed.