### PR TITLE
Image validation: allow both tag and digest

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -355,17 +355,26 @@ public class JobValidator {
     final String digest;
 
     final int lastAtSign = imageRef.lastIndexOf('@');
-    final int lastColon = imageRef.lastIndexOf(':');
+    final int tagColon;
+    final int tagEnd;
 
+    // Parse digest
     if (lastAtSign != -1) {
-      repo = imageRef.substring(0, lastAtSign);
       digest = imageRef.substring(lastAtSign + 1);
+      tagEnd = lastAtSign;
+      tagColon = imageRef.lastIndexOf(':', tagEnd);
       valid &= validateDigest(digest, errors);
-    } else if (lastColon != -1 && !(tag = imageRef.substring(lastColon + 1)).contains("/")) {
-      repo = imageRef.substring(0, lastColon);
+    } else {
+      tagColon = imageRef.lastIndexOf(':');
+      tagEnd = imageRef.length();
+    }
+
+    // Parse tag
+    if (tagColon != -1 && !(tag = imageRef.substring(tagColon + 1, tagEnd)).contains("/")) {
+      repo = imageRef.substring(0, tagColon);
       valid &= validateTag(tag, errors);
     } else {
-      repo = imageRef;
+      repo = imageRef.substring(0, tagEnd);
     }
 
     final String invalidRepoName = "Invalid repository name (ex: \"registry.domain.tld/myrepos\")";

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -138,11 +138,13 @@ public class JobValidatorTest {
             .build()), is(empty()));
     assertThat(
         validator.validate(b.setImage(
-            "baz.io/foo/foo-bar:1.2.3-SNAPSHOT-20170830T143321-decafbad@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+            "baz.io/foo/foo-bar:1.2.3-SNAPSHOT-20170830T143321-decafbad"
+                + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
             .build()), is(empty()));
     assertThat(
         validator.validate(b.setImage(
-            "baz.io:4711/foo/foo-bar:1.2.3-SNAPSHOT-20170830T143321-decafbad@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+            "baz.io:4711/foo/foo-bar:1.2.3-SNAPSHOT-20170830T143321-decafbad"
+                + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
             .build()), is(empty()));
   }
 
@@ -255,7 +257,8 @@ public class JobValidatorTest {
         validator.validate(b.setImage("repo:").build()));
 
     assertEquals(newHashSet("Tag cannot be empty"),
-        validator.validate(b.setImage("repo:@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("repo:"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Digest cannot be empty"),
         validator.validate(b.setImage("foo@").build()));
@@ -290,7 +293,8 @@ public class JobValidatorTest {
         validator.validate(b.setImage("reg.istry :4711/repo").build()));
 
     assertEquals(newHashSet("Invalid domain name: \"1.2.3.4.\""),
-        validator.validate(b.setImage("1.2.3.4.:4711/namespace/repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("1.2.3.4.:4711/namespace/repo"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"reg.istry: 4711\""),
         validator.validate(b.setImage("reg.istry: 4711/repo").build()));
@@ -299,7 +303,8 @@ public class JobValidatorTest {
         validator.validate(b.setImage("reg.istry:4711 /repo").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"reg.istry:4711 \""),
-        validator.validate(b.setImage("reg.istry:4711 /repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("reg.istry:4711 /repo"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid image name (reg.istry:4711/ repo), only ^([a-z0-9._-]+)$ is "
                             + "allowed for each slash-separated name component "
@@ -321,10 +326,12 @@ public class JobValidatorTest {
                             + "(failed on \"repo \")"),
         validator.validate(b.setImage("reg.istry:4711/namespace/repo ").build()));
 
-    assertEquals(newHashSet("Invalid image name (reg.istry:4711/namespace/ repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae), only "
+    assertEquals(newHashSet("Invalid image name (reg.istry:4711/namespace/ repo"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae), only "
                             + "^([a-z0-9._-]+)$ is allowed for each slash-separated name component "
                             + "(failed on \" repo\")"),
-        validator.validate(b.setImage("reg.istry:4711/namespace/ repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("reg.istry:4711/namespace/ repo"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid domain name: \"foo-.ba|z\""),
         validator.validate(b.setImage("foo-.ba|z/namespace/baz").build()));
@@ -339,10 +346,12 @@ public class JobValidatorTest {
         validator.validate(b.setImage("reg..istry/namespace/baz:foo").build()));
 
     assertEquals(newHashSet("Invalid domain name: \"reg..istry\""),
-        validator.validate(b.setImage("reg..istry/namespace/baz:foo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("reg..istry/namespace/baz:foo"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid domain name: \"reg..istry\""),
-        validator.validate(b.setImage("reg..istry/namespace/baz@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("reg..istry/namespace/baz"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"foo:345345345\""),
         validator.validate(b.setImage("foo:345345345/namespace/baz").build()));
@@ -351,7 +360,8 @@ public class JobValidatorTest {
         validator.validate(b.setImage("foo:345345345/namespace/baz:bar").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"foo:345345345\""),
-        validator.validate(b.setImage("foo:345345345/namespace/baz:bar@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+        validator.validate(b.setImage("foo:345345345/namespace/baz:bar"
+            + "@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"foo:-17\""),
         validator.validate(b.setImage("foo:-17/namespace/baz").build()));

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -136,6 +136,14 @@ public class JobValidatorTest {
         validator.validate(b.setImage(
             "foo@tarsum.v1+sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b")
             .build()), is(empty()));
+    assertThat(
+        validator.validate(b.setImage(
+            "baz.io/foo/foo-bar:1.2.3-SNAPSHOT-20170830T143321-decafbad@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+            .build()), is(empty()));
+    assertThat(
+        validator.validate(b.setImage(
+            "baz.io:4711/foo/foo-bar:1.2.3-SNAPSHOT-20170830T143321-decafbad@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+            .build()), is(empty()));
   }
 
   @Test
@@ -243,14 +251,29 @@ public class JobValidatorTest {
     assertEquals(newHashSet("Tag cannot be empty"),
         validator.validate(b.setImage("repo:").build()));
 
+    assertEquals(newHashSet("Tag cannot be empty"),
+        validator.validate(b.setImage("repo:").build()));
+
+    assertEquals(newHashSet("Tag cannot be empty"),
+        validator.validate(b.setImage("repo:@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+
     assertEquals(newHashSet("Digest cannot be empty"),
         validator.validate(b.setImage("foo@").build()));
 
     assertEquals(newHashSet("Illegal digest: \":123\""),
         validator.validate(b.setImage("foo@:123").build()));
 
+    assertEquals(newHashSet("Illegal digest: \":123\""),
+        validator.validate(b.setImage("foo:bar@:123").build()));
+
     assertEquals(newHashSet("Illegal digest: \"sha256:\""),
         validator.validate(b.setImage("foo@sha256:").build()));
+
+    assertEquals(newHashSet("Illegal digest: \"sha256:\""),
+        validator.validate(b.setImage("foo:bar@sha256:").build()));
+
+    assertEquals(newHashSet("Illegal digest: \"sha256:\""),
+        validator.validate(b.setImage("foo:4711/baz:bar@sha256:").build()));
 
     assertFalse(validator.validate(b.setImage("repo:/").build()).isEmpty());
 
@@ -266,11 +289,17 @@ public class JobValidatorTest {
     assertEquals(newHashSet("Invalid domain name: \"reg.istry \""),
         validator.validate(b.setImage("reg.istry :4711/repo").build()));
 
+    assertEquals(newHashSet("Invalid domain name: \"1.2.3.4.\""),
+        validator.validate(b.setImage("1.2.3.4.:4711/namespace/repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+
     assertEquals(newHashSet("Invalid port in endpoint: \"reg.istry: 4711\""),
         validator.validate(b.setImage("reg.istry: 4711/repo").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"reg.istry:4711 \""),
         validator.validate(b.setImage("reg.istry:4711 /repo").build()));
+
+    assertEquals(newHashSet("Invalid port in endpoint: \"reg.istry:4711 \""),
+        validator.validate(b.setImage("reg.istry:4711 /repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid image name (reg.istry:4711/ repo), only ^([a-z0-9._-]+)$ is "
                             + "allowed for each slash-separated name component "
@@ -292,6 +321,11 @@ public class JobValidatorTest {
                             + "(failed on \"repo \")"),
         validator.validate(b.setImage("reg.istry:4711/namespace/repo ").build()));
 
+    assertEquals(newHashSet("Invalid image name (reg.istry:4711/namespace/ repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae), only "
+                            + "^([a-z0-9._-]+)$ is allowed for each slash-separated name component "
+                            + "(failed on \" repo\")"),
+        validator.validate(b.setImage("reg.istry:4711/namespace/ repo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+
     assertEquals(newHashSet("Invalid domain name: \"foo-.ba|z\""),
         validator.validate(b.setImage("foo-.ba|z/namespace/baz").build()));
 
@@ -301,8 +335,23 @@ public class JobValidatorTest {
     assertEquals(newHashSet("Invalid domain name: \"reg..istry\""),
         validator.validate(b.setImage("reg..istry/namespace/baz").build()));
 
+    assertEquals(newHashSet("Invalid domain name: \"reg..istry\""),
+        validator.validate(b.setImage("reg..istry/namespace/baz:foo").build()));
+
+    assertEquals(newHashSet("Invalid domain name: \"reg..istry\""),
+        validator.validate(b.setImage("reg..istry/namespace/baz:foo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+
+    assertEquals(newHashSet("Invalid domain name: \"reg..istry\""),
+        validator.validate(b.setImage("reg..istry/namespace/baz@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
+
     assertEquals(newHashSet("Invalid port in endpoint: \"foo:345345345\""),
         validator.validate(b.setImage("foo:345345345/namespace/baz").build()));
+
+    assertEquals(newHashSet("Invalid port in endpoint: \"foo:345345345\""),
+        validator.validate(b.setImage("foo:345345345/namespace/baz:bar").build()));
+
+    assertEquals(newHashSet("Invalid port in endpoint: \"foo:345345345\""),
+        validator.validate(b.setImage("foo:345345345/namespace/baz:bar@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae").build()));
 
     assertEquals(newHashSet("Invalid port in endpoint: \"foo:-17\""),
         validator.validate(b.setImage("foo:-17/namespace/baz").build()));


### PR DESCRIPTION
Allow both tag and digest in docker image references.