### PR TITLE
Fix bug that erases metadata from job JSON file

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -402,11 +402,9 @@ public class JobCreateCommand extends ControlCommand {
 
     final Map<String, String> metadata = Maps.newHashMap();
     metadata.putAll(defaultMetadata());
+    metadata.putAll(builder.getMetadata());
     final List<String> metadataList = options.getList(metadataArg.getDest());
-    if (!metadataList.isEmpty()) {
-      // TODO (mbrown): values from job conf file (which maybe involves dereferencing env vars?)
-      metadata.putAll(parseListOfPairs(metadataList, "metadata"));
-    }
+    metadata.putAll(parseListOfPairs(metadataList, "metadata"));
     builder.setMetadata(metadata);
 
     // Parse port mappings

--- a/helios-tools/src/test/resources/job_config_extra_metadata.json
+++ b/helios-tools/src/test/resources/job_config_extra_metadata.json
@@ -1,0 +1,6 @@
+{
+  "metadata": {
+    "foo" : "bar",
+    "baz" : "qux"
+  }
+}


### PR DESCRIPTION
This fixes a bug that causes metadata passed in for job creation
from the JSON file is erased by the absence of the `--metadata`
switch in the CLI command.