### PR TITLE
helios-testing: shade and relocate guava classes

### DIFF
--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -82,6 +82,35 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <configuration>
+                    <createSourcesJar>true</createSourcesJar>
+                    <artifactSet>
+                        <includes>
+                            <include>com.google.guava:**</include>
+                        </includes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>com.spotify.helios.testing.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
 </project>


### PR DESCRIPTION
Adds a second artifact for helios-testing (with classifier=`shaded`)
that relocates Guava classes inside the JAR to a new package name.

This aims to cut down on pain internally whenever a team wants to
upgrade a project to a newer version of helios-testing, as Guava
incompatibilities from different versions being used is a common
headache or roadblock.

Closes #1119