### PR TITLE
ensure google credentials file is closed after read

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
@@ -117,16 +117,17 @@ class GoogleCredentialsAccessTokenSupplier implements Supplier<Optional<AccessTo
     if (googleCredentialsPath != null) {
       final File file = new File(googleCredentialsPath);
       if (file.exists()) {
-        final FileInputStream s = new FileInputStream(file);
-        credentials = GoogleCredentials.fromStream(s);
-        LOG.debug("Using Google Credentials from file: " + file.getAbsolutePath());
+        try (final FileInputStream s = new FileInputStream(file)) {
+          credentials = GoogleCredentials.fromStream(s);
+          LOG.info("Using Google Credentials from file: " + file.getAbsolutePath());
+        }
       }
     }
 
     // fallback to application default credentials
     if (credentials == null) {
       credentials = GoogleCredentials.getApplicationDefault();
-      LOG.debug("Using Google Application Default Credentials");
+      LOG.info("Using Google Application Default Credentials");
     }
 
     return scopes.isEmpty() ? credentials : credentials.createScoped(scopes);


### PR DESCRIPTION
don't assume that the google oauth2 library closes the stream