### PR TITLE
Fix RollingUpdateCommand to print correct rollout options

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/RolloutOptions.java
@@ -101,10 +101,9 @@ public class RolloutOptions {
         .setIgnoreFailures(ignoreFailures);
   }
 
-
   /**
    * Return a new RolloutOptions instance by merging this instance with another one.
-   * The other instance is assumed to have no null-valued fields.
+   * @throws NullPointerException if any attribute in both instances are null.
    */
   public RolloutOptions withFallback(final RolloutOptions that) {
     return RolloutOptions.newBuilder()

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DeploymentGroupTest.java
@@ -23,6 +23,7 @@ package com.spotify.helios.system;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Iterables.getLast;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;
+import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -50,6 +51,7 @@ import com.spotify.helios.common.descriptors.HostStatus;
 import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
+import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatus;
 import com.spotify.helios.common.protocol.DeploymentGroupStatusResponse;
 import com.spotify.helios.common.protocol.HostDeregisterResponse;
@@ -130,7 +132,23 @@ public class DeploymentGroupTest extends SystemTestBase {
 
     // create a deployment group and job
     cli("create-deployment-group", "--json", TEST_GROUP, TEST_LABEL);
-    final JobId jobId = createJob(testJobName, testJobVersion, BUSYBOX, IDLE_COMMAND);
+
+    final Job job1 = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(testJobVersion)
+        .setImage(BUSYBOX)
+        .setHostname(null)
+        .setCommand(IDLE_COMMAND)
+        .setEnv(emptyMap())
+        .setPorts(emptyMap())
+        .setRegistration(emptyMap())
+        .setGracePeriod(null)
+        .setVolumes(emptyMap())
+        .setExpires(null)
+        .setRolloutOptions(RolloutOptions.newBuilder().build())
+        .build();
+
+    final JobId jobId = createJob(job1);
 
     // TODO: fix this!
     // Wait to make sure the host-update has run
@@ -152,7 +170,22 @@ public class DeploymentGroupTest extends SystemTestBase {
     // create a second job
     final String secondJobVersion = testJobVersion + "2";
     final String secondJobNameAndVersion = testJobNameAndVersion + "2";
-    final JobId secondJobId = createJob(testJobName, secondJobVersion, BUSYBOX, IDLE_COMMAND);
+
+    final Job job2 = Job.newBuilder()
+        .setName(testJobName)
+        .setVersion(secondJobVersion)
+        .setImage(BUSYBOX)
+        .setHostname(null)
+        .setCommand(IDLE_COMMAND)
+        .setEnv(emptyMap())
+        .setPorts(emptyMap())
+        .setRegistration(emptyMap())
+        .setGracePeriod(null)
+        .setVolumes(emptyMap())
+        .setExpires(null)
+        .setRolloutOptions(RolloutOptions.newBuilder().build())
+        .build();
+    final JobId secondJobId = createJob(job2);
 
     // trigger a rolling update to replace the first job with the second job
     final String output = cli("rolling-update", secondJobNameAndVersion, TEST_GROUP);

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobDeployCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobDeployCommand.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.protocol.JobDeployResponse;
 import java.io.BufferedReader;
@@ -74,16 +75,17 @@ public class JobDeployCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws ExecutionException, InterruptedException {
+    final JobId jobId = job.getId();
     final List<String> hosts = options.getList(hostsArg.getDest());
-    final Deployment job = Deployment.of(jobId,
+    final Deployment deployment = Deployment.of(jobId,
         options.getBoolean(noStartArg.getDest()) ? STOP : START);
 
     if (!json) {
-      out.printf("Deploying %s on %s%n", job, hosts);
+      out.printf("Deploying %s on %s%n", deployment, hosts);
     }
 
     int code = 0;
@@ -98,7 +100,7 @@ public class JobDeployCommand extends WildcardJobCommand {
         out.printf("%s: ", host);
       }
       final String token = options.getString(tokenArg.getDest());
-      final JobDeployResponse result = client.deploy(job, host, token).get();
+      final JobDeployResponse result = client.deploy(deployment, host, token).get();
       if (result.getStatus() == JobDeployResponse.Status.OK) {
         if (!json) {
           out.printf("done%n");

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
@@ -138,18 +138,10 @@ public class JobInspectCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws ExecutionException, InterruptedException {
-
-    final Map<JobId, Job> jobs = client.jobs(jobId.toString()).get();
-    if (jobs.size() == 0) {
-      out.printf("Unknown job: %s%n", jobId);
-      return 1;
-    }
-
-    final Job job = Iterables.getOnlyElement(jobs.values());
 
     if (json) {
       out.println(Json.asPrettyStringUnchecked(job));

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobRemoveCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobRemoveCommand.java
@@ -22,6 +22,7 @@ package com.spotify.helios.cli.command;
 
 import com.spotify.helios.cli.Utils;
 import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.protocol.JobDeleteResponse;
 import java.io.BufferedReader;
@@ -54,11 +55,12 @@ public class JobRemoveCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws IOException, ExecutionException, InterruptedException {
     final boolean yes = options.getBoolean(yesArg.getDest());
+    final JobId jobId = job.getId();
 
     if (!yes) {
       out.printf("This will remove the job %s%n", jobId);

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStartCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStartCommand.java
@@ -24,6 +24,7 @@ import com.spotify.helios.cli.Utils;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.Goal;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -55,11 +56,11 @@ public class JobStartCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {
-
+    final JobId jobId = job.getId();
     final List<String> hosts = options.getList(hostsArg.getDest());
 
     final Deployment deployment = new Deployment.Builder()

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStopCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobStopCommand.java
@@ -24,6 +24,7 @@ import com.spotify.helios.cli.Utils;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.Goal;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -55,10 +56,11 @@ public class JobStopCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {
+    final JobId jobId = job.getId();
     final List<String> hosts = options.getList(hostsArg.getDest());
 
     final Deployment deployment = new Deployment.Builder()

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobUndeployCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobUndeployCommand.java
@@ -25,6 +25,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 import com.google.common.collect.ImmutableList;
 import com.spotify.helios.cli.Utils;
 import com.spotify.helios.client.HeliosClient;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.JobStatus;
 import com.spotify.helios.common.protocol.JobUndeployResponse;
@@ -68,11 +69,11 @@ public class JobUndeployCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {
-
+    final JobId jobId = job.getId();
     final boolean all = options.getBoolean(allArg.getDest());
     final boolean yes = options.getBoolean(yesArg.getDest());
     final List<String> hosts;

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/RollingUpdateCommand.java
@@ -21,7 +21,6 @@
 package com.spotify.helios.cli.command;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
 import static java.lang.String.format;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
@@ -31,6 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -144,10 +144,12 @@ public class RollingUpdateCommand extends WildcardJobCommand {
   }
 
   @Override
-  protected int runWithJobId(final Namespace options, final HeliosClient client,
-                             final PrintStream out, final boolean json, final JobId jobId,
-                             final BufferedReader stdin)
+  protected int runWithJob(final Namespace options, final HeliosClient client,
+                           final PrintStream out, final boolean json, final Job job,
+                           final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException {
+    final JobId jobId = job.getId();
+
     final String name = options.getString(nameArg.getDest());
     final Long timeout = options.getLong(timeoutArg.getDest());
     final Integer parallelism = options.getInt(parallelismArg.getDest());
@@ -184,6 +186,15 @@ public class RollingUpdateCommand extends WildcardJobCommand {
       return 1;
     }
 
+    final RolloutOptions optionsFromJob = job.getRolloutOptions();
+    final Integer actualParallelism =
+        nullableWithFallback(parallelism, optionsFromJob.getParallelism());
+    final Long actualTimeout = nullableWithFallback(timeout, optionsFromJob.getTimeout());
+    final Boolean actualOverlap = nullableWithFallback(overlap, optionsFromJob.getOverlap());
+    final String actualToken = nullableWithFallback(token, optionsFromJob.getToken());
+    final Boolean actualIgnoreFailures =
+        nullableWithFallback(ignoreFailures, optionsFromJob.getIgnoreFailures());
+
     if (!json) {
       out.println(format("Rolling update%s started: %s -> %s "
                          + "(parallelism=%d, timeout=%d, overlap=%b, token=%s, "
@@ -191,20 +202,20 @@ public class RollingUpdateCommand extends WildcardJobCommand {
           async ? " (async)" : "",
           name,
           jobId.toShortString(),
-          parallelism,
-          timeout,
-          overlap,
-          token,
-          ignoreFailures,
+          actualParallelism,
+          actualTimeout,
+          actualOverlap,
+          actualToken,
+          actualIgnoreFailures,
           async ? "" : "\n"));
     }
 
     final Map<String, Object> jsonOutput = Maps.newHashMap();
-    jsonOutput.put("parallelism", parallelism);
-    jsonOutput.put("timeout", timeout);
-    jsonOutput.put("overlap", overlap);
-    jsonOutput.put("token", token);
-    jsonOutput.put("ignoreFailures", ignoreFailures);
+    jsonOutput.put("parallelism", actualParallelism);
+    jsonOutput.put("timeout", actualTimeout);
+    jsonOutput.put("overlap", actualOverlap);
+    jsonOutput.put("token", actualToken);
+    jsonOutput.put("ignoreFailures", actualIgnoreFailures);
 
     if (async) {
       if (json) {
@@ -298,5 +309,12 @@ public class RollingUpdateCommand extends WildcardJobCommand {
   interface SleepFunction {
     void sleep(long millis) throws InterruptedException;
   }
-}
 
+  /**
+   * Return first argument if not null. Otherwise return second argument.
+   */
+  private <T> T nullableWithFallback(final T first, final T second) {
+    return first != null ? first : second;
+  }
+
+}

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/WildcardJobCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/WildcardJobCommand.java
@@ -81,13 +81,13 @@ abstract class WildcardJobCommand extends ControlCommand {
       return 1;
     }
 
-    final JobId jobId = Iterables.getOnlyElement(jobs.keySet());
+    final Job job = Iterables.getOnlyElement(jobs.values());
 
-    return runWithJobId(options, client, out, json, jobId, stdin);
+    return runWithJob(options, client, out, json, job, stdin);
   }
 
-  protected abstract int runWithJobId(final Namespace options, final HeliosClient client,
-                                      final PrintStream out, final boolean json, final JobId jobId,
-                                      final BufferedReader stdin)
+  protected abstract int runWithJob(final Namespace options, final HeliosClient client,
+                                    final PrintStream out, final boolean json, final Job job,
+                                    final BufferedReader stdin)
       throws ExecutionException, InterruptedException, IOException;
 }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -37,6 +37,7 @@ import com.spotify.helios.client.HeliosClient;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
 import com.spotify.helios.common.descriptors.HostSelector;
+import com.spotify.helios.common.descriptors.Job;
 import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.TaskStatus;
@@ -65,6 +66,12 @@ public class RollingUpdateCommandTest {
   private static final int PARALLELISM = 1;
   private static final long TIMEOUT = 300;
   private static final String TOKEN = "my_token";
+
+  private static final Job JOB = Job.newBuilder()
+      .setName(JOB_ID.getName())
+      .setVersion(JOB_ID.getVersion())
+      .setHash(JOB_ID.getHash())
+      .build();
 
   private static final RolloutOptions OPTIONS = RolloutOptions.newBuilder()
       .setTimeout(TIMEOUT)
@@ -148,7 +155,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host3", JOB_ID, TaskStatus.State.RUNNING))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, false, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -175,7 +182,7 @@ public class RollingUpdateCommandTest {
 
     when(options.getBoolean("async")).thenReturn(true);
 
-    final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, false, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -208,7 +215,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host3", OLD_JOB_ID, TaskStatus.State.RUNNING))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, false, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -240,7 +247,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host2", null, null))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, false, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -271,7 +278,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host2", null, null))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, false, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, false, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -303,7 +310,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host3", JOB_ID, TaskStatus.State.RUNNING))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -327,7 +334,7 @@ public class RollingUpdateCommandTest {
 
     when(options.getBoolean("async")).thenReturn(true);
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -360,7 +367,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host3", OLD_JOB_ID, TaskStatus.State.RUNNING))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -392,7 +399,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host2", null, null))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -423,7 +430,7 @@ public class RollingUpdateCommandTest {
             makeHostStatus("host2", null, null))
     ));
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
@@ -453,7 +460,7 @@ public class RollingUpdateCommandTest {
     ));
     when(options.getBoolean("migrate")).thenReturn(true);
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     // Verify that rollingUpdate() was called with migrate=true
@@ -490,7 +497,7 @@ public class RollingUpdateCommandTest {
     ));
     when(options.getBoolean("overlap")).thenReturn(true);
 
-    final int ret = command.runWithJobId(options, client, out, true, JOB_ID, null);
+    final int ret = command.runWithJob(options, client, out, true, JOB, null);
     final String output = baos.toString();
 
     // Verify that rollingUpdate() was called with migrate=true

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/RollingUpdateCommandTest.java
@@ -22,6 +22,8 @@ package com.spotify.helios.cli.command;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.spotify.helios.common.descriptors.DeploymentGroup.RollingUpdateReason.MANUAL;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -67,10 +69,20 @@ public class RollingUpdateCommandTest {
   private static final long TIMEOUT = 300;
   private static final String TOKEN = "my_token";
 
+  private static final RolloutOptions jobOptions = RolloutOptions.newBuilder()
+      .setParallelism(123)
+      .setTimeout(456L)
+      .setMigrate(true)
+      .setOverlap(true)
+      .setToken("my_token_from_job_options")
+      .setIgnoreFailures(true)
+      .build();
+
   private static final Job JOB = Job.newBuilder()
       .setName(JOB_ID.getName())
       .setVersion(JOB_ID.getVersion())
       .setHash(JOB_ID.getHash())
+      .setRolloutOptions(jobOptions)
       .build();
 
   private static final RolloutOptions OPTIONS = RolloutOptions.newBuilder()
@@ -160,19 +172,6 @@ public class RollingUpdateCommandTest {
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(0, ret);
-
-    final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
-        + "overlap=false, token=" + TOKEN + ", ignoreFailures=false)\n"
-        + "\n"
-        + "host1 -> RUNNING (1/3)\n"
-        + "host2 -> RUNNING (2/3)\n"
-        + "host3 -> RUNNING (3/3)\n"
-        + "\n"
-        + "Done.\n"
-        + "Duration: 4.00 s\n";
-
-    assertEquals(expected, output.replaceAll("\\p{Blank}+|(?:\\p{Blank})$", " "));
   }
 
   @Test
@@ -220,17 +219,6 @@ public class RollingUpdateCommandTest {
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
-
-    final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
-        + "overlap=false, token=" + TOKEN + ", ignoreFailures=false)\n"
-        + "\n"
-        + "host1 -> RUNNING (1/3)\n"
-        + "\n"
-        + "Failed: Deployment-group job id changed during rolling-update\n"
-        + "Duration: 2.00 s\n";
-
-    assertEquals(expected, output.replaceAll("\\p{Blank}+|(?:\\p{Blank})$", " "));
   }
 
   @Test
@@ -252,16 +240,6 @@ public class RollingUpdateCommandTest {
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
-
-    final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
-        + "overlap=false, token=" + TOKEN + ", ignoreFailures=false)\n"
-        + "\n"
-        + "\n"
-        + "Timed out! (rolling-update still in progress)\n"
-        + "Duration: 601.00 s\n";
-
-    assertEquals(expected, output.replaceAll("\\p{Blank}+|(?:\\p{Blank})$", " "));
   }
 
   @Test
@@ -283,17 +261,6 @@ public class RollingUpdateCommandTest {
 
     verify(client).rollingUpdate(GROUP_NAME, JOB_ID, OPTIONS);
     assertEquals(1, ret);
-
-    final String expected =
-        "Rolling update started: my_group -> foo:2:1212121 (parallelism=1, timeout=300, "
-        + "overlap=false, token=" + TOKEN + ", ignoreFailures=false)\n"
-        + "\n"
-        + "host1 -> RUNNING (1/2)\n"
-        + "\n"
-        + "Failed: foobar\n"
-        + "Duration: 1.00 s\n";
-
-    assertEquals(expected, output.replaceAll("\\p{Blank}+|(?:\\p{Blank})$", " "));
   }
 
   // ----------------------------
@@ -522,6 +489,133 @@ public class RollingUpdateCommandTest {
         .put("ignoreFailures", false)
         .build()
     );
+  }
+
+  @Test
+  public void testCommandLineOptions() throws Exception {
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.ACTIVE, null,
+            makeHostStatus("host1", JOB_ID, TaskStatus.State.RUNNING))
+    ));
+
+    String optionString = "(parallelism=1, timeout=300, overlap=false, token=my_token, "
+                          + "ignoreFailures=false)";
+
+    command.runWithJob(options, client, out, false, JOB, null);
+
+    assertThat(baos.toString(), containsString(optionString));
+  }
+
+  @Test
+  public void testFallbackToJobOptions() throws Exception {
+    final Namespace cmdlineOptions = mock(Namespace.class);
+    when(cmdlineOptions.getString("deployment-group-name")).thenReturn(null);
+    when(cmdlineOptions.getInt("parallelism")).thenReturn(null);
+    when(cmdlineOptions.getLong("timeout")).thenReturn(null);
+    when(cmdlineOptions.getLong("rollout_timeout")).thenReturn(10L);
+    when(cmdlineOptions.getBoolean("async")).thenReturn(true);
+    when(cmdlineOptions.getBoolean("migrate")).thenReturn(null);
+    when(cmdlineOptions.getBoolean("overlap")).thenReturn(null);
+    when(cmdlineOptions.getString("token")).thenReturn("cli_token");
+    when(cmdlineOptions.getBoolean("ignore_failures")).thenReturn(null);
+
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.ACTIVE, null,
+            makeHostStatus("host1", JOB_ID, TaskStatus.State.RUNNING))
+    ));
+
+    String optionString = "(parallelism=123, timeout=456, overlap=true, "
+        + "token=cli_token, ignoreFailures=true)";
+
+    command.runWithJob(cmdlineOptions, client, out, false, JOB, null);
+
+    assertThat(baos.toString(), containsString(optionString));
+  }
+
+  @Test
+  public void testRollingUpdateSuccessOutput() throws Exception {
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.ACTIVE, null,
+            makeHostStatus("host1", JOB_ID, TaskStatus.State.RUNNING))
+    ));
+
+    when(options.getBoolean("overlap")).thenReturn(true);
+
+    final String expectedSubstring = "host1 -> RUNNING (1/1)\n"
+        + "\n"
+        + "Done.\n"
+        + "Duration: 0.00 s\n";
+
+    command.runWithJob(options, client, out, false, JOB, null);
+
+    assertThat(baos.toString(), containsString(expectedSubstring));
+  }
+
+  @Test
+  public void testRollingUpdateFailureOutput() throws Exception {
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.FAILED, "mock failure",
+            makeHostStatus("host1", JOB_ID, TaskStatus.State.RUNNING))
+    ));
+
+    when(options.getBoolean("overlap")).thenReturn(true);
+
+    final String expectedSubstring = "Failed: mock failure\n";
+
+    command.runWithJob(options, client, out, false, JOB, null);
+
+    assertThat(baos.toString(), containsString(expectedSubstring));
+  }
+
+  @Test
+  public void testGroupIdChangedDuringRolloutOutput() throws Exception {
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.ROLLING_OUT, null,
+            makeHostStatus("host1", null, null)),
+        statusResponse(DeploymentGroupStatusResponse.Status.ROLLING_OUT, NEW_JOB_ID, null,
+            makeHostStatus("host1", null, null))
+    ));
+
+    final String expectedSubstring = "Failed: Deployment-group job id changed during "
+                                     + "rolling-update";
+
+    command.runWithJob(options, client, out, false, JOB, null);
+
+    assertThat(baos.toString(), containsString(expectedSubstring));
+  }
+
+  @Test
+  public void testTimeoutDuringRolloutOutput() throws Exception {
+    when(client.rollingUpdate(anyString(), any(JobId.class), any(RolloutOptions.class)))
+        .thenReturn(immediateFuture(new RollingUpdateResponse(RollingUpdateResponse.Status.OK)));
+
+    when(client.deploymentGroupStatus(GROUP_NAME)).then(new ResponseAnswer(
+        statusResponse(DeploymentGroupStatusResponse.Status.ROLLING_OUT, null,
+            makeHostStatus("host1", null, null)),
+        statusResponse(DeploymentGroupStatusResponse.Status.ROLLING_OUT, null,
+            makeHostStatus("host1", null, null))
+    ));
+
+    final String expectedSubstring = "Timed out! (rolling-update still in progress)";
+
+    command.runWithJob(options, client, out, false, JOB, null);
+
+    assertThat(baos.toString(), containsString(expectedSubstring));
   }
 
   private static class TimeUtil implements RollingUpdateCommand.SleepFunction, Supplier<Long> {


### PR DESCRIPTION
Refactor `WildcardJobCommand.runWithJobId()` to take a `Job` arg.
The downside is passing more info than necessary for some subcommands.
The upside is we do not make extra calls to the master to retrieve
a Job we already have.