### PR TITLE
Removes uses of deprecated 'HostAndPort.getHostText' method.

### DIFF
--- a/docs/testing_framework.md
+++ b/docs/testing_framework.md
@@ -106,7 +106,7 @@ public class ServiceIT {
     // allocated port of the job
     HostAndPort port = temporaryJob.address("wiggum");
     String pingUri = String.format("http://%s:%d/ping",
-                                   port.getHostText(),
+                                   port.getHost(),
                                    port.getPort());
 
     HttpResponse response = client.execute(new HttpGet(pingUri));
@@ -166,7 +166,7 @@ public class SystemIT {
 
     final HostAndPort address = cassandra.address("cassandra");
     final CassandraClient cassandraClient = new CassandraClient();
-    cassandraClient.connect(address.getHostText(), address.getPort());
+    cassandraClient.connect(address.getHost(), address.getPort());
     cassandraClient.populateTestData();
   }
 

--- a/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
+++ b/helios-integration-tests/src/test/java/com/spotify/helios/HeliosSoloIT.java
@@ -121,7 +121,7 @@ public class HeliosSoloIT {
     // Connect to alpine container to get the curl response. If we get back the nginx welcome page
     // we know that helios properly registered the nginx service in SkyDNS.
     final Callable<String> socketResponse = () -> {
-      try (final Socket s = new Socket(alpineAddress.getHostText(), alpineAddress.getPort())) {
+      try (final Socket s = new Socket(alpineAddress.getHost(), alpineAddress.getPort())) {
         return IOUtils.toString(s.getInputStream(), Charsets.UTF_8).trim();
       }
     };

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/statistics/FastForwardReporter.java
@@ -105,7 +105,7 @@ public class FastForwardReporter implements Managed {
 
     final FastForward ff;
     if (address.isPresent()) {
-      ff = FastForward.setup(address.get().getHostText(), address.get().getPort());
+      ff = FastForward.setup(address.get().getHost(), address.get().getPort());
     } else {
       ff = FastForward.setup();
     }

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -69,7 +69,7 @@ public class HeliosDeploymentResource extends ExternalResource {
           @Override
           public Boolean call() throws Exception {
             final HostAndPort hap = deployment.address();
-            final SocketAddress address = new InetSocketAddress(hap.getHostText(), hap.getPort());
+            final SocketAddress address = new InetSocketAddress(hap.getHost(), hap.getPort());
             log.debug("attempting to connect to {}", address);
 
             try {

--- a/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/SimpleTest.java
@@ -118,8 +118,8 @@ public class SimpleTest extends TemporaryJobsTestBase {
       }
 
       //verify address and addresses return valid HostAndPort objects
-      assertEquals("wrong host", testHost1, job1.address("echo").getHostText());
-      assertEquals("wrong host", testHost1, getOnlyElement(job1.addresses("echo")).getHostText());
+      assertEquals("wrong host", testHost1, job1.address("echo").getHost());
+      assertEquals("wrong host", testHost1, getOnlyElement(job1.addresses("echo")).getHost());
 
       ping(DOCKER_HOST.address(), job1.port(testHost1, "echo"));
     }


### PR DESCRIPTION
Instead use HostandPort.getHost()