### PR TITLE
client: Make Google token scopes configurable

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenProvider.java
@@ -21,11 +21,10 @@
 
 package com.spotify.helios.client;
 
-import static java.util.Collections.singletonList;
-
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,6 +35,11 @@ import org.slf4j.LoggerFactory;
 class GoogleCredentialsAccessTokenProvider {
   private static final Logger log =
       LoggerFactory.getLogger(GoogleCredentialsAccessTokenProvider.class);
+
+  public static final List<String> DEFAULT_SCOPES = ImmutableList.of(
+      "https://www.googleapis.com/auth/cloud-platform.read-only",
+      "https://www.googleapis.com/auth/userinfo.email"
+  );
 
   /**
    * Attempt to load an Access Token using Google Credentials.
@@ -86,11 +90,5 @@ class GoogleCredentialsAccessTokenProvider {
     newCredentials.refresh();
 
     return newCredentials.getAccessToken();
-  }
-
-  static AccessToken getAccessToken() throws IOException {
-    // Google Service Account Credentials require an access scope before calling `refresh()`;
-    // see https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam.
-    return getAccessToken(singletonList("https://www.googleapis.com/auth/cloud-platform.read-only"));
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -609,6 +609,8 @@ public class HeliosClient implements Closeable {
     private boolean sslHostnameVerification = true;
     private boolean googleCredentialsEnabled = true;
     private AccessToken googleAccessToken;
+    private List<String> googleAccessTokenScopes =
+        GoogleCredentialsAccessTokenProvider.DEFAULT_SCOPES;
     private ListeningScheduledExecutorService executorService;
     private boolean shutDownExecutorOnClose = true;
     private int httpTimeout = 10000;
@@ -667,6 +669,11 @@ public class HeliosClient implements Closeable {
 
     public Builder setGoogleAccessToken(final AccessToken accessToken) {
       this.googleAccessToken = accessToken;
+      return this;
+    }
+
+    public Builder setGoogleAccessTokenScopes(final List<String> scopes) {
+      this.googleAccessTokenScopes = scopes;
       return this;
     }
 
@@ -753,7 +760,8 @@ public class HeliosClient implements Closeable {
           accessTokenOpt = Optional.of(googleAccessToken);
         } else {
           try {
-            accessTokenOpt = Optional.of(GoogleCredentialsAccessTokenProvider.getAccessToken());
+            accessTokenOpt = Optional.of(
+                GoogleCredentialsAccessTokenProvider.getAccessToken(googleAccessTokenScopes));
           } catch (IOException | RuntimeException e) {
             // As with AgentProxy below, defer actually enforcing authorization to the masters
             log.debug("Exception (possibly benign) while loading Google Credentials", e);


### PR DESCRIPTION
* Add userinfo.email as a default scope to Google token.