### PR TITLE
Revert "Upgrade docker-client dep from 8.9.0 to 8.9.2"

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>ssh-agent-proxy</artifactId>
+            <version>0.1.5</version>
         </dependency>
         <dependency>
             <groupId>com.spotify</groupId>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -321,6 +321,11 @@
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>1.53</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-unixsocket</artifactId>
+            <version>0.8</version>
+        </dependency>
 
         <!-- versions that we have to manage to avoid requireUpperBoundDeps violations -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>
-                <version>8.9.2</version>
+                <version>8.9.0</version>
                 <classifier>shaded</classifier>
             </dependency>
 
@@ -319,16 +319,6 @@
                         <artifactId>netty-codec-http2</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.github.jnr</groupId>
-                <artifactId>jnr-unixsocket</artifactId>
-                <version>0.18</version>
-            </dependency>
-            <dependency>
-                <groupId>com.spotify</groupId>
-                <artifactId>ssh-agent-proxy</artifactId>
-                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>


### PR DESCRIPTION
Reverts spotify/helios#1190

We've seen problems with jobs that use `exec` healthchecks since this change, see https://github.com/spotify/docker-client/pull/916#issuecomment-352896897