### PR TITLE
Add note about using hosts for label discovery in deployment groups

### DIFF
--- a/docs/deployment_groups.md
+++ b/docs/deployment_groups.md
@@ -31,6 +31,14 @@ Creating a deployment group with the same name and labels as an existing one wil
 "not modified" response. Creating a deployment group with the same name but different labels as an
 existing one will return an error stating that the deployment group already exists.
 
+To figure out which labels are available and what sort of hosts each label key
+and value would return, you can use
+
+    $ helios hosts some-substring
+
+This will return a lot of information, including which labels (and values)
+apply to each host.
+
 ### Updating the definition
 
 To change the definition of a deployment group, such as adding/removing host


### PR DESCRIPTION
This adds a quick note to use the `helios hosts` command to figure out which labels (and values) apply to a given host.