### PR TITLE
remove extra repositories from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,25 +104,6 @@
     </developer>
   </developers>
 
-  <repositories>
-    <repository>
-      <id>clojars.org</id>
-      <url>http://clojars.org/repo</url>
-    </repository>
-    <repository>
-      <id>bintray-readytalk</id>
-      <url>http://dl.bintray.com/readytalk/maven</url>
-    </repository>
-    <repository>
-      <id>ossrh</id>
-      <name>Sonatype OSS</name>
-      <url>https://oss.sonatype.org/content/repositories/releases/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>com.intellij</groupId>


### PR DESCRIPTION
I don't think any of these are needed - all of the libraries used are in
Maven Central.