### PR TITLE
upgrade to jackson 2.9.0, change Json property inclusion

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/Json.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/Json.java
@@ -51,7 +51,10 @@ public class Json {
       .configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private static final ObjectWriter NORMALIZING_OBJECT_WRITER = new ObjectMapper()
-      .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+      .setDefaultPropertyInclusion(
+          //parameters are valueIncl=NON_EMPTY, contentIncl=ALWAYS
+          JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.ALWAYS)
+      )
       .configure(SORT_PROPERTIES_ALPHABETICALLY, true)
       .configure(ORDER_MAP_ENTRIES_BY_KEYS, true)
       .configure(WRITE_DATES_AS_TIMESTAMPS, false)

--- a/pom.xml
+++ b/pom.xml
@@ -157,32 +157,32 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>2.8.8</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-guava</artifactId>
-                <version>2.8.8</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.8.8</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.8.8</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.8.8</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>2.8.8</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
~~~merging this will break the tests of any helios-testing users, who will end up downloading a new docker image of `spotify/helios-solo:latest` on their next test run. All test users will have to upgrade their helios-testing/helios-client dependency in sync with the merge of this PR.~~~

Fixes #1143.