### PR TITLE
JobValidator: improve error message when job.expires is in past

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -174,8 +174,9 @@ public class JobValidator {
 
     // Validate Expiry
     final Date expiry = job.getExpires();
-    if (expiry != null && expiry.before(new Date())) {
-      errors.add("Job expires in the past");
+    final Date now = new Date();
+    if (expiry != null && expiry.before(now)) {
+      errors.add("Job expires in the past - " + expiry + " is before " + now);
     }
 
     errors.addAll(validateJobHealthCheck(job));

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -455,7 +456,7 @@ public class JobValidatorTest {
     final java.util.Date d = new java.util.Date(System.currentTimeMillis() - (86400 * 1000));
     final Job j = Job.newBuilder().setName("foo").setVersion("1").setImage("foobar")
         .setExpires(d).build();
-    assertEquals(newHashSet("Job expires in the past"), validator.validate(j));
+    assertThat(validator.validate(j), contains(startsWith("Job expires in the past")));
   }
 
   @Test


### PR DESCRIPTION
I helped someone troubleshoot a problem where their integration tests
could not deploy any job to helios-solo because helios-master rejected
the job as the job.expires field was in the past.

After a lot of debugging, we found the cause of this was another test
in their test suite where the global state in joda-time's
`DateTimeUtils` was set and never cleared. TemporaryJobsBuilder uses
`new DateTime()` from joda-time to get the current time and add 30
minutes onto it when setting the default job.expires value.

One thing that was a big help in troubleshooting this was modifying the
JobValidator inside the helios-solo image to output the job.expires
value it was receiving and rejecting, and I think this additional output
would be helpful in general beyond the one specific bug I was hunting.