### PR TITLE
fix HeliosSoloDeployment library for Docker For Mac

### DIFF
--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -56,9 +56,14 @@ import com.spotify.helios.common.protocol.JobUndeployResponse;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 import java.io.File;
+import java.net.Inet4Address;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -158,6 +163,20 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   /**
+   * Return first found non-loopback ip from enumeration of network devices.
+   * InetAddress.getLocalHost() will not work, as it returns the loopback device
+   */
+  public static String findFirstInet4Addr(Collection<InetAddress> addrs)
+      throws HeliosDeploymentException {
+    for (InetAddress addr : addrs) {
+      if (addr instanceof Inet4Address && !addr.isLoopbackAddress()) {
+        return addr.getHostAddress();
+      }
+    }
+    throw new HeliosDeploymentException("Cannot resolve inet address");
+  }
+
+  /**
    * Determine what address to use when attempting to communicate with containers deployed via the
    * helios-solo container. This will be passed into the helios-solo container as the HOST_ADDRESS
    * environment variable and is later used by TemporaryJob to figure out how to reach ports mapped
@@ -173,10 +192,14 @@ public class HeliosSoloDeployment implements HeliosDeployment {
 
     if (dockerHostAddressIsLocalhost()) {
       if (isDockerForMac(dockerInfo)) {
+        log.info("determineHeliosHost: local environment appears to be Docker for Mac");
         try {
-          log.info("determineHeliosHost: local environment appears to be Docker for Mac");
-          return InetAddress.getLocalHost().getHostAddress();
-        } catch (UnknownHostException e) {
+          List<InetAddress> addrs = new ArrayList<InetAddress>();
+          for (NetworkInterface nic : Collections.list(NetworkInterface.getNetworkInterfaces())) {
+            addrs.addAll(Collections.list(nic.getInetAddresses()));
+          }
+          return findFirstInet4Addr(addrs);
+        } catch (SocketException e) {
           throw new HeliosDeploymentException("Cannot resolve local hostname", e);
         }
       }

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.helios.testing;
 
+import static com.spotify.helios.testing.HeliosSoloDeployment.findFirstInet4Addr;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.net.InetAddresses;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.spotify.docker.client.DockerClient;
@@ -64,6 +66,9 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
 import java.io.File;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -407,5 +412,17 @@ public class HeliosSoloDeploymentTest {
 
     verify(dockerClient, timeout(5000)).logs(eq(CONTAINER_ID),
         Matchers.<DockerClient.LogsParam>anyVararg());
+  }
+
+  @Test
+  public void testFindFirstInet4Addr() throws HeliosDeploymentException {
+    List addrs = new ArrayList<InetAddress>();
+    addrs.add(InetAddresses.forString("fe80:0:0:0:0:0:0:1"));
+    addrs.add(InetAddresses.forString("0:0:0:0:0:0:0:1"));
+    addrs.add(InetAddresses.forString("127.0.0.1"));
+    addrs.add(InetAddresses.forString("10.12.34.56"));
+    addrs.add(InetAddresses.forString("10.98.76.54"));
+
+    assertEquals("10.12.34.56", findFirstInet4Addr(addrs));
   }
 }


### PR DESCRIPTION
InetAddress.getLocalHost() returns the loopback device. This does not allow an application that is running inside a container from being able to communicate with the host, since hitting 127.0.0.1 will make it talk to itself. An ipv4 address of the host needs to be given to the container.

@davidxia @mavenraven @mattnworb