### PR TITLE
HeliosSoloDeployment: support Google Container Registry credentials

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosConfig.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosConfig.java
@@ -35,19 +35,18 @@ public class HeliosConfig {
   public static final String APP_CONFIG_FILE = "helios.conf";
 
   /**
-   * @param component The name of the component we're loading config for
-   *                  (i.e. Temp jobs, Helios solo)
    * @return The root configuration loaded from the helios configuration files.
    */
-  static Config loadConfig(final String component) {
-    final ConfigResolveOptions resolveOptions =
-        ConfigResolveOptions.defaults().setAllowUnresolved(true);
+  static Config loadConfig() {
+    final ConfigResolveOptions resolveOptions = ConfigResolveOptions
+        .defaults()
+        .setAllowUnresolved(true);
 
-    final Config baseConfig = ConfigFactory.load(
-        BASE_CONFIG_FILE, ConfigParseOptions.defaults(), resolveOptions);
+    final ConfigParseOptions parseOptions = ConfigParseOptions.defaults();
 
-    final Config appConfig = ConfigFactory.load(
-        APP_CONFIG_FILE, ConfigParseOptions.defaults(), resolveOptions);
+    final Config baseConfig = ConfigFactory.load(BASE_CONFIG_FILE, parseOptions, resolveOptions);
+
+    final Config appConfig = ConfigFactory.load(APP_CONFIG_FILE, parseOptions, resolveOptions);
 
     return appConfig.withFallback(baseConfig);
   }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -582,7 +582,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
    * @return A Builder that can be used to instantiate a HeliosSoloDeployment.
    */
   public static Builder builder(final String profile) {
-    return new Builder(profile, HeliosConfig.loadConfig("helios-solo"));
+    return new Builder(profile, HeliosConfig.loadConfig());
   }
 
   /**

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -698,7 +698,7 @@ public class HeliosSoloDeployment implements HeliosDeployment {
         if (credentialsFile.exists()) {
           this.googleContainerRegistryCredentials = Optional.of(credentialsFile);
         } else {
-          log.info("Ignoring non-existent google-container-registry.credentials file: {}", path);
+          log.warn("Ignoring non-existent google-container-registry.credentials file: {}", path);
         }
       }
     }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -517,7 +517,7 @@ public class TemporaryJobs implements TestRule {
 
   static Builder builder(final String profile, final Map<String, String> env,
                          final HeliosClient.Builder clientBuilder) {
-    return new Builder(profile, HeliosConfig.loadConfig("helios-testing"), env, clientBuilder);
+    return new Builder(profile, HeliosConfig.loadConfig(), env, clientBuilder);
   }
 
   public static class Builder {


### PR DESCRIPTION
HeliosSoloDeployment: support Google Container Registry credentials

If the configuration profile used by helios-solo contains an entry for `google-container-registry.credentials`, then HeliosSoloDeployment will launch the helios-solo container with additional configuration:

- add an environment variable for `HELIOS_AGENT_OPTS` which contains the flag `--docker-gcp-account-credentials=<file>`
- add a volume bind for the directory containing the credentials file so that helios agent can find the credentials pointed to above

This will allow helios-agent inside the helios-solo container to be able to fetch images from Google Container Registry for any tests that need to do so.

If the value is not set in the configuration file for helios-testing/helios-solo (`helios.conf` or `helios-base.conf`), or to override the value, the system property `-Dhelios.testing.profiles.local.google-container-registry.credentials` can be set to the file path.

If the configuration entry points to a file that doesn't exist then it is ignored.

This allows the user to configure helios-testing/HeliosSoloDeployment to be flexible about what credentials are used inside the helios-solo container, by making it just a matter of configuration to point to a file containing the credentials.