### PR TITLE
refactor GoogleCredentialsAccessTokenSupplier

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/AuthorizationHeaderSupplier.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/AuthorizationHeaderSupplier.java
@@ -1,0 +1,33 @@
+/*-
+ * -\-\-
+ * Helios Client
+ * --
+ * Copyright (C) 2016 - 2018 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.helios.client;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+
+/**
+ * Supplies an Authorization header value to use in HTTP requests to the Helios API.
+ * <p>
+ * If an implementation has no header value to return, then an empty Optional
+ * should be returned.</p>
+ */
+public interface AuthorizationHeaderSupplier extends Supplier<Optional<String>> {
+}

--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
@@ -1,35 +1,29 @@
 /*
  *  -\-\-
- *  helios-client
- *  --
- *  Copyright (C) 2017 Spotify AB
- *  --
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * helios-client
+ * --
+ * Copyright (C) 2017 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  * 
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *  -/-/-
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
  *
  */
 
 package com.spotify.helios.client;
 
-import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,96 +32,21 @@ class GoogleCredentialsAccessTokenSupplier implements AuthorizationHeaderSupplie
   private static final Logger LOG =
       LoggerFactory.getLogger(GoogleCredentialsAccessTokenSupplier.class);
 
-  public static final List<String> DEFAULT_SCOPES = ImmutableList.of(
-      "https://www.googleapis.com/auth/cloud-platform.read-only",
-      "https://www.googleapis.com/auth/userinfo.email"
-  );
+  private final GoogleCredentials credentials;
 
-  private final Optional<AccessToken> staticToken;
-  private final List<String> tokenScopes;
-  private final Object lock = new Object();
-  private GoogleCredentials credentials;
-
-  GoogleCredentialsAccessTokenSupplier() {
-    this(null, DEFAULT_SCOPES);
-  }
-
-  GoogleCredentialsAccessTokenSupplier(final AccessToken staticToken) {
-    this(staticToken, DEFAULT_SCOPES);
-  }
-
-  GoogleCredentialsAccessTokenSupplier(final AccessToken staticToken,
-                                       final List<String> tokenScopes) {
-    this(staticToken, tokenScopes, null);
-  }
-
-  @VisibleForTesting
-  GoogleCredentialsAccessTokenSupplier(final AccessToken staticToken,
-                                       final List<String> tokenScopes,
-                                       final GoogleCredentials credentials) {
-    this.staticToken = Optional.fromNullable(staticToken);
-    this.tokenScopes = tokenScopes;
+  GoogleCredentialsAccessTokenSupplier(final GoogleCredentials credentials) {
     this.credentials = credentials;
   }
 
   @Override
   public Optional<String> get() {
-    if (staticToken.isPresent()) {
-      return Optional.of("Bearer " + staticToken.get().getTokenValue());
-    }
-
     try {
-      synchronized (lock) {
-        if (credentials == null) {
-          credentials = getCredentialsWithScopes(tokenScopes);
-        }
-        // call getRequestMetadata to kick the if-expired-then-renew check
-        credentials.getRequestMetadata(null);
-      }
-
+      // call getRequestMetadata to kick the if-expired-then-renew check
+      credentials.getRequestMetadata(null);
       return Optional.of("Bearer " + credentials.getAccessToken().getTokenValue());
     } catch (IOException | RuntimeException e) {
-      LOG.debug("Exception (possibly benign) while loading Google Credentials", e);
+      LOG.error("Exception while refreshing Google Credentials", e);
       return Optional.absent();
     }
-  }
-
-  /**
-   * Attempt to load Google Credentials with specified scopes.
-   * <ol>
-   * <li>First check to see if the environment variable HELIOS_GOOGLE_CREDENTIALS is set
-   * and points to a readable file</li>
-   * <li>Otherwise check if Google Application Default Credentials (ADC) can be loaded</li>
-   * </ol>
-   *
-   * <p>Note that we use a special environment variable of our own in addition to any environment
-   * variable that the ADC loading uses (GOOGLE_APPLICATION_CREDENTIALS) in case there is a need
-   * for the user to use the latter env var for some other purpose.
-   *
-   * @return Return a {@link GoogleCredentials}
-   */
-  private static GoogleCredentials getCredentialsWithScopes(final List<String> scopes)
-      throws IOException {
-    GoogleCredentials credentials = null;
-
-    // first check whether the environment variable is set
-    final String googleCredentialsPath = System.getenv("HELIOS_GOOGLE_CREDENTIALS");
-    if (googleCredentialsPath != null) {
-      final File file = new File(googleCredentialsPath);
-      if (file.exists()) {
-        try (final FileInputStream s = new FileInputStream(file)) {
-          credentials = GoogleCredentials.fromStream(s);
-          LOG.info("Using Google Credentials from file: " + file.getAbsolutePath());
-        }
-      }
-    }
-
-    // fallback to application default credentials
-    if (credentials == null) {
-      credentials = GoogleCredentials.getApplicationDefault();
-      LOG.info("Using Google Application Default Credentials");
-    }
-
-    return scopes.isEmpty() ? credentials : credentials.createScoped(scopes);
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
@@ -43,37 +43,37 @@ class GoogleCredentialsAccessTokenSupplier implements AuthorizationHeaderSupplie
       "https://www.googleapis.com/auth/userinfo.email"
   );
 
-  private final boolean enabled;
-  private final AccessToken staticToken;
+  private final Optional<AccessToken> staticToken;
   private final List<String> tokenScopes;
   private final Object lock = new Object();
   private GoogleCredentials credentials;
 
-  GoogleCredentialsAccessTokenSupplier(final boolean enabled,
-                                       final AccessToken staticToken,
+  GoogleCredentialsAccessTokenSupplier() {
+    this(null, DEFAULT_SCOPES);
+  }
+
+  GoogleCredentialsAccessTokenSupplier(final AccessToken staticToken) {
+    this(staticToken, DEFAULT_SCOPES);
+  }
+
+  GoogleCredentialsAccessTokenSupplier(final AccessToken staticToken,
                                        final List<String> tokenScopes) {
-    this(enabled, staticToken, tokenScopes, null);
+    this(staticToken, tokenScopes, null);
   }
 
   @VisibleForTesting
-  GoogleCredentialsAccessTokenSupplier(final boolean enabled,
-                                       final AccessToken staticToken,
+  GoogleCredentialsAccessTokenSupplier(final AccessToken staticToken,
                                        final List<String> tokenScopes,
                                        final GoogleCredentials credentials) {
-    this.enabled = enabled;
-    this.staticToken = staticToken;
+    this.staticToken = Optional.fromNullable(staticToken);
     this.tokenScopes = tokenScopes;
     this.credentials = credentials;
   }
 
   @Override
   public Optional<String> get() {
-    if (!enabled) {
-      return Optional.absent();
-    }
-
-    if (staticToken != null) {
-      return Optional.of("Bearer " + staticToken.getTokenValue());
+    if (staticToken.isPresent()) {
+      return Optional.of("Bearer " + staticToken.get().getTokenValue());
     }
 
     try {

--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAuthorizationHeaderSupplier.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAuthorizationHeaderSupplier.java
@@ -27,14 +27,18 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class GoogleCredentialsAccessTokenSupplier implements AuthorizationHeaderSupplier {
+/**
+ * AuthorizationHeaderSupplier instance that uses Google OAuth2 credentials to set the header
+ * value.
+ */
+class GoogleCredentialsAuthorizationHeaderSupplier implements AuthorizationHeaderSupplier {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(GoogleCredentialsAccessTokenSupplier.class);
+      LoggerFactory.getLogger(GoogleCredentialsAuthorizationHeaderSupplier.class);
 
   private final GoogleCredentials credentials;
 
-  GoogleCredentialsAccessTokenSupplier(final GoogleCredentials credentials) {
+  GoogleCredentialsAuthorizationHeaderSupplier(final GoogleCredentials credentials) {
     this.credentials = credentials;
   }
 

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -674,7 +674,7 @@ public class HeliosClient implements Closeable {
      * Customize the AuthorizationHeaderSupplier instance used to determine what Authorization
      * header value (if any) to send in API requests. If not set, and
      * {@link #setGoogleCredentialsEnabled(boolean)} is not disabled, then an instance of
-     * {@link GoogleCredentialsAccessTokenSupplier} is used.
+     * {@link GoogleCredentialsAuthorizationHeaderSupplier} is used.
      */
     public Builder setAuthorizationHeaderSupplier(final AuthorizationHeaderSupplier supplier) {
       this.authorizationHeaderSupplier = supplier;
@@ -773,12 +773,14 @@ public class HeliosClient implements Closeable {
       final DefaultHttpConnector connector =
           new DefaultHttpConnector(endpointIterator, httpTimeout, sslHostnameVerification);
 
-      if (this.authorizationHeaderSupplier == null) {
+      AuthorizationHeaderSupplier authorizationSupplier = this.authorizationHeaderSupplier;
+
+      if (authorizationSupplier == null) {
         if (googleCredentialsEnabled) {
           final GoogleCredentials credentials = loadGoogleCredentials();
-          this.authorizationHeaderSupplier = new GoogleCredentialsAccessTokenSupplier(credentials);
+          authorizationSupplier = new GoogleCredentialsAuthorizationHeaderSupplier(credentials);
         } else {
-          this.authorizationHeaderSupplier = new AuthorizationHeaderSupplier() {
+          authorizationSupplier = new AuthorizationHeaderSupplier() {
             @Override
             public Optional<String> get() {
               return Optional.absent();
@@ -815,7 +817,7 @@ public class HeliosClient implements Closeable {
       }
 
       return new AuthenticatingHttpConnector(user,
-          this.authorizationHeaderSupplier,
+          authorizationSupplier,
           agentProxyOpt,
           Optional.fromNullable(certKeyPaths),
           endpointIterator,

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -66,7 +66,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.spotify.helios.common.HeliosException;
 import com.spotify.helios.common.Json;
 import com.spotify.helios.common.Resolver;
-import com.spotify.helios.common.Version;
 import com.spotify.helios.common.VersionCompatibility;
 import com.spotify.helios.common.descriptors.Deployment;
 import com.spotify.helios.common.descriptors.DeploymentGroup;
@@ -754,9 +753,9 @@ public class HeliosClient implements Closeable {
       final DefaultHttpConnector connector =
           new DefaultHttpConnector(endpointIterator, httpTimeout, sslHostnameVerification);
 
-      Supplier<Optional<AccessToken>> accessTokenSupplier = new
-          GoogleCredentialsAccessTokenSupplier(googleCredentialsEnabled, googleAccessToken,
-          googleAccessTokenScopes);
+      AuthorizationHeaderSupplier authorizationHeaderSupplier =
+          new GoogleCredentialsAccessTokenSupplier(googleCredentialsEnabled, googleAccessToken,
+              googleAccessTokenScopes);
 
       Optional<AgentProxy> agentProxyOpt = Optional.absent();
       try {
@@ -786,7 +785,7 @@ public class HeliosClient implements Closeable {
       }
 
       return new AuthenticatingHttpConnector(user,
-          accessTokenSupplier,
+          authorizationHeaderSupplier,
           agentProxyOpt,
           Optional.fromNullable(certKeyPaths),
           endpointIterator,

--- a/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/HeliosClient.java
@@ -42,13 +42,14 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -92,6 +93,8 @@ import com.spotify.sshagentproxy.AgentProxies;
 import com.spotify.sshagentproxy.AgentProxy;
 import com.spotify.sshagenttls.CertKeyPaths;
 import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -597,6 +600,8 @@ public class HeliosClient implements Closeable {
 
   public static class Builder {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Builder.class);
+
     private static final String HELIOS_CERT_PATH = "HELIOS_CERT_PATH";
     // used in the name format of the Client's executor's ThreadFactory to differentiate between
     // different instances of HeliosClient. this way we avoid having multiple threads named
@@ -609,6 +614,11 @@ public class HeliosClient implements Closeable {
     private boolean sslHostnameVerification = true;
     private boolean googleCredentialsEnabled = true;
     private AuthorizationHeaderSupplier authorizationHeaderSupplier = null;
+    private GoogleCredentials googleCredentials;
+    private List<String> googleScopes = ImmutableList.of(
+        "https://www.googleapis.com/auth/cloud-platform.read-only",
+        "https://www.googleapis.com/auth/userinfo.email"
+    );
     private ListeningScheduledExecutorService executorService;
     private boolean shutDownExecutorOnClose = true;
     private int httpTimeout = 10000;
@@ -660,7 +670,8 @@ public class HeliosClient implements Closeable {
       return this;
     }
 
-    /** Customize the AuthorizationHeaderSupplier instance used to determine what Authorization
+    /**
+     * Customize the AuthorizationHeaderSupplier instance used to determine what Authorization
      * header value (if any) to send in API requests. If not set, and
      * {@link #setGoogleCredentialsEnabled(boolean)} is not disabled, then an instance of
      * {@link GoogleCredentialsAccessTokenSupplier} is used.
@@ -672,6 +683,16 @@ public class HeliosClient implements Closeable {
 
     public Builder setGoogleCredentialsEnabled(final boolean enabled) {
       this.googleCredentialsEnabled = enabled;
+      return this;
+    }
+
+    public Builder setGoogleCredentials(final GoogleCredentials credentials) {
+      this.googleCredentials = credentials;
+      return this;
+    }
+
+    public Builder setGoogleAccessTokenScopes(final List<String> scopes) {
+      this.googleScopes = scopes;
       return this;
     }
 
@@ -754,8 +775,8 @@ public class HeliosClient implements Closeable {
 
       if (this.authorizationHeaderSupplier == null) {
         if (googleCredentialsEnabled) {
-          this.authorizationHeaderSupplier =
-              new GoogleCredentialsAccessTokenSupplier();
+          final GoogleCredentials credentials = loadGoogleCredentials();
+          this.authorizationHeaderSupplier = new GoogleCredentialsAccessTokenSupplier(credentials);
         } else {
           this.authorizationHeaderSupplier = new AuthorizationHeaderSupplier() {
             @Override
@@ -799,6 +820,34 @@ public class HeliosClient implements Closeable {
           Optional.fromNullable(certKeyPaths),
           endpointIterator,
           connector);
+    }
+
+    private GoogleCredentials loadGoogleCredentials() {
+      try {
+        GoogleCredentials credentials = null;
+
+        if (googleCredentials != null) {
+          credentials = googleCredentials;
+        } else if (System.getenv("HELIOS_GOOGLE_CREDENTIALS") != null) {
+          final String path = System.getenv("HELIOS_GOOGLE_CREDENTIALS");
+          final File file = new File(path);
+          try (final FileInputStream s = new FileInputStream(file)) {
+            credentials = GoogleCredentials.fromStream(s);
+            LOG.info("Using Google Credentials from file: " + file.getAbsolutePath());
+          }
+        }
+
+        // if not specified and no environment variable set, fallback to application default
+        // credentials
+        if (credentials == null) {
+          credentials = GoogleCredentials.getApplicationDefault();
+          LOG.info("Using Google Application Default Credentials");
+        }
+
+        return googleScopes.isEmpty() ? credentials : credentials.createScoped(googleScopes);
+      } catch (IOException ex) {
+        throw new RuntimeException("IOException loading Google Credentials", ex);
+      }
     }
   }
 

--- a/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
@@ -25,9 +25,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.common.base.Optional;
 import java.io.IOException;
 import java.net.URI;
@@ -39,7 +41,7 @@ public class GoogleCredentialsAccessTokenSupplierTest {
   public void testGetWhenDisabled() {
     final GoogleCredentialsAccessTokenSupplier supplier =
         new GoogleCredentialsAccessTokenSupplier(false, null, null);
-    assertThat(supplier.get(), equalTo(Optional.<AccessToken>absent()));
+    assertThat(supplier.get(), equalTo(Optional.<String>absent()));
   }
 
   @Test
@@ -47,15 +49,20 @@ public class GoogleCredentialsAccessTokenSupplierTest {
     final AccessToken token = new AccessToken("token", null);
     final GoogleCredentialsAccessTokenSupplier supplier =
         new GoogleCredentialsAccessTokenSupplier(true, token, null);
-    assertThat(supplier.get(), equalTo(Optional.of(token)));
+    assertThat(supplier.get(), equalTo(Optional.of("Bearer token")));
   }
 
   @Test
   public void testGetWithCredentials() throws IOException {
-    final GoogleCredentials credentials = mock(GoogleCredentials.class);
+    final AccessToken accessToken = new AccessToken("foobar", null);
+
+    // instantiating the GoogleCredentials class directly is a big hack to workaround the fact that
+    // we cannot stub the final method getAccessToken()
+    final GoogleCredentials credentials = new GoogleCredentials(accessToken);
+
     final GoogleCredentialsAccessTokenSupplier supplier = new GoogleCredentialsAccessTokenSupplier(
         true, null, null, credentials);
-    supplier.get();
-    verify(credentials).getRequestMetadata(any(URI.class));
+
+    assertThat(supplier.get(), equalTo(Optional.of("Bearer foobar")));
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
@@ -22,17 +22,11 @@ package com.spotify.helios.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.common.base.Optional;
 import java.io.IOException;
-import java.net.URI;
 import org.junit.Test;
 
 public class GoogleCredentialsAccessTokenSupplierTest {
@@ -40,7 +34,7 @@ public class GoogleCredentialsAccessTokenSupplierTest {
   @Test
   public void testGetWhenDisabled() {
     final GoogleCredentialsAccessTokenSupplier supplier =
-        new GoogleCredentialsAccessTokenSupplier(false, null, null);
+        new GoogleCredentialsAccessTokenSupplier(null, null);
     assertThat(supplier.get(), equalTo(Optional.<String>absent()));
   }
 
@@ -48,7 +42,7 @@ public class GoogleCredentialsAccessTokenSupplierTest {
   public void testGetWithStaticToken() {
     final AccessToken token = new AccessToken("token", null);
     final GoogleCredentialsAccessTokenSupplier supplier =
-        new GoogleCredentialsAccessTokenSupplier(true, token, null);
+        new GoogleCredentialsAccessTokenSupplier(token, null);
     assertThat(supplier.get(), equalTo(Optional.of("Bearer token")));
   }
 
@@ -61,7 +55,7 @@ public class GoogleCredentialsAccessTokenSupplierTest {
     final GoogleCredentials credentials = new GoogleCredentials(accessToken);
 
     final GoogleCredentialsAccessTokenSupplier supplier = new GoogleCredentialsAccessTokenSupplier(
-        true, null, null, credentials);
+        null, null, credentials);
 
     assertThat(supplier.get(), equalTo(Optional.of("Bearer foobar")));
   }

--- a/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,37 +26,19 @@ import static org.hamcrest.Matchers.equalTo;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Optional;
-import java.io.IOException;
 import org.junit.Test;
 
 public class GoogleCredentialsAccessTokenSupplierTest {
 
-  @Test
-  public void testGetWhenDisabled() {
-    final GoogleCredentialsAccessTokenSupplier supplier =
-        new GoogleCredentialsAccessTokenSupplier(null, null);
-    assertThat(supplier.get(), equalTo(Optional.<String>absent()));
-  }
+  private final AccessToken accessToken = new AccessToken("foobar", null);
+
+  // instantiating the GoogleCredentials class directly is a big hack to workaround the fact that
+  // we cannot stub the final method getAccessToken()
+  private final GoogleCredentialsAccessTokenSupplier supplier =
+      new GoogleCredentialsAccessTokenSupplier(new GoogleCredentials(accessToken));
 
   @Test
-  public void testGetWithStaticToken() {
-    final AccessToken token = new AccessToken("token", null);
-    final GoogleCredentialsAccessTokenSupplier supplier =
-        new GoogleCredentialsAccessTokenSupplier(token, null);
-    assertThat(supplier.get(), equalTo(Optional.of("Bearer token")));
-  }
-
-  @Test
-  public void testGetWithCredentials() throws IOException {
-    final AccessToken accessToken = new AccessToken("foobar", null);
-
-    // instantiating the GoogleCredentials class directly is a big hack to workaround the fact that
-    // we cannot stub the final method getAccessToken()
-    final GoogleCredentials credentials = new GoogleCredentials(accessToken);
-
-    final GoogleCredentialsAccessTokenSupplier supplier = new GoogleCredentialsAccessTokenSupplier(
-        null, null, credentials);
-
+  public void testGetWithCredentials() {
     assertThat(supplier.get(), equalTo(Optional.of("Bearer foobar")));
   }
 }

--- a/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAuthorizationHeaderSupplierTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAuthorizationHeaderSupplierTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,14 +28,14 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Optional;
 import org.junit.Test;
 
-public class GoogleCredentialsAccessTokenSupplierTest {
+public class GoogleCredentialsAuthorizationHeaderSupplierTest {
 
   private final AccessToken accessToken = new AccessToken("foobar", null);
 
   // instantiating the GoogleCredentials class directly is a big hack to workaround the fact that
   // we cannot stub the final method getAccessToken()
-  private final GoogleCredentialsAccessTokenSupplier supplier =
-      new GoogleCredentialsAccessTokenSupplier(new GoogleCredentials(accessToken));
+  private final GoogleCredentialsAuthorizationHeaderSupplier supplier =
+      new GoogleCredentialsAuthorizationHeaderSupplier(new GoogleCredentials(accessToken));
 
   @Test
   public void testGetWithCredentials() {


### PR DESCRIPTION
These PR contains two refactorings:

1. throw exception if file at HELIOS_GOOGLE_CREDENTIALS cannot be read

    This changes the behavior when the HELIOS_GOOGLE_CREDENTIALS environment variable is set to a file that does not exist or cannot be read from falling to Application Default Credentials to instead throw an exception.

    If the environment variable contains invalid configuration, it seems better to throw an exception rather than silently use a different set of (possibly incorrect) credentials.

    We have seen some confusing behavior internally arising from the fact that this class would load an unexpected set of credentials when the file at the environment variable could not be loaded.

2. introduce a AuthorizationHeaderSupplier interface

    This is a refactoring of the GoogleCredentialsAccessTokenSupplier class and its usage in AuthenticationHttpConnector and HeliosClient.Builder to make those classes less tied to the Google Cloud OAuth2 token concepts.

    The goal here is to make it much simpler to add non-Google implementations of this interface in the future without having to have other layers of Helios (such as AuthenticatingHttpConnector) aware of those implementation details.