### PR TITLE
Initial support for authorization with access tokens

### DIFF
--- a/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/HeliosClientTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
@@ -50,7 +51,8 @@ import org.junit.Test;
 public class HeliosClientTest {
 
   private final RequestDispatcher dispatcher = mock(RequestDispatcher.class);
-  private final HeliosClient client = new HeliosClient("test", dispatcher);
+  private final HeliosClient client =
+      new HeliosClient("testclient", Optional.<String>absent(), dispatcher);
 
   @Test(expected = IllegalStateException.class)
   public void testBuildWithNoEndpoints() {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliMain.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliMain.java
@@ -30,6 +30,8 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import com.google.common.base.Optional;
+import com.spotify.helios.cli.command.CliCommand;
 import com.spotify.helios.common.LoggingConfig;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -71,8 +73,12 @@ public class CliMain {
   public int run() {
     try {
       final BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in));
-      return parser.getCommand().run(parser.getNamespace(), parser.getTargets(), out, err,
-          parser.getUsername(), parser.getJson(), stdin);
+      final CliCommand cmd = parser.getCommand();
+      final Optional<String> accessToken = cmd.needsAuthorizaton()
+                                           ? parser.getAccessToken() : Optional.<String>absent();
+
+      return cmd.run(parser.getNamespace(), parser.getTargets(), out, err,
+                     parser.getUsername(), accessToken, parser.getJson(), stdin);
     } catch (Exception e) {
       // print entire stack trace in verbose mode, otherwise just the exception message
       if (parser.getNamespace().getInt("verbose") > 0) {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -23,6 +23,7 @@ package com.spotify.helios.cli;
 import static java.lang.String.format;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -60,7 +61,8 @@ public final class Utils {
   }
 
   public static HeliosClient getClient(final Target target, final PrintStream err,
-                                       final String username, final Namespace options) {
+                                       final String username, final Optional<String> accessToken,
+                                       final Namespace options) {
 
     List<URI> endpoints = Collections.emptyList();
     try {
@@ -88,6 +90,7 @@ public final class Utils {
         .setRetryTimeout(retryTimeout, TimeUnit.SECONDS)
         .setSslHostnameVerification(!options.getBoolean("insecure"))
         .setUser(username)
+        .setAccessToken(accessToken)
         .build();
   }
 

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/CliCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/CliCommand.java
@@ -20,6 +20,7 @@
 
 package com.spotify.helios.cli.command;
 
+import com.google.common.base.Optional;
 import com.spotify.helios.cli.Target;
 import java.io.BufferedReader;
 import java.io.PrintStream;
@@ -27,8 +28,12 @@ import java.util.List;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 public interface CliCommand {
-  int run(final Namespace options, final List<Target> targets, final PrintStream out,
-          final PrintStream err, final String username, final boolean json,
+  boolean needsAuthorizaton();
+
+  int run(final Namespace options, final List<Target> targets,
+          final PrintStream out, final PrintStream err,
+          final String username, final Optional<String> accessToken,
+          final boolean json,
           final BufferedReader stdin)
       throws Exception;
 }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/ControlCommand.java
@@ -23,6 +23,7 @@ package com.spotify.helios.cli.command;
 import static com.google.common.base.Strings.repeat;
 import static java.lang.String.format;
 
+import com.google.common.base.Optional;
 import com.spotify.helios.cli.Target;
 import com.spotify.helios.cli.Utils;
 import com.spotify.helios.client.HeliosClient;
@@ -53,10 +54,16 @@ public abstract class ControlCommand implements CliCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return false;
+  }
+
+  @Override
   public int run(final Namespace options, final List<Target> targets, final PrintStream out,
-                 final PrintStream err, final String username, final boolean json,
-                 final BufferedReader stdin)
+                 final PrintStream err, final String username, final Optional<String> accessToken,
+                 final boolean json, final BufferedReader stdin)
       throws Exception {
+
     boolean allSuccessful = true;
 
     boolean isFirst = true;
@@ -86,7 +93,7 @@ public abstract class ControlCommand implements CliCommand {
         }
       }
 
-      final boolean successful = run(options, target, out, err, username, json, stdin);
+      final boolean successful = run(options, target, out, err, username, accessToken, json, stdin);
       if (shortCircuit && !successful) {
         return 1;
       }
@@ -111,12 +118,12 @@ public abstract class ControlCommand implements CliCommand {
   /**
    * Execute against a cluster at a specific endpoint.
    */
-  private boolean run(final Namespace options, final Target target, final PrintStream out,
-                      final PrintStream err, final String username, final boolean json,
-                      final BufferedReader stdin)
+  private boolean run(final Namespace options, final Target target,
+                      final PrintStream out, final PrintStream err,
+                      final String username, final Optional<String> accessToken,
+                      final boolean json, final BufferedReader stdin)
       throws Exception {
-
-    final HeliosClient client = Utils.getClient(target, err, username, options);
+    final HeliosClient client = Utils.getClient(target, err, username, accessToken, options);
     if (client == null) {
       return false;
     }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupCreateCommand.java
@@ -68,6 +68,11 @@ public class DeploymentGroupCreateCommand extends ControlCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   int run(final Namespace options, final HeliosClient client, final PrintStream out,
           final boolean json, final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupRemoveCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupRemoveCommand.java
@@ -48,6 +48,11 @@ public class DeploymentGroupRemoveCommand extends ControlCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   int run(final Namespace options, final HeliosClient client, final PrintStream out,
           final boolean json, final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStopCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/DeploymentGroupStopCommand.java
@@ -47,6 +47,11 @@ public class DeploymentGroupStopCommand extends ControlCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   int run(final Namespace options, final HeliosClient client, final PrintStream out,
           final boolean json, final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostDeregisterCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostDeregisterCommand.java
@@ -63,6 +63,11 @@ public class HostDeregisterCommand extends ControlCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   int run(final Namespace options, final HeliosClient client, final PrintStream out,
           final boolean json, final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/HostRegisterCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/HostRegisterCommand.java
@@ -48,6 +48,11 @@ public class HostRegisterCommand extends ControlCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   int run(final Namespace options, final HeliosClient client, PrintStream out, final boolean json,
           final BufferedReader stdin)
       throws ExecutionException, InterruptedException {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -281,6 +281,11 @@ public class JobCreateCommand extends ControlCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   int run(final Namespace options, final HeliosClient client, final PrintStream out,
           final boolean json, final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobDeployCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobDeployCommand.java
@@ -74,6 +74,11 @@ public class JobDeployCommand extends WildcardJobCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   protected int runWithJobId(final Namespace options, final HeliosClient client,
                              final PrintStream out, final boolean json, final JobId jobId,
                              final BufferedReader stdin)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobRemoveCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobRemoveCommand.java
@@ -64,6 +64,11 @@ public class JobRemoveCommand extends WildcardJobCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   protected int runWithJobId(final Namespace options, final HeliosClient client,
                              final PrintStream out, final boolean json, final JobId jobId,
                              final BufferedReader stdin)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStartCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStartCommand.java
@@ -55,6 +55,11 @@ public class JobStartCommand extends WildcardJobCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   protected int runWithJobId(final Namespace options, final HeliosClient client,
                              final PrintStream out, final boolean json, final JobId jobId,
                              final BufferedReader stdin)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStopCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStopCommand.java
@@ -55,6 +55,11 @@ public class JobStopCommand extends WildcardJobCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   protected int runWithJobId(final Namespace options, final HeliosClient client,
                              final PrintStream out, final boolean json, final JobId jobId,
                              final BufferedReader stdin)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobUndeployCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobUndeployCommand.java
@@ -78,6 +78,11 @@ public class JobUndeployCommand extends WildcardJobCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   protected int runWithJobId(final Namespace options, final HeliosClient client,
                              final PrintStream out, final boolean json, final JobId jobId,
                              final BufferedReader stdin)

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/MultiTargetControlCommand.java
@@ -20,6 +20,7 @@
 
 package com.spotify.helios.cli.command;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.spotify.helios.cli.Target;
@@ -45,14 +46,19 @@ public abstract class MultiTargetControlCommand implements CliCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return false;
+  }
+
+  @Override
   public int run(final Namespace options, final List<Target> targets, final PrintStream out,
-                 final PrintStream err, final String username, final boolean json,
-                 final BufferedReader stdin)
+                 final PrintStream err, final String username, final Optional<String> accessToken,
+                 final boolean json, final BufferedReader stdin)
       throws Exception {
 
     final Builder<TargetAndClient> clientBuilder = ImmutableList.<TargetAndClient>builder();
     for (final Target target : targets) {
-      final HeliosClient client = Utils.getClient(target, err, username, options);
+      final HeliosClient client = Utils.getClient(target, err, username, accessToken, options);
       if (client == null) {
         return 1;
       }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -147,6 +147,11 @@ public class RollingUpdateCommand extends WildcardJobCommand {
   }
 
   @Override
+  public boolean needsAuthorizaton() {
+    return true;
+  }
+
+  @Override
   protected int runWithJobId(final Namespace options, final HeliosClient client,
                              final PrintStream out, final boolean json, final JobId jobId,
                              final BufferedReader stdin)

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliConfigTest.java
@@ -74,9 +74,13 @@ public class CliConfigTest {
     final File file = temporaryFolder.newFile();
     try (final FileOutputStream outFile = new FileOutputStream(file)) {
       final ByteBuffer byteBuffer = Charsets.UTF_8.encode(
-          "{\"masterEndpoints\":[\"" + ENDPOINT1 + "\", \"" + ENDPOINT2 + "\", \"" + ENDPOINT3
-          + "\"], \"domains\":[\"" + SITE1 + "\", \"" + SITE2 + "\", \"" + SITE3
-          + "\"], \"srvName\":\"foo\"}");
+          "{"
+          + "\"masterEndpoints\":"
+          +     "[\"" + ENDPOINT1 + "\", \"" + ENDPOINT2 + "\", \"" + ENDPOINT3 + "\"],"
+          + "\"domains\":[\"" + SITE1 + "\", \"" + SITE2 + "\", \"" + SITE3 + "\"],"
+          + "\"srvName\":\"foo\","
+          + "\"accessTokenCommand\":[\"echo\", \"Hello World!\"]"
+          + "}");
       outFile.write(byteBuffer.array(), 0, byteBuffer.remaining());
       final CliConfig config = CliConfig.fromFile(file, environment);
 
@@ -96,10 +100,14 @@ public class CliConfigTest {
     expectedEx.expectMessage(Matchers.containsString("Expecting close brace } or a comma"));
 
     try (final FileOutputStream outFile = new FileOutputStream(file)) {
-      outFile.write(Charsets.UTF_8.encode(
-          "{\"masterEndpoints\":[\"" + ENDPOINT1 + "\", \"" + ENDPOINT2 + "\", \"" + ENDPOINT3
-          + "\"], \"domains\":[\"" + SITE1 + "\", \"" + SITE2 + "\", \"" + SITE3
-          + "\"], \"srvName\":\"foo\"").array());
+      ByteBuffer byteBuffer = Charsets.UTF_8.encode(
+          "{"
+          + "\"masterEndpoints\":"
+          +     "[\"" + ENDPOINT1 + "\", \"" + ENDPOINT2 + "\", \"" + ENDPOINT3 + "\"],"
+          + "\"domains\":[\"" + SITE1 + "\", \"" + SITE2 + "\", \"" + SITE3 + "\"],"
+          + "\"srvName\":\"foo\","
+          + "\"accessTokenCommand\":[\"echo\", \"Hello World!\"]");
+      outFile.write(byteBuffer.array(), 0, byteBuffer.remaining());
       CliConfig.fromFile(file, environment);
     }
   }


### PR DESCRIPTION
This PR adds an `accessTokenCommand` key to the `$HOME/.helios/config` file
that may be executed to provide an access token for use with authentication and
authorization. Commands that act mutatively (eg, `helios deploy`) have been
marked as needing authorization; this is not yet enforced.

Needs more testing, but submitting this initial PR to check the approach.

cc @mattnworb @davidxia @mavenraven