### PR TITLE
JobValidator: Don't allow mount points to be reused between ramdisks …

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -192,6 +192,22 @@ public class JobValidator {
       }
     }
 
+    // Check that mount-points aren't reused between ramdisks and volumes.
+    // This will not caught all cases where docker will fail to create the container because of
+    // conflict. For example, a job with a ramdisk mounted at "/a/b" and a volume that binds "/a"
+    // in the container to "/tmp" on the host will fail.
+    final Set<String> volumeMountPoints = Sets.newHashSet();
+    for (String s : job.getVolumes().keySet()) {
+      volumeMountPoints.add(s.split(":", 2)[0]);
+    }
+
+    for (final String mountPoint : job.getRamdisks().keySet()) {
+      if (volumeMountPoints.contains(mountPoint)) {
+        errors.add(format("Ramdisk mount point used by volume: %s", mountPoint));
+      }
+    }
+
+
     return errors;
   }
 


### PR DESCRIPTION
…and volumes

Note that this does not catch all bad cases. For example a job like this will
likely cause problems:

```
{
  ...
  "volumes": {
    "/foo:rw": "/foo",
    "/foo:ro": "/foo"
  }
}
```

Another case where docker will fail to start the container is this:

```
{
  ...
  "volumes": {
    "/herp": "/tmp"
  },
  "ramdisks": {
    "/herp/derp": "rw,size=1"
  }
}
```