### PR TITLE
Include new docker-ce as possible dependency

### DIFF
--- a/src/deb/helios-solo/control
+++ b/src/deb/helios-solo/control
@@ -3,7 +3,7 @@ Version: [[version]]
 Section: non-free/net
 Priority: optional
 Architecture: all
-Depends: docker.io | lxc-docker | docker-engine, helios, jq, bind9-host
+Depends: docker-ce | docker.io | lxc-docker | docker-engine, helios, jq, bind9-host
 Provides: helios-standalone
 Conflicts: helios-standalone
 Replaces: helios-standalone


### PR DESCRIPTION
The new way to install docker is installing docker community edition.

@davidxia @mattnworb 