### PR TITLE
client: Support authentication using access tokens

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -81,3 +81,20 @@ The latter is typically not suitable for non-interactive use cases (e.g. a scrip
 When you use the Helios API (via the `HeliosClient` class) you have the same options as when using the CLI, as explained above. You can also explicitly set the path where the certificate and key is via the `HeliosClient.Builder.setCertKeyPaths()` method. If a certificate path is set explicitly the `HELIOS_CERT_PATH` is ignored.
 
 Again, for non-interactive use cases relying on ssh-agent is typically not a suitable solution so we recommend that you specify a path either explicitly or via the `HELIOS_CERT_PATH` environment variable.
+
+## Access Tokens
+
+In addition to the above authentication schemes, the `Builder` for the
+`HeliosClient` class will attempt to acquire an access token from Google
+credentials. If it is set, the `HELIOS_GOOGLE_CREDENTIALS` environment variable
+will be used; otherwise, the Application Default Credentials will be used. When
+a token is available, it will be included by the client in all requests using an
+`Authorization: Bearer <token>` header. This feature is enabled by default, but
+can be disabled by passing `--google-credentials=false` at the command line, or
+by calling `setGoogleCredentialsEnabled(false)` on the builder.
+
+Only access tokens derived from Google credentials are supported at this time.
+If Google credentials are not available, the header is simply omitted; the
+client proceeds with the request as before, using the authentication schemes
+described above when possible. The necessary process of verifying the identity
+and enforcing authorization of resources is not implemented in this project.

--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -108,6 +108,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -22,7 +22,9 @@ package com.spotify.helios.client;
 
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.util.Collections.singletonList;
 
+import com.google.auth.oauth2.AccessToken;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -45,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import javax.security.auth.x500.X500Principal;
+import javax.ws.rs.HEAD;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +60,7 @@ public class AuthenticatingHttpConnector implements HttpConnector {
   private static final Logger log = LoggerFactory.getLogger(AuthenticatingHttpConnector.class);
 
   private final String user;
+  private final Optional<AccessToken> accessTokenOpt;
   private final Optional<AgentProxy> agentProxy;
   private final Optional<CertKeyPaths> clientCertificatePath;
   private final List<Identity> identities;
@@ -65,22 +69,25 @@ public class AuthenticatingHttpConnector implements HttpConnector {
   private final DefaultHttpConnector delegate;
 
   public AuthenticatingHttpConnector(final String user,
+                                     final Optional<AccessToken> accessTokenOpt,
                                      final Optional<AgentProxy> agentProxyOpt,
                                      final Optional<CertKeyPaths> clientCertificatePath,
                                      final EndpointIterator endpointIterator,
                                      final DefaultHttpConnector delegate) {
-    this(user, agentProxyOpt, clientCertificatePath, endpointIterator,
+    this(user, accessTokenOpt, agentProxyOpt, clientCertificatePath, endpointIterator,
         delegate, getSshIdentities(agentProxyOpt));
   }
 
   @VisibleForTesting
   AuthenticatingHttpConnector(final String user,
+                              final Optional<AccessToken> accessTokenOpt,
                               final Optional<AgentProxy> agentProxyOpt,
                               final Optional<CertKeyPaths> clientCertificatePath,
                               final EndpointIterator endpointIterator,
                               final DefaultHttpConnector delegate,
                               final List<Identity> identities) {
     this.user = user;
+    this.accessTokenOpt = accessTokenOpt;
     this.agentProxy = agentProxyOpt;
     this.clientCertificatePath = clientCertificatePath;
     this.endpointIterator = endpointIterator;
@@ -105,7 +112,10 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     try {
       log.debug("connecting to {}", ipUri);
 
-      if (clientCertificatePath.isPresent()) {
+      if (accessTokenOpt.isPresent()) {
+        // prioritize using bearer token
+        return connectWithBearerToken(ipUri, method, entity, headers);
+      } else if (clientCertificatePath.isPresent()) {
         // prioritize using the certificate file if set
         return connectWithCertificateFile(ipUri, method, entity, headers);
       } else if (agentProxy.isPresent() && !identities.isEmpty()) {
@@ -127,6 +137,14 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     }
   }
 
+  private HttpURLConnection connectWithBearerToken(final URI ipUri, final String method,
+                                                   final byte[] entity,
+                                                   final Map<String, List<String>> headers)
+      throws HeliosException {
+    headers.put("Authorization", singletonList(String.format("Bearer %s", accessTokenOpt)));
+    return doConnect(ipUri, method, entity, headers);
+  }
+
   private HttpURLConnection connectWithCertificateFile(final URI ipUri, final String method,
                                                        final byte[] entity,
                                                        final Map<String, List<String>> headers)
@@ -135,8 +153,7 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     final CertKeyPaths clientCertificatePath = this.clientCertificatePath.get();
     log.debug("configuring CertificateFileHttpsHandler with {}", clientCertificatePath);
 
-    delegate.setExtraHttpsHandler(CertFileHttpsHandler.create(false, clientCertificatePath)
-    );
+    delegate.setExtraHttpsHandler(CertFileHttpsHandler.create(false, clientCertificatePath));
 
     return doConnect(ipUri, method, entity, headers);
   }

--- a/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthenticatingHttpConnector.java
@@ -113,9 +113,12 @@ public class AuthenticatingHttpConnector implements HttpConnector {
       log.debug("connecting to {}", ipUri);
 
       if (accessTokenOpt.isPresent()) {
-        // prioritize using bearer token
-        return connectWithBearerToken(ipUri, method, entity, headers);
-      } else if (clientCertificatePath.isPresent()) {
+        final String token = accessTokenOpt.get().getTokenValue();
+        headers.put("Authorization", singletonList("Bearer " + token));
+        log.debug("Add Authorization header with bearer token");
+      }
+
+      if (clientCertificatePath.isPresent()) {
         // prioritize using the certificate file if set
         return connectWithCertificateFile(ipUri, method, entity, headers);
       } else if (agentProxy.isPresent() && !identities.isEmpty()) {
@@ -135,14 +138,6 @@ public class AuthenticatingHttpConnector implements HttpConnector {
     } catch (IOException e) {
       throw new HeliosException("Unexpected error connecting to " + ipUri, e);
     }
-  }
-
-  private HttpURLConnection connectWithBearerToken(final URI ipUri, final String method,
-                                                   final byte[] entity,
-                                                   final Map<String, List<String>> headers)
-      throws HeliosException {
-    headers.put("Authorization", singletonList(String.format("Bearer %s", accessTokenOpt)));
-    return doConnect(ipUri, method, entity, headers);
   }
 
   private HttpURLConnection connectWithCertificateFile(final URI ipUri, final String method,

--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
@@ -1,0 +1,77 @@
+/*
+ *  -\-\-
+ *  helios-client
+ *  --
+ *  Copyright (C) 2017 Spotify AB
+ *  --
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *  -/-/-
+ *
+ */
+
+package com.spotify.helios.client;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GoogleCredentialsAccessTokenProvider {
+  private static final Logger log =
+      LoggerFactory.getLogger(GoogleCredentialsAccessTokenProvider.class);
+
+  /**
+   * Attempt to load an Access Token using Google Credentials.
+   * <ol>
+   * <li>First check to see if the environment variable HELIOS_GOOGLE_CREDENTIALS is set
+   * and points to a readable file</li>
+   * <li>Otherwise check if Google Application Default Credentials can be loaded</li>
+   * </ol>
+   *
+   * <p>Note that we use a special environment variable of our own in addition to any environment
+   * variable that the ADC loading uses (GOOGLE_APPLICATION_CREDENTIALS) in case there is a need
+   * for the user to use the latter env var for some other purpose.
+   *
+   * @return Return an AccessToken or null
+   */
+  public static AccessToken getAccessToken() throws IOException {
+    GoogleCredentials credentials = null;
+
+    // first check whether the environment variable is set
+    final String googleCredentialsPath = System.getenv("HELIOS_GOOGLE_CREDENTIALS");
+    if (googleCredentialsPath != null) {
+      final File file = new File(googleCredentialsPath);
+      if (file.exists()) {
+        final FileInputStream s = new FileInputStream(file);
+        credentials = GoogleCredentials.fromStream(s);
+        log.debug("Using Google Credentials from file: " + file.getAbsolutePath());
+      }
+    }
+
+    // fallback to application default credentials
+    if (credentials == null) {
+      credentials = GoogleCredentials.getApplicationDefault();
+      log.debug("Using Google Application Default Credentials");
+    }
+
+    if (credentials == null) {
+      return null;
+    }
+
+    credentials.refresh();
+    return credentials.getAccessToken();
+  }
+}

--- a/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
@@ -64,7 +64,7 @@ public class AuthenticatingHttpConnectorTest {
   private final DefaultHttpConnector connector = mock(DefaultHttpConnector.class);
   private final String method = "GET";
   private final byte[] entity = new byte[0];
-  private final ImmutableMap<String, List<String>> headers = ImmutableMap.of();
+  private final Map<String, List<String>> headers = new HashMap<>();
   private final ImmutableMap<String, List<String>> headersWithAuthorization =
       ImmutableMap.of("Authorization", Collections.singletonList("Bearer <token>"));
 
@@ -106,18 +106,19 @@ public class AuthenticatingHttpConnectorTest {
         connector);
   }
 
-
-  private AuthenticatingHttpConnector createAuthenticatingConnectorWithAccessToken() {
+  private AuthenticatingHttpConnector createAuthenticatingConnectorWithAccessToken(
+      final Optional<AgentProxy> proxy, final List<Identity> identities) {
     final EndpointIterator endpointIterator = EndpointIterator.of(endpoints);
     final AccessToken accessToken =
         new AccessToken("dummy-access-token", null);
 
     return new AuthenticatingHttpConnector(USER,
         Optional.<AccessToken>of(accessToken),
-        Optional.<AgentProxy>absent(),
+        proxy,
         Optional.<CertKeyPaths>absent(),
         endpointIterator,
-        connector);
+        connector,
+        identities);
   }
 
   private CustomTypeSafeMatcher<URI> matchesAnyEndpoint(final String path) {
@@ -135,6 +136,20 @@ public class AuthenticatingHttpConnectorTest {
           }
         }
         return false;
+      }
+    };
+  }
+
+  private CustomTypeSafeMatcher<Map<String, List<String>>> hasKeys(final List<String> keys) {
+    return new CustomTypeSafeMatcher<Map<String, List<String>>>("A map with keys " + keys) {
+      @Override
+      protected boolean matchesSafely(final Map<String, List<String>> map) {
+        for (final String key : keys) {
+          if (!map.containsKey(key)) {
+            return false;
+          }
+        }
+        return true;
       }
     };
   }
@@ -171,7 +186,8 @@ public class AuthenticatingHttpConnectorTest {
   @Test
   public void testAccessToken_ResponseIsOk() throws Exception {
     final AuthenticatingHttpConnector authConnector =
-        createAuthenticatingConnectorWithAccessToken();
+        createAuthenticatingConnectorWithAccessToken(
+            Optional.<AgentProxy>absent(), ImmutableList.<Identity>of());
 
     final String path = "/foo/bar";
 
@@ -179,14 +195,41 @@ public class AuthenticatingHttpConnectorTest {
     when(connector.connect(argThat(matchesAnyEndpoint(path)),
         eq(method),
         eq(entity),
-        eq(headersWithAuthorization))
+        argThat(hasKeys(Collections.singletonList("Authorization"))))
+    ).thenReturn(connection);
+    when(connection.getResponseCode()).thenReturn(200);
+
+    final URI uri = new URI("https://helios" + path);
+    final HttpURLConnection returnedConnection =
+        authConnector.connect(uri, method, entity, headers);
+
+    assertSame(returnedConnection, connection);
+  }
+
+  @Test
+  public void testAccessToken_UsesAgentIdentities() throws Exception {
+    final AgentProxy proxy = mock(AgentProxy.class);
+    final Identity identity = mockIdentity();
+    final AuthenticatingHttpConnector authConnector = createAuthenticatingConnectorWithAccessToken(
+        Optional.of(proxy), ImmutableList.of(identity));
+
+    final String path = "/foo/bar";
+
+    final HttpsURLConnection connection = mock(HttpsURLConnection.class);
+    when(connector.connect(argThat(matchesAnyEndpoint(path)),
+        eq(method),
+        eq(entity),
+        argThat(hasKeys(Collections.singletonList("Authorization"))))
     ).thenReturn(connection);
     when(connection.getResponseCode()).thenReturn(200);
 
     final URI uri = new URI("https://helios" + path);
 
-    final Map<String, List<String>> headers = new HashMap<>();
-    authConnector.connect(uri, method, entity, headers);
+    final HttpURLConnection returnedConnection =
+        authConnector.connect(uri, method, entity, headers);
+    assertSame(returnedConnection, connection);
+
+    verify(connector).setExtraHttpsHandler(isA(HttpsHandler.class));
   }
 
   @Test
@@ -341,9 +384,7 @@ public class AuthenticatingHttpConnectorTest {
     final HttpURLConnection returnedConnection = authConnector.connect(
         uri, method, entity, headers);
 
-    assertSame("If there is only one identity do not expect any additional endpoints to "
-               + "be called after the first returns Unauthorized",
-        returnedConnection, connection);
-
+    assertSame("Expect client to forego making additional connections when "
+               + "server returns 502 Bad Gateway", returnedConnection, connection);
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/AuthenticatingHttpConnectorTest.java
@@ -109,8 +109,7 @@ public class AuthenticatingHttpConnectorTest {
   private AuthenticatingHttpConnector createAuthenticatingConnectorWithAccessToken(
       final Optional<AgentProxy> proxy, final List<Identity> identities) {
     final EndpointIterator endpointIterator = EndpointIterator.of(endpoints);
-    final AccessToken accessToken =
-        new AccessToken("dummy-access-token", null);
+    final AccessToken accessToken = new AccessToken("<token>", null);
 
     return new AuthenticatingHttpConnector(USER,
         Optional.<AccessToken>of(accessToken),

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -29,7 +29,6 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static net.sourceforge.argparse4j.impl.Arguments.SUPPRESS;
 import static net.sourceforge.argparse4j.impl.Arguments.append;
-import static net.sourceforge.argparse4j.impl.Arguments.fileType;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -265,7 +264,6 @@ public class CliParser {
     private final Argument domainsArg;
     private final Argument srvNameArg;
     private final Argument usernameArg;
-    private final Argument useGoogleCredentialsArg;
     private final Argument googleCredentialsArg;
     private final Argument verbose;
     private final Argument noLogSetup;
@@ -299,15 +297,10 @@ public class CliParser {
           .setDefault(System.getProperty("user.name"))
           .help("username");
 
-      useGoogleCredentialsArg = addArgument("--use-google-credentials")
+      googleCredentialsArg = addArgument("--google-credentials")
           .type(Boolean.class)
           .setDefault(true)
-          .help("authenticate using access token derived from Google Credentials");
-
-      googleCredentialsArg = addArgument("--google-credentials")
-          .type(fileType().verifyExists().verifyCanRead())
-          .help("path to a Google Credentials file; when not provided, Application "
-                + "Default Credentials will be used");
+          .help("enable authentication using access tokens derived from Google Credentials");
 
       verbose = addArgument("-v", "--verbose")
           .action(Arguments.count());

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -29,6 +29,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static net.sourceforge.argparse4j.impl.Arguments.SUPPRESS;
 import static net.sourceforge.argparse4j.impl.Arguments.append;
+import static net.sourceforge.argparse4j.impl.Arguments.fileType;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -264,6 +265,7 @@ public class CliParser {
     private final Argument domainsArg;
     private final Argument srvNameArg;
     private final Argument usernameArg;
+    private final Argument useGoogleCredentialsArg;
     private final Argument googleCredentialsArg;
     private final Argument verbose;
     private final Argument noLogSetup;
@@ -297,10 +299,15 @@ public class CliParser {
           .setDefault(System.getProperty("user.name"))
           .help("username");
 
-      googleCredentialsArg = addArgument("--google-application-default-credentials")
+      useGoogleCredentialsArg = addArgument("--use-google-credentials")
           .type(Boolean.class)
           .setDefault(true)
-          .help(SUPPRESS);
+          .help("authenticate using access token derived from Google Credentials");
+
+      googleCredentialsArg = addArgument("--google-credentials")
+          .type(fileType().verifyExists().verifyCanRead())
+          .help("path to a Google Credentials file; when not provided, Application "
+                + "Default Credentials will be used");
 
       verbose = addArgument("-v", "--verbose")
           .action(Arguments.count());

--- a/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/CliParser.java
@@ -264,6 +264,7 @@ public class CliParser {
     private final Argument domainsArg;
     private final Argument srvNameArg;
     private final Argument usernameArg;
+    private final Argument googleCredentialsArg;
     private final Argument verbose;
     private final Argument noLogSetup;
     private final Argument jsonArg;
@@ -295,6 +296,11 @@ public class CliParser {
       usernameArg = addArgument("-u", "--username")
           .setDefault(System.getProperty("user.name"))
           .help("username");
+
+      googleCredentialsArg = addArgument("--google-application-default-credentials")
+          .type(Boolean.class)
+          .setDefault(true)
+          .help(SUPPRESS);
 
       verbose = addArgument("-v", "--verbose")
           .action(Arguments.count());

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -33,7 +33,6 @@ import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.protocol.SetGoalResponse;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
@@ -83,15 +82,12 @@ public final class Utils {
 
     log.debug("using HeliosClient httpTimeout={}, retryTimeout={}", httpTimeout, retryTimeout);
 
-
-
     return HeliosClient.newBuilder()
         .setEndpointSupplier(Endpoints.of(target.getEndpointSupplier()))
         .setHttpTimeout(httpTimeout, TimeUnit.SECONDS)
         .setRetryTimeout(retryTimeout, TimeUnit.SECONDS)
         .setSslHostnameVerification(!options.getBoolean("insecure"))
-        .setUseGoogleCredentials(options.getBoolean("use_google_credentials"))
-        .setGoogleCredentials(options.<File>get("google_credentials"))
+        .setGoogleCredentialsEnabled(options.getBoolean("google_credentials"))
         .setUser(username)
         .build();
   }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -87,6 +87,8 @@ public final class Utils {
         .setHttpTimeout(httpTimeout, TimeUnit.SECONDS)
         .setRetryTimeout(retryTimeout, TimeUnit.SECONDS)
         .setSslHostnameVerification(!options.getBoolean("insecure"))
+        .setGoogleApplicationDefaultCredentials(
+            options.getBoolean("google_application_default_credentials"))
         .setUser(username)
         .build();
   }

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Utils.java
@@ -33,6 +33,7 @@ import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.HostSelector;
 import com.spotify.helios.common.protocol.SetGoalResponse;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
@@ -82,13 +83,15 @@ public final class Utils {
 
     log.debug("using HeliosClient httpTimeout={}, retryTimeout={}", httpTimeout, retryTimeout);
 
+
+
     return HeliosClient.newBuilder()
         .setEndpointSupplier(Endpoints.of(target.getEndpointSupplier()))
         .setHttpTimeout(httpTimeout, TimeUnit.SECONDS)
         .setRetryTimeout(retryTimeout, TimeUnit.SECONDS)
         .setSslHostnameVerification(!options.getBoolean("insecure"))
-        .setGoogleApplicationDefaultCredentials(
-            options.getBoolean("google_application_default_credentials"))
+        .setUseGoogleCredentials(options.getBoolean("use_google_credentials"))
+        .setGoogleCredentials(options.<File>get("google_credentials"))
         .setUser(username)
         .build();
   }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -22,6 +22,7 @@ package com.spotify.helios.cli;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Charsets;
@@ -34,8 +35,10 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class CliParserTest {
@@ -194,17 +197,26 @@ public class CliParserTest {
   }
 
   @Test
-  public void testGoogleApplicationDefaultCredentialsEnabledByDefault() throws Exception {
+  public void testGoogleCredentialsEnabledByDefault() throws Exception {
     final CliParser parser = new CliParser(toArray(singleEndpointArgs));
 
-    assertTrue(parser.getNamespace().getBoolean("google_application_default_credentials"));
+    assertTrue(parser.getNamespace().getBoolean("use_google_credentials"));
+    assertNull(parser.getNamespace().getString("google_credentials"));
   }
 
   @Test
-  public void testGoogleApplicationDefaultCredentialsDisabled() throws Exception {
+  public void testGoogleCredentialsDisabled() throws Exception {
     final CliParser parser = new CliParser(
-        toArray(singleEndpointArgs, "--google-application-default-credentials=false"));
+        toArray(singleEndpointArgs, "--use-google-credentials=false"));
 
-    assertFalse(parser.getNamespace().getBoolean("google_application_default_credentials"));
+    assertFalse(parser.getNamespace().getBoolean("use_google_credentials"));
+    assertNull(parser.getNamespace().getString("google_credentials"));
+  }
+
+  @Test
+  public void testGoogleCredentialsFromFile() throws Exception {
+    final CliParser parser = new CliParser(
+        toArray(singleEndpointArgs, "--google-credentials=/dev/null"));
+    assertEquals(new File("/dev/null"), parser.getNamespace().get("google_credentials"));
   }
 }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -199,24 +199,13 @@ public class CliParserTest {
   @Test
   public void testGoogleCredentialsEnabledByDefault() throws Exception {
     final CliParser parser = new CliParser(toArray(singleEndpointArgs));
-
-    assertTrue(parser.getNamespace().getBoolean("use_google_credentials"));
-    assertNull(parser.getNamespace().getString("google_credentials"));
+    assertTrue(parser.getNamespace().getBoolean("google_credentials"));
   }
 
   @Test
-  public void testGoogleCredentialsDisabled() throws Exception {
+  public void testDisableGoogleCredentials() throws Exception {
     final CliParser parser = new CliParser(
-        toArray(singleEndpointArgs, "--use-google-credentials=false"));
-
-    assertFalse(parser.getNamespace().getBoolean("use_google_credentials"));
-    assertNull(parser.getNamespace().getString("google_credentials"));
-  }
-
-  @Test
-  public void testGoogleCredentialsFromFile() throws Exception {
-    final CliParser parser = new CliParser(
-        toArray(singleEndpointArgs, "--google-credentials=/dev/null"));
-    assertEquals(new File("/dev/null"), parser.getNamespace().get("google_credentials"));
+        toArray(singleEndpointArgs, "--google-credentials=false"));
+    assertFalse(parser.getNamespace().getBoolean("google_credentials"));
   }
 }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -192,4 +192,19 @@ public class CliParserTest {
 
     assertTrue(parser.getNamespace().getBoolean("insecure"));
   }
+
+  @Test
+  public void testGoogleApplicationDefaultCredentialsEnabledByDefault() throws Exception {
+    final CliParser parser = new CliParser(toArray(singleEndpointArgs));
+
+    assertTrue(parser.getNamespace().getBoolean("google_application_default_credentials"));
+  }
+
+  @Test
+  public void testGoogleApplicationDefaultCredentialsDisabled() throws Exception {
+    final CliParser parser = new CliParser(
+        toArray(singleEndpointArgs, "--google-application-default-credentials=false"));
+
+    assertFalse(parser.getNamespace().getBoolean("google_application_default_credentials"));
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -353,12 +353,12 @@
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-credentials</artifactId>
-                <version>0.4.0</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
-                <version>0.4.0</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
This adds support for acquiring an access token within the HeliosClient
Builder via Google Application Default Credentials. When available, the
client will prefer to send an access token in requests as the means for
authentication. As we don't intend for Google credentials to be a hard
requirement, the client will fall back onto the existing authentication
mechanism of self-signed certs and mutual TLS if tokens are unavailable.


An alternative approach to https://github.com/spotify/helios/pull/1133. This approach foregoes pretense of making this a generic access token and enables use of the token by default. I can add a flag to disable use of the token if we feel that's obligated.

cc @mattnworb @mavenraven @davidxia 