### PR TITLE
integrate with Google ContainerRegistry support in docker-client

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/AgentConfig.java
@@ -20,6 +20,7 @@
 
 package com.spotify.helios.agent;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.spotify.docker.client.DockerHost;
 import com.spotify.helios.servicescommon.CommonConfiguration;
 import com.spotify.helios.servicescommon.FastForwardConfig;
@@ -67,6 +68,9 @@ public class AgentConfig extends CommonConfiguration<AgentConfig> {
   private List<String> extraHosts;
   private boolean jobHistoryDisabled;
   private int connectionPoolSize;
+
+  /** Credentials to use with Google Container Registry. */
+  private GoogleCredentials googleCredentials;
 
   public boolean isInhibitMetrics() {
     return inhibitMetrics;
@@ -367,6 +371,15 @@ public class AgentConfig extends CommonConfiguration<AgentConfig> {
 
   public AgentConfig setConnectionPoolSize(final int connectionPoolSize) {
     this.connectionPoolSize = connectionPoolSize;
+    return this;
+  }
+
+  public GoogleCredentials getGoogleCredentials() {
+    return googleCredentials;
+  }
+
+  public AgentConfig setGoogleCredentials(final GoogleCredentials googleCredentials) {
+    this.googleCredentials = googleCredentials;
     return this;
   }
 }

--- a/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AddExtraHostContainerDecoratorTest.java
@@ -35,7 +35,7 @@ public class AddExtraHostContainerDecoratorTest {
 
   @Test
   public void simpleTest() {
-    final List<String> hosts = ImmutableList.of("one", "two");
+    final List<String> hosts = ImmutableList.of("one:one", "two:two");
     final AddExtraHostContainerDecorator decorator = new AddExtraHostContainerDecorator(hosts);
 
     final HostConfig.Builder hostBuilder = HostConfig.builder();

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
       <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>docker-client</artifactId>
-        <version>8.4.0</version>
+        <version>8.6.0</version>
         <classifier>shaded</classifier>
       </dependency>
 
@@ -155,32 +155,32 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.6.0</version>
+        <version>2.8.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-guava</artifactId>
-        <version>2.6.0</version>
+        <version>2.8.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.6.0</version>
+        <version>2.8.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.6.0</version>
+        <version>2.8.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.6.0</version>
+        <version>2.8.8</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>2.6.0</version>
+        <version>2.8.8</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>
@@ -195,17 +195,17 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.11</version>
+        <version>1.2.1</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.1.11</version>
+        <version>1.2.1</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-access</artifactId>
-        <version>1.1.11</version>
+        <version>1.2.1</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.argparse4j</groupId>
@@ -391,7 +391,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Updates docker-client to 8.6.0 which has support for configuring the
DockerClient instance to authenticate against Google Container Registry.

(Note: this requires https://github.com/spotify/docker-client/pull/762 to be merged and released in docker-client first, before this PR can be merged)

The credentials to use in authenticating for pulls from GCR are
configured with a new flag `--docker-gcp-account-credentials`. The GCR
authentication layer is only enabled when this flag is set. This
argument value is expected to be a file containing the JSON key for the
service or user account to pull images with.