### PR TITLE
client: Add cloud-platform scope to GoogleCredentials

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
@@ -21,6 +21,8 @@
 
 package com.spotify.helios.client;
 
+import static java.util.Collections.singletonList;
+
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.File;
@@ -29,7 +31,7 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GoogleCredentialsAccessTokenProvider {
+class GoogleCredentialsAccessTokenProvider {
   private static final Logger log =
       LoggerFactory.getLogger(GoogleCredentialsAccessTokenProvider.class);
 
@@ -38,7 +40,7 @@ public class GoogleCredentialsAccessTokenProvider {
    * <ol>
    * <li>First check to see if the environment variable HELIOS_GOOGLE_CREDENTIALS is set
    * and points to a readable file</li>
-   * <li>Otherwise check if Google Application Default Credentials can be loaded</li>
+   * <li>Otherwise check if Google Application Default Credentials (ADC) can be loaded</li>
    * </ol>
    *
    * <p>Note that we use a special environment variable of our own in addition to any environment
@@ -47,7 +49,7 @@ public class GoogleCredentialsAccessTokenProvider {
    *
    * @return Return an AccessToken or null
    */
-  public static AccessToken getAccessToken() throws IOException {
+  static AccessToken getAccessToken() throws IOException {
     GoogleCredentials credentials = null;
 
     // first check whether the environment variable is set
@@ -71,7 +73,11 @@ public class GoogleCredentialsAccessTokenProvider {
       return null;
     }
 
+    // Google Service Account Credentials require an access scope before calling `refresh()`;
+    // see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam.
+    credentials.createScoped(singletonList("https://www.googleapis.com/auth/cloud-platform"));
     credentials.refresh();
+
     return credentials.getAccessToken();
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
@@ -28,6 +28,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ class GoogleCredentialsAccessTokenProvider {
    *
    * @return Return an AccessToken or null
    */
-  static AccessToken getAccessToken() throws IOException {
+  static AccessToken getAccessToken(List<String> scopes) throws IOException {
     GoogleCredentials credentials = null;
 
     // first check whether the environment variable is set
@@ -73,11 +74,17 @@ class GoogleCredentialsAccessTokenProvider {
       return null;
     }
 
-    // Google Service Account Credentials require an access scope before calling `refresh()`;
-    // see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam.
-    credentials.createScoped(singletonList("https://www.googleapis.com/auth/cloud-platform"));
+    if (!scopes.isEmpty()) {
+      credentials.createScoped(scopes);
+    }
     credentials.refresh();
 
     return credentials.getAccessToken();
+  }
+
+  static AccessToken getAccessToken() throws IOException {
+    // Google Service Account Credentials require an access scope before calling `refresh()`;
+    // see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam.
+    return getAccessToken(singletonList("https://www.googleapis.com/auth/cloud-platform"));
   }
 }


### PR DESCRIPTION
When the `GoogleCredentials` to use are `ServiceAccountCredentials`, we
must define an access scope before calling `refresh()`. Though it is
quite broad, the `https://www.googleapis.com/auth/cloud-platform` scope
is necessary to make API requests against Google Cloud IAM and many
other Google Cloud Platform APIs, so we must use it here.

@mattnworb @mavenraven