### PR TITLE
Add log message for rolling-update failures

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/rollingupdate/RollingUpdateOpFactory.java
@@ -195,6 +195,8 @@ public class RollingUpdateOpFactory {
         deploymentGroup, task, errMsg, errorCode, metadata);
     events.add(taskEv);
     events.add(eventFactory.rollingUpdateFailed(deploymentGroup, taskEv));
+    log.info("rolling-update step on deployment-group name={} failed; message={}",
+        deploymentGroup.getName(), errMsg);
 
     return new RollingUpdateOp(ImmutableList.copyOf(operations),
         ImmutableList.copyOf(events));


### PR DESCRIPTION
Presently, helios-master will emit Kafka and Google Cloud PubSub events
when a rolling-update fails (in addition to storing the failure and
error message in ZooKeeper). This change adds a log message for the
failure as well, which should be useful for systems without a defined
event handler or for quick-and-dirty integrations that don't need the
larger feature set of something like Kafka or Google Cloud PubSub.

@davidxia @mattnworb @mavenraven