### PR TITLE
Adds container stat logging.

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -115,6 +115,13 @@ class TaskRunner extends InterruptingExecutionThreadService {
     // Interrupt the thread blocking on waitContainer
     stopAsync().awaitTerminated();
 
+    if (System.getenv("CONTAINER_STATS") != null) {
+      try {
+        log.info("container {} stats: {}", containerName, docker.stats(containerName));
+      } catch (DockerException e) {
+        log.warn("Could not log container stats. Exception was {}", e);
+      }
+    }
     try {
       docker.stopContainer(container, secondsToWaitBeforeKill);
     } catch (DockerException e) {


### PR DESCRIPTION
Will now log something like:

```
11:39:53.009 helios[10076]: INFO  [Reactor(supervisor-nginx-job:1:37a95798891e139654cb43fc4ae7d81eed31d909)] TaskRunner: container helios-6C61263F2E604C7BA07AB38A3BD6048E212A03DD-nginx-job_1_37a9579_e526ad0d stats: ContainerStats{read=Thu Sep 07 11:39:39 EDT 2017, network=null, networks={eth0=NetworkStats{rxBytes=1296, rxPackets=16, rxDropped=0, rxErrors=0, txBytes=0, txPackets=0, txDropped=0, txErrors=0}}, memoryStats=MemoryStats{stats=Stats{activeFile=36864, totalActiveFile=36864, inactiveFile=8192, totalInactiveFile=8192, cache=73728, totalCache=73728, activeAnon=1417216, totalActiveAnon=1417216, inactiveAnon=8192, totalInactiveAnon=8192, hierarchicalMemoryLimit=9223372036854771712, mappedFile=4096, totalMappedFile=4096, pgmajfault=0, totalPgmajfault=0, pgpgin=802, totalPgpgin=802, pgpgout=443, totalPgpgout=443, pgfault=1041, totalPgfault=1041, rss=1396736, totalRss=1396736, rssHuge=0, totalRssHuge=0, unevictable=0, totalUnevictable=0, totalWriteback=0, writeback=0}, maxUsage=1835008, usage=1593344, failcnt=null, limit=1044127744}, blockIoStats=BlockIoStats{ioServiceBytesRecursive=[], ioServicedRecursive=[], ioQueueRecursive=[], ioServiceTimeRecursive=[], ioWaitTimeRecursive=[], ioMergedRecursive=[], ioTimeRecursive=[], sectorsRecursive=[]}, cpuStats=CpuStats{cpuUsage=CpuUsage{totalUsage=24327596, percpuUsage=[24327596], usageInKernelmode=0, usageInUsermode=20000000}, systemCpuUsage=201670000000, throttlingData=ThrottlingData{periods=0, throttledPeriods=0, throttledTime=0}}, precpuStats=CpuStats{cpuUsage=CpuUsage{totalUsage=24327596, percpuUsage=[24327596], usageInKernelmode=0, usageInUsermode=20000000}, systemCpuUsage=200670000000, throttlingData=ThrottlingData{periods=0, throttledPeriods=0, throttledTime=0}}}
```
before attempting to shut down the container.
