### PR TITLE
less verbose logs from HeliosSoloLogService

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloLogService.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloLogService.java
@@ -111,10 +111,7 @@ class HeliosSoloLogService extends AbstractScheduledService {
         }
       }
     } catch (Exception e) {
-      // Ignore TimeoutException as that is to be expected sometimes
-      if (!(Throwables.getRootCause(e) instanceof TimeoutException)) {
-        log.warn("Caught exception, will ignore", e);
-      }
+      log.debug("Caught exception, will ignore", e);
     }
   }
 


### PR DESCRIPTION
If this class is going to ignore any exceptions it caches when trying to
communicate with the helios-solo instance and attach logs, it might as
well be silent about doing so and not log at warning level.