### PR TITLE
jackson: use 2.8.6 - avoid bugs in 2.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,32 +157,32 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.6</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-guava</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.6</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.6</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.6</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.6</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>2.8.8</version>
+                <version>2.8.6</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
People are having issues with jackson 2.8.8 as required by helios-test due to this issue: https://github.com/FasterXML/jackson-databind/issues/1756