### PR TITLE
Allow adding labels to containers

### DIFF
--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -32,6 +32,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_EXPIRES;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_GRACE_PERIOD;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HEALTH_CHECK;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HOSTNAME;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_LABELS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_METADATA;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
@@ -200,7 +201,8 @@ public class JobValidatorTest {
                             EMPTY_REGISTRATION, EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                             EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
                             EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
-                            EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_SECONDS_TO_WAIT);
+                            EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS,
+                            EMPTY_SECONDS_TO_WAIT);
     final JobId recomputedId = job.toBuilder().build().getId();
     assertEquals(ImmutableSet.of("Id hash mismatch: " + job.getId().getHash()
         + " != " + recomputedId.getHash()), validator.validate(job));

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
@@ -103,6 +103,7 @@ public class JobTest {
     final Map<String, String> setMetadata = ImmutableMap.of("set_metadata_key", "set_metadata_val");
     final Set<String> setAddCapabilities = ImmutableSet.of("set_cap_add1", "set_cap_add2");
     final Set<String> setDropCapabilities = ImmutableSet.of("set_cap_drop1", "set_cap_drop2");
+    final Map<String, String> setLabels = ImmutableMap.of("set_label_key", "set_label_val");
 
     // Input to addXXX
     final Map<String, String> addEnv = ImmutableMap.of("add", "env");
@@ -118,6 +119,7 @@ public class JobTest {
         ServiceEndpoint.of("add_service", "add_proto"), addServicePorts);
     final Map<String, String> addVolumes = ImmutableMap.of("/add", "/volume");
     final Map<String, String> addMetadata = ImmutableMap.of("add_metadata_key", "add_metadata_val");
+    final Map<String, String> addLabels = ImmutableMap.of("add_labels_key", "add_labels_val");
 
     // Expected output from getXXX
     final String expectedName = setName;
@@ -141,6 +143,7 @@ public class JobTest {
     final Map<String, String> expectedMetadata = concat(setMetadata, addMetadata);
     final Set<String> expectedAddCapabilities = setAddCapabilities;
     final Set<String> expectedDropCapabilities = setDropCapabilities;
+    final Map<String, String> expectedLabels = concat(setLabels, addLabels);
 
     // Check setXXX methods
     builder.setName(setName);
@@ -163,6 +166,7 @@ public class JobTest {
     builder.setMetadata(setMetadata);
     builder.setAddCapabilities(setAddCapabilities);
     builder.setDropCapabilities(setDropCapabilities);
+    builder.setLabels(setLabels);
 
     // Check addXXX methods
     for (final Map.Entry<String, String> entry : addEnv.entrySet()) {
@@ -179,6 +183,9 @@ public class JobTest {
     }
     for (final Map.Entry<String, String> entry : addMetadata.entrySet()) {
       builder.addMetadata(entry.getKey(), entry.getValue());
+    }
+    for (final Map.Entry<String, String> entry : addLabels.entrySet()) {
+      builder.addLabels(entry.getKey(), entry.getValue());
     }
 
     assertEquals("name", expectedName, builder.getName());
@@ -202,6 +209,7 @@ public class JobTest {
     assertEquals("addCapabilities", expectedAddCapabilities, builder.getAddCapabilities());
     assertEquals("dropCapabilities", expectedDropCapabilities,
                  builder.getDropCapabilities());
+    assertEquals("labels", expectedLabels, builder.getLabels());
 
     // Check final output
     final Job job = builder.build();
@@ -225,6 +233,7 @@ public class JobTest {
     assertEquals("metadata", expectedMetadata, job.getMetadata());
     assertEquals("addCapabilities", expectedAddCapabilities, job.getAddCapabilities());
     assertEquals("dropCapabilities", expectedDropCapabilities, job.getDropCapabilities());
+    assertEquals("labels", expectedLabels, job.getLabels());
 
     // Check toBuilder
     final Job.Builder rebuilder = job.toBuilder();
@@ -250,6 +259,7 @@ public class JobTest {
     assertEquals("addCapabilities", expectedAddCapabilities, rebuilder.getAddCapabilities());
     assertEquals("dropCapabilities", expectedDropCapabilities,
                  rebuilder.getDropCapabilities());
+    assertEquals("labels", expectedLabels, rebuilder.getLabels());
 
     // Check clone
     final Job.Builder cloned = builder.clone();
@@ -275,6 +285,7 @@ public class JobTest {
     assertEquals("addCapabilities", expectedAddCapabilities, cloned.getAddCapabilities());
     assertEquals("dropCapabilities", expectedDropCapabilities,
                  cloned.getDropCapabilities());
+    assertEquals("labels", expectedLabels, cloned.getLabels());
 
     final Job clonedJob = cloned.build();
     assertEquals("name", expectedName, clonedJob.getId().getName());
@@ -299,6 +310,7 @@ public class JobTest {
     assertEquals("addCapabilities", expectedAddCapabilities, clonedJob.getAddCapabilities());
     assertEquals("dropCapabilities", expectedDropCapabilities,
                  clonedJob.getDropCapabilities());
+    assertEquals("labels", expectedLabels, clonedJob.getLabels());
   }
 
   @SafeVarargs

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -110,6 +110,7 @@ public class TaskConfig {
     builder.env(containerEnvStrings());
     builder.exposedPorts(containerExposedPorts());
     builder.volumes(volumes());
+    builder.labels(job.getLabels());
 
     for (final ContainerDecorator decorator : containerDecorators) {
       decorator.decorateContainerConfig(job, imageInfo, dockerVersion, builder);

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
@@ -25,10 +25,14 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.ImageInfo;
 import com.spotify.helios.common.descriptors.HealthCheck;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.PortMapping;
@@ -36,6 +40,8 @@ import com.spotify.helios.common.descriptors.ServiceEndpoint;
 import com.spotify.helios.common.descriptors.ServicePorts;
 import com.spotify.helios.serviceregistration.ServiceRegistration;
 import com.spotify.helios.serviceregistration.ServiceRegistration.EndpointHealthCheck;
+
+import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 
@@ -46,6 +52,7 @@ public class TaskConfigTest {
   private static final int EXTERNAL_PORT = 20000;
   private static final Set<String> CAP_ADDS = ImmutableSet.of("cap1", "cap2");
   private static final Set<String> CAP_DROPS = ImmutableSet.of("cap3", "cap4");
+  private static final Map<String, String> LABELS = ImmutableMap.of("label", "value");
   private static final Job JOB = Job.newBuilder()
       .setName("foobar")
       .setCommand(asList("foo", "bar"))
@@ -55,6 +62,7 @@ public class TaskConfigTest {
       .addRegistration(ServiceEndpoint.of("service", "http"), ServicePorts.of(PORT_NAME))
       .setAddCapabilities(CAP_ADDS)
       .setDropCapabilities(CAP_DROPS)
+      .setLabels(LABELS)
       .build();
 
   @Test
@@ -120,5 +128,19 @@ public class TaskConfigTest {
     final HostConfig hostConfig = taskConfig.hostConfig(Optional.absent());
     assertThat(ImmutableSet.copyOf(hostConfig.capAdd()), equalTo(CAP_ADDS));
     assertThat(ImmutableSet.copyOf(hostConfig.capDrop()), equalTo(CAP_DROPS));
+  }
+
+  @Test
+  public void testContainerConfig() throws Exception {
+    final TaskConfig taskConfig = TaskConfig.builder()
+            .namespace("test")
+            .host(HOST)
+            .job(JOB)
+            .build();
+
+    final ImageInfo imageInfo = mock(ImageInfo.class);
+    final ContainerConfig containerConfig = taskConfig.containerConfig(
+            imageInfo, Optional.absent());
+    assertThat(ImmutableMap.copyOf(containerConfig.labels()), equalTo(LABELS));
   }
 }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
@@ -29,6 +29,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_EXPIRES;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_GRACE_PERIOD;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HEALTH_CHECK;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_HOSTNAME;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_LABELS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_METADATA;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
@@ -59,7 +60,7 @@ public class IdMismatchJobCreateTest extends SystemTestBase {
                 EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                 EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
                 EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
-                EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_SECONDS_TO_WAIT)
+                EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS, EMPTY_SECONDS_TO_WAIT)
     ).get();
 
     // TODO (dano): Maybe this should be ID_MISMATCH but then JobValidator must become able to

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -123,6 +123,7 @@ public class JobCreateCommand extends ControlCommand {
   private final Argument metadataArg;
   private final Argument addCapabilityArg;
   private final Argument dropCapabilityArg;
+  private final Argument labelsArg;
   private final Supplier<Map<String, String>> envVarSupplier;
 
   public JobCreateCommand(final Subparser parser) {
@@ -270,6 +271,12 @@ public class JobCreateCommand extends ControlCommand {
         .setDefault(new ArrayList<String>())
         .help("The Linux capabilities this Helios job drops from its Docker container. "
               + "Defaults to nothing.");
+
+    labelsArg = parser.addArgument("--labels")
+            .action(append())
+            .setDefault(new ArrayList<String>())
+            .help("Labels (key-value pairs) to apply onto the container. "
+                    + "Defaults to nothing.");
 
     this.envVarSupplier = envVarSupplier;
   }
@@ -539,6 +546,13 @@ public class JobCreateCommand extends ControlCommand {
     final List<String> dropCaps = options.getList(dropCapabilityArg.getDest());
     if (dropCaps != null && !dropCaps.isEmpty()) {
       builder.setDropCapabilities(dropCaps);
+    }
+
+    final List<String> labelsList = options.getList(labelsArg.getDest());
+    if (!labelsList.isEmpty()) {
+      final Map<String, String> labels = Maps.newHashMap();
+      labels.putAll(parseListOfPairs(labelsList, "labels"));
+      builder.setLabels(labels);
     }
 
     // We build without a hash here because we want the hash to be calculated server-side.

--- a/helios-tools/src/test/resources/job_config_extra_labels.json
+++ b/helios-tools/src/test/resources/job_config_extra_labels.json
@@ -1,0 +1,6 @@
+{
+  "labels": {
+    "foo": "bar",
+    "baz": "qux"
+  }
+}


### PR DESCRIPTION
Hi!
This PR adds the ability to set labels on the containers started by Helios. There is probably a bunch of work remaining, I haven't been able to successfully start the integration tests on my machine yet, and the building and starting of helios-solo doesn't seem to work on Windows with boot2docker? (I can understand if this is not a configuration that you test...)

But while I get that ironed out, it'd be great if you have any feedback on places I have missed to add this, or more tests that need to be written? 