### PR TITLE
Add support to helios for creating tmpfs mounts

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -355,6 +355,27 @@ read-only volume, respectively.
 
 Format: `[container-path]:[rw|ro]:[host-path]`.
 
+### ramdisks
+Memory-backed (tmpfs) mounts. Optional.
+
+Format:
+```
+"ramdisks": {
+  "<mount-point>": "<mount-options>",
+  ...
+}
+```
+
+The mount point is the path where the ramdisk will be mounted in the container.
+The mount point must be an absolute path.
+
+Example:
+```
+"ramdisks": {
+  "/tmp": "rw,size=32m",
+  "/run": "rw,noexec,nosuid,size=65535k"
+}
+```
 
 ### Health Checks
 

--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -184,6 +184,14 @@ public class JobValidator {
       errors.addAll(validateAddCapabilities(job));
     }
 
+    // Validate ramdisks
+    for (final String mountPoint : job.getRamdisks().keySet()) {
+      if (!mountPoint.startsWith("/")) {
+        errors.add("Ramdisk mount point is not absolute: " + mountPoint);
+        continue;
+      }
+    }
+
     return errors;
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -137,6 +137,7 @@ public class Job extends Descriptor implements Comparable<Job> {
   public static final Set<String> EMPTY_CAPS = emptySet();
   public static final Map<String, String> EMPTY_LABELS = emptyMap();
   public static final Integer EMPTY_SECONDS_TO_WAIT = null;
+  public static final Map<String, String> EMPTY_RAMDISKS = emptyMap();
 
   private final JobId id;
   private final String image;
@@ -161,6 +162,7 @@ public class Job extends Descriptor implements Comparable<Job> {
   private final Set<String> dropCapabilities;
   private final Map<String, String> labels;
   private final Integer secondsToWaitBeforeKill;
+  private final Map<String, String> ramdisks;
 
   /**
    * Create a Job.
@@ -221,7 +223,8 @@ public class Job extends Descriptor implements Comparable<Job> {
       @JsonProperty("addCapabilities") @Nullable final Set<String> addCapabilities,
       @JsonProperty("dropCapabilities") @Nullable final Set<String> dropCapabilities,
       @JsonProperty("labels") @Nullable final Map<String, String> labels,
-      @JsonProperty("secondsToWaitBeforeKill") @Nullable final Integer secondsToWaitBeforeKill) {
+      @JsonProperty("secondsToWaitBeforeKill") @Nullable final Integer secondsToWaitBeforeKill,
+      @JsonProperty("ramdisks") @Nullable final Map<String, String> ramdisks) {
     this.id = id;
     this.image = image;
 
@@ -248,6 +251,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     this.dropCapabilities = firstNonNull(dropCapabilities, EMPTY_CAPS);
     this.labels = Optional.fromNullable(labels).or(EMPTY_LABELS);
     this.secondsToWaitBeforeKill = secondsToWaitBeforeKill;
+    this.ramdisks = firstNonNull(ramdisks, EMPTY_RAMDISKS);
   }
 
   private Job(final JobId id, final Builder.Parameters pm) {
@@ -276,6 +280,7 @@ public class Job extends Descriptor implements Comparable<Job> {
     this.dropCapabilities = ImmutableSet.copyOf(pm.dropCapabilities);
     this.secondsToWaitBeforeKill = pm.secondsToWaitBeforeKill;
     this.labels = ImmutableMap.copyOf(pm.labels);
+    this.ramdisks = ImmutableMap.copyOf(pm.ramdisks);
   }
 
   public JobId getId() {
@@ -370,6 +375,10 @@ public class Job extends Descriptor implements Comparable<Job> {
     return secondsToWaitBeforeKill;
   }
 
+  public Map<String, String> getRamdisks() {
+    return ramdisks;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -412,7 +421,8 @@ public class Job extends Descriptor implements Comparable<Job> {
            && Objects.equals(this.addCapabilities, that.addCapabilities)
            && Objects.equals(this.dropCapabilities, that.dropCapabilities)
            && Objects.equals(this.labels, that.labels)
-           && Objects.equals(this.secondsToWaitBeforeKill, that.secondsToWaitBeforeKill);
+           && Objects.equals(this.secondsToWaitBeforeKill, that.secondsToWaitBeforeKill)
+           && Objects.equals(this.ramdisks, that.ramdisks);
   }
 
   @Override
@@ -421,7 +431,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         id, image, hostname, expires, created, command, env, resources,
         ports, registration, registrationDomain, gracePeriod, volumes, creatingUser,
         token, healthCheck, securityOpt, networkMode, metadata, addCapabilities,
-        dropCapabilities, labels, secondsToWaitBeforeKill);
+        dropCapabilities, labels, secondsToWaitBeforeKill, ramdisks);
   }
 
   @Override
@@ -450,6 +460,7 @@ public class Job extends Descriptor implements Comparable<Job> {
            + ", dropCapabilities=" + dropCapabilities
            + ", labels=" + labels
            + ", secondsToWaitBeforeKill=" + secondsToWaitBeforeKill
+           + ", ramdisks=" + ramdisks
            + '}';
   }
 
@@ -482,7 +493,8 @@ public class Job extends Descriptor implements Comparable<Job> {
         .setAddCapabilities(addCapabilities)
         .setDropCapabilities(dropCapabilities)
         .setLabels(labels)
-        .setSecondsToWaitBeforeKill(secondsToWaitBeforeKill);
+        .setSecondsToWaitBeforeKill(secondsToWaitBeforeKill)
+        .setRamdisks(ramdisks);
   }
 
   public static class Builder implements Cloneable {
@@ -525,6 +537,7 @@ public class Job extends Descriptor implements Comparable<Job> {
       public Set<String> dropCapabilities;
       public Map<String, String> labels;
       public Integer secondsToWaitBeforeKill;
+      public Map<String, String> ramdisks;
 
       private Parameters() {
         this.created = EMPTY_CREATED;
@@ -544,6 +557,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         this.addCapabilities = EMPTY_CAPS;
         this.dropCapabilities = EMPTY_CAPS;
         this.labels = EMPTY_LABELS;
+        this.ramdisks = Maps.newHashMap(EMPTY_RAMDISKS);
       }
 
       private Parameters(final Parameters pm) {
@@ -571,6 +585,7 @@ public class Job extends Descriptor implements Comparable<Job> {
         this.dropCapabilities = pm.dropCapabilities;
         this.labels = pm.labels;
         this.secondsToWaitBeforeKill = pm.secondsToWaitBeforeKill;
+        this.ramdisks = Maps.newHashMap(pm.ramdisks);
       }
 
       private Parameters withoutMetaParameters() {
@@ -742,6 +757,16 @@ public class Job extends Descriptor implements Comparable<Job> {
       return this;
     }
 
+    public Builder setRamdisks(final Map<String, String> ramdisks) {
+      pm.ramdisks = Maps.newHashMap(ramdisks);
+      return this;
+    }
+
+    public Builder addRamdisk(final String mountPoint, final String mountOptions) {
+      pm.ramdisks.put(mountPoint, mountOptions);
+      return this;
+    }
+
     public String getName() {
       return pm.name;
     }
@@ -828,6 +853,10 @@ public class Job extends Descriptor implements Comparable<Job> {
 
     public Integer secondsToWaitBeforeKill() {
       return pm.secondsToWaitBeforeKill;
+    }
+
+    public Map<String, String> getRamdisks() {
+      return ImmutableMap.copyOf(pm.ramdisks);
     }
 
     @SuppressWarnings({"CloneDoesntDeclareCloneNotSupportedException", "CloneDoesntCallSuperClone"})

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -35,6 +35,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_HOSTNAME;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_LABELS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_METADATA;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_RAMDISKS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_RESOURCES;
@@ -202,7 +203,7 @@ public class JobValidatorTest {
                             EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
                             EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
                             EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS,
-                            EMPTY_SECONDS_TO_WAIT);
+                            EMPTY_SECONDS_TO_WAIT, EMPTY_RAMDISKS);
     final JobId recomputedId = job.toBuilder().build().getId();
     assertEquals(ImmutableSet.of("Id hash mismatch: " + job.getId().getHash()
         + " != " + recomputedId.getHash()), validator.validate(job));
@@ -359,6 +360,13 @@ public class JobValidatorTest {
 
     assertEquals(newHashSet("Volume source is not absolute: bar"),
                  validator.validate(j.toBuilder().addVolume("/foo", "bar").build()));
+  }
+
+  @Test
+  public void testInvalidRamdiskMountPointFails() {
+    final Job j = Job.newBuilder().setName("foo").setVersion("1").setImage("foobar").build();
+    assertEquals(newHashSet("Ramdisk mount point is not absolute: relative-path"),
+        validator.validate(j.toBuilder().addRamdisk("relative-path", "derp").build()));
   }
 
   @Test

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -287,6 +287,10 @@ public class TaskConfig {
         .securityOpt(securityOpt.toArray(new String[securityOpt.size()]))
         .networkMode(job.getNetworkMode());
 
+    if (!job.getRamdisks().isEmpty()) {
+      builder.tmpfs(job.getRamdisks());
+    }
+
     final Resources resources = job.getResources();
     if (resources != null) {
       builder.memory(resources.getMemory());

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
@@ -32,6 +32,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_HOSTNAME;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_LABELS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_METADATA;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_PORTS;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_RAMDISKS;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_RESOURCES;
@@ -60,7 +61,8 @@ public class IdMismatchJobCreateTest extends SystemTestBase {
                 EMPTY_GRACE_PERIOD, EMPTY_VOLUMES, EMPTY_EXPIRES,
                 EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
                 EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
-                EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS, EMPTY_SECONDS_TO_WAIT)
+                EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS, EMPTY_SECONDS_TO_WAIT,
+                EMPTY_RAMDISKS)
     ).get();
 
     // TODO (dano): Maybe this should be ID_MISMATCH but then JobValidator must become able to

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
@@ -1,0 +1,138 @@
+/*-
+ * -\-\-
+ * Helios System Tests
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.system;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.spotify.helios.common.descriptors.Goal.START;
+import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
+import static com.spotify.helios.common.descriptors.TaskStatus.State.RUNNING;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+import com.spotify.helios.Polling;
+import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Job;
+import com.spotify.helios.common.descriptors.JobId;
+import com.spotify.helios.common.descriptors.PortMapping;
+import com.spotify.helios.common.descriptors.TaskStatus;
+import com.spotify.helios.common.protocol.CreateJobResponse;
+import com.spotify.helios.common.protocol.JobDeployResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.concurrent.Callable;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RamdiskTest extends SystemTestBase {
+
+  private HeliosClient client;
+  private Job job;
+
+  @Before
+  public void setup() throws Exception {
+    startDefaultMaster();
+
+    client = defaultClient();
+    startDefaultAgent(testHost());
+
+    job = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .addRamdisk("/much-volatile", "rw,noexec,nosuid,size=65536k")
+        .setCommand(asList("sh", "-c", "nc -p 4711 -lle sh -c \"df | grep much-volatile\""))
+        .addPort("df", PortMapping.of(4711))
+        .setCreatingUser(TEST_USER)
+        .build();
+  }
+
+  @Test
+  public void testClient() throws Exception {
+    final CreateJobResponse created = client.createJob(job).get();
+    assertEquals(CreateJobResponse.Status.OK, created.getStatus());
+    assertRamdisk(job.getId());
+  }
+
+  @Test
+  public void testCli() throws Exception {
+    final JobId jobId = createJob(job);
+    assertRamdisk(jobId);
+  }
+
+  public void assertRamdisk(final JobId jobId) throws Exception {
+    // Wait for agent to come up
+    awaitHostRegistered(client, testHost(), LONG_WAIT_SECONDS, SECONDS);
+    awaitHostStatus(client, testHost(), UP, LONG_WAIT_SECONDS, SECONDS);
+
+    // Deploy the job on the agent
+    final Deployment deployment = Deployment.of(jobId, START);
+    final JobDeployResponse deployed = client.deploy(deployment, testHost()).get();
+    assertEquals(JobDeployResponse.Status.OK, deployed.getStatus());
+
+    // Wait for the job to run
+    final TaskStatus taskStatus = awaitJobState(
+        client, testHost(), jobId, RUNNING, LONG_WAIT_SECONDS, SECONDS);
+    assertJobEquals(job, taskStatus.getJob());
+
+    final Integer dfPort = taskStatus.getPorts().get("df").getExternalPort();
+
+    assert dfPort != null;
+
+    // Read "foo" from /volume/bar
+    final String foo = recvUtf8(dfPort, 5);
+    assertEquals("tmpfs", foo);
+  }
+
+  private String recvUtf8(final int port, final int numBytes) throws Exception {
+    final byte[] bytes = recv(port, numBytes);
+    return new String(bytes, UTF_8);
+  }
+
+  private byte[] recv(final int port, final int numBytes) throws Exception {
+    checkArgument(numBytes > 0, "numBytes must be > 0");
+    return Polling.await(LONG_WAIT_SECONDS, SECONDS, new Callable<byte[]>() {
+      @Override
+      public byte[] call() {
+        try (final Socket s = new Socket(DOCKER_HOST.address(), port)) {
+          final byte[] bytes = new byte[numBytes];
+          final InputStream is = s.getInputStream();
+          final int first = is.read();
+          // Check if the uml kernel slirp driver did an accept->close on us,
+          // i.e. the actual listener is not up yet
+          if (first == -1) {
+            return null;
+          }
+          bytes[0] = (byte) first;
+          for (int i = 1; i < numBytes; i++) {
+            bytes[i] = (byte) is.read();
+          }
+          return bytes;
+        } catch (IOException e) {
+          return null;
+        }
+      }
+    });
+  }
+}

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
@@ -100,9 +100,9 @@ public class RamdiskTest extends SystemTestBase {
 
     assert dfPort != null;
 
-    // Read "foo" from /volume/bar
-    final String foo = recvUtf8(dfPort, 5);
-    assertEquals("tmpfs", foo);
+    // If "/much-volatile" mount is present a line starting with tmpfs should be returned
+    final String dfOutput = recvUtf8(dfPort, 5);
+    assertEquals("tmpfs", dfOutput);
   }
 
   private String recvUtf8(final int port, final int numBytes) throws Exception {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
@@ -28,6 +28,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 import com.spotify.helios.Polling;
 import com.spotify.helios.client.HeliosClient;
@@ -43,12 +44,20 @@ import java.io.InputStream;
 import java.net.Socket;
 import java.util.concurrent.Callable;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class RamdiskTest extends SystemTestBase {
 
   private HeliosClient client;
   private Job job;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    // Doesn't work on CircleCI because they don't support creating tmpfs using docker.
+    // https://discuss.circleci.com/t/docker-tmpfs-support/10416
+    assumeFalse(isCircleCi());
+  }
 
   @Before
   public void setup() throws Exception {

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/RamdiskTest.java
@@ -61,7 +61,7 @@ public class RamdiskTest extends SystemTestBase {
         .setName(testJobName)
         .setVersion(testJobVersion)
         .setImage(BUSYBOX)
-        .addRamdisk("/much-volatile", "rw,noexec,nosuid,size=65536k")
+        .addRamdisk("/much-volatile", "rw,noexec,nosuid,size=1")
         .setCommand(asList("sh", "-c", "nc -p 4711 -lle sh -c \"df | grep much-volatile\""))
         .addPort("df", PortMapping.of(4711))
         .setCreatingUser(TEST_USER)


### PR DESCRIPTION
Allows users to specify tmpfs partitions in their jobs that are then
created and mounted when the container is run. For example:

```
"ramdisks": {
  # "<mount-point-in-container>": "<mount-options">
  "/run": "rw,noexec,nosuid,size=65536k",
}
```

In the above example `/run` in the container would be mounted to a
tmpfs partition.

This is, for example, useful to put `/tmp` on a tmpfs. One reason
why you might want to do this for Java apps is because the HotSpot JVM
writes a hsperfdata file in `/tmp` synchrously during GC -- which
can lead to issues where GC takes a long time because it's blocked on IO.