### PR TITLE
agent: Report when container exits in healthchecks

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -196,6 +196,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
             final String err = "container " + containerId + " exited during health checking. "
                                + "Exit code: " + state.exitCode() + ", Config: " + config;
             log.warn(err);
+            listener.exited(state.exitCode());
             throw new RuntimeException(err);
           }
 


### PR DESCRIPTION
The `TaskMonitor` has logic to throttle a container if the container
restarts too frequently. Prior to this change, however, the throttling
logic is bypassed when a container exits during healthchecks, since in
that case we throw an exception. The `TaskRunner` should report the
container's exit, even if the container never reached "running".

@mattnworb @davidxia