### PR TITLE
Inconsistent values in the example job config

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -353,9 +353,9 @@ Will ultimately have these options at `rolling-update` time.
 ```
 "rolloutOptions": {
   "migrate": false,
-  "parallelism": 3,
+  "parallelism": 2,
   "timeout": 300,
-  "overlap": true,
+  "overlap": false,
   "token": "",
   "ignoreFailures": false
 }


### PR DESCRIPTION
If only the missing fields are updated the other fields should be kept the same as in the example just above.