### PR TITLE
ensure all output from HostListCommand is sorted

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostListCommand.java
@@ -54,6 +54,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import net.sourceforge.argparse4j.inf.Argument;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -157,9 +158,8 @@ public class HostListCommand extends ControlCommand {
       return 1;
     }
 
-    final List<String> sortedHosts = natural().sortedCopy(hosts);
-
     if (quiet) {
+      final List<String> sortedHosts = natural().sortedCopy(hosts);
       if (json) {
         out.println(Json.asPrettyStringUnchecked(sortedHosts));
       } else {
@@ -168,11 +168,11 @@ public class HostListCommand extends ControlCommand {
         }
       }
     } else {
-      final Map<String, HostStatus> statuses = client.hostStatuses(hosts, queryParams).get();
+      final Map<String, HostStatus> statuses =
+          new TreeMap<>(client.hostStatuses(hosts, queryParams).get());
+
       if (json) {
-        final Map<String, HostStatus> sorted = Maps.newTreeMap();
-        sorted.putAll(statuses);
-        out.println(Json.asPrettyStringUnchecked(sorted));
+        out.println(Json.asPrettyStringUnchecked(statuses));
       } else {
         final Table table = table(out);
         table.row("HOST", "STATUS", "DEPLOYED", "RUNNING", "CPUS", "MEM", "LOAD AVG", "MEM USAGE",

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/HostListCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/HostListCommandTest.java
@@ -69,8 +69,6 @@ public class HostListCommandTest {
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
   private final PrintStream out = new PrintStream(baos);
 
-  private static final List<String> HOSTS = ImmutableList.of("host1.", "host2.", "host3.");
-
   private static final String JOB_NAME = "job";
   private static final String JOB_VERSION1 = "1-aaa";
   private static final String JOB_VERSION2 = "3-ccc";
@@ -110,7 +108,11 @@ public class HostListCommandTest {
 
   @Before
   public void setUp() throws ParseException {
-    when(client.listHosts()).thenReturn(immediateFuture(HOSTS));
+    // purposefully in non-sorted order so that tests that verify that the output is sorted are
+    // actually testing HostListCommand behavior and not accidentally testing what value the
+    // mock returns
+    final List<String> hosts = ImmutableList.of("host3.", "host1.", "host2.");
+    when(client.listHosts()).thenReturn(immediateFuture(hosts));
 
     final HostInfo hostInfo = HostInfo.newBuilder()
         .setCpus(4)
@@ -150,12 +152,12 @@ public class HostListCommandTest {
         .build();
 
     final Map<String, HostStatus> statuses = ImmutableMap.of(
-        HOSTS.get(0), upStatus,
-        HOSTS.get(1), upStatus,
-        HOSTS.get(2), downStatus
+        "host3.", downStatus,
+        "host1.", upStatus,
+        "host2.", upStatus
     );
 
-    when(client.hostStatuses(eq(HOSTS), anyMapOf(String.class, String.class)))
+    when(client.hostStatuses(eq(hosts), anyMapOf(String.class, String.class)))
         .thenReturn(immediateFuture(statuses));
   }
 


### PR DESCRIPTION
In the default cause of a command like `helios hosts`, the output
currently is not sorted at all by the command - the iteration order of
the Map returned by `client.hostStatuses()` controls the output of
hosts/rows printed to stdout.

In every other case (using `--json` or `-q`) the output *is* sorted.

This change makes it so that the Map used from `client.hostStatuses()`
is always sorted, and slightly modifies the test setup so that we can
verify that the HostListCommand is sorting data if it is returned in an
unsorted way.