### PR TITLE
Prevent creation of jobs with external ports and grace period

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -23,6 +23,7 @@ package com.spotify.helios.common;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static java.util.regex.Pattern.compile;
 
 import com.google.common.base.Joiner;
@@ -208,7 +209,18 @@ public class JobValidator {
       }
     }
 
+    errors.addAll(validateGracePeriodAndExternalPorts(job));
+
     return errors;
+  }
+
+  private Set<String> validateGracePeriodAndExternalPorts(final Job job) {
+    final Integer gracePeriod = job.getGracePeriod();
+    if (gracePeriod != null && gracePeriod > 0 && job.hasExternalPorts()) {
+      return singleton("This configuration will prevent new containers from deploying during the "
+                       + "gracePeriod because of port conflicts.");
+    }
+    return emptySet();
   }
 
   /**

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Job.java
@@ -404,6 +404,18 @@ public class Job extends Descriptor implements Comparable<Job> {
     return rolloutOptions;
   }
 
+  /**
+   * Returns true if any of the Job's {@link PortMapping}s has an external port.
+   */
+  public boolean hasExternalPorts() {
+    for (final PortMapping pm : ports.values()) {
+      if (pm.hasExternalPort()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/JobTest.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.spotify.helios.common.descriptors.Descriptor.parse;
 import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -546,5 +547,29 @@ public class JobTest {
 
     assertNull(builder.buildWithoutHash().getId().getHash());
     assertNotNull(builder.build().getId().getHash());
+  }
+
+  @Test
+  public void testHasExternalPorts() {
+    final Job.Builder builder = Job.newBuilder().setName("foo").setVersion("1").setImage("foobar");
+
+    final Job noPorts = builder.build();
+    assertThat(noPorts.hasExternalPorts(), equalTo(false));
+
+    final Job noExternalPorts = builder
+        .setPorts(ImmutableMap.of(
+            "add_ports1", PortMapping.of(1234),
+            "add_ports2", PortMapping.of(2345)
+        ))
+        .build();
+    assertThat(noExternalPorts.hasExternalPorts(), equalTo(false));
+
+    final Job externalPorts = builder
+        .setPorts(ImmutableMap.of(
+            "add_ports1", PortMapping.of(1234),
+            "add_ports2", PortMapping.of(2345, 9090)
+        ))
+        .build();
+    assertThat(externalPorts.hasExternalPorts(), equalTo(true));
   }
 }

--- a/helios-client/src/test/resources/job-with-external-ports-and-grace-period.json
+++ b/helios-client/src/test/resources/job-with-external-ports-and-grace-period.json
@@ -1,0 +1,22 @@
+{
+  "id": "foobar:1:48d9888333089d782fc2bb0e1681c0afe1dc1454",
+  "image": "example.net/foo/bar",
+  "gracePeriod": 500,
+  "ports": {
+    "http": {
+      "internalPort": 8080,
+      "externalPort": 8080,
+      "protocol": "tcp"
+    }
+  },
+  "registration": {
+    "my-cool-service/http": {
+      "ports": {
+        "http": {}
+      }
+    }
+  },
+  "volumes": {
+    "/some/path:ro": "/another/path"
+  }
+}

--- a/helios-client/src/test/resources/job-with-external-ports.json
+++ b/helios-client/src/test/resources/job-with-external-ports.json
@@ -1,0 +1,21 @@
+{
+  "id": "foobar:1:104e77cf3aa8d497526e34e8631348069a544e0c",
+  "image": "example.net/foo/bar",
+  "ports": {
+    "http": {
+      "internalPort": 8080,
+      "externalPort": 8080,
+      "protocol": "tcp"
+    }
+  },
+  "registration": {
+    "my-cool-service/http": {
+      "ports": {
+        "http": {}
+      }
+    }
+  },
+  "volumes": {
+    "/some/path:ro": "/another/path"
+  }
+}

--- a/helios-client/src/test/resources/job-with-grace-period.json
+++ b/helios-client/src/test/resources/job-with-grace-period.json
@@ -1,0 +1,21 @@
+{
+  "id": "foobar:1:854145e9a5e09a8c635c0f584f45d5f26342bef7",
+  "image": "example.net/foo/bar",
+  "gracePeriod": 10,
+  "ports": {
+    "http": {
+      "internalPort": 8080,
+      "protocol": "tcp"
+    }
+  },
+  "registration": {
+    "my-cool-service/http": {
+      "ports": {
+        "http": {}
+      }
+    }
+  },
+  "volumes": {
+    "/some/path:ro": "/another/path"
+  }
+}

--- a/helios-client/src/test/resources/job-with-no-external-ports.json
+++ b/helios-client/src/test/resources/job-with-no-external-ports.json
@@ -1,0 +1,20 @@
+{
+  "id": "foobar:1:65597d013748b8eac1d86ac5088ab6e6bf9546b4",
+  "image": "example.net/foo/bar",
+  "ports": {
+    "http": {
+      "internalPort": 8080,
+      "protocol": "tcp"
+    }
+  },
+  "registration": {
+    "my-cool-service/http": {
+      "ports": {
+        "http": {}
+      }
+    }
+  },
+  "volumes": {
+    "/some/path:ro": "/another/path"
+  }
+}

--- a/helios-client/src/test/resources/job-with-no-ports.json
+++ b/helios-client/src/test/resources/job-with-no-ports.json
@@ -1,0 +1,7 @@
+{
+  "id": "foobar:1:253df2150e8993ba14086c106961377ebeae0185",
+  "image": "example.net/foo/bar",
+  "volumes": {
+    "/some/path:ro": "/another/path"
+  }
+}


### PR DESCRIPTION
Presently, the default `gracePeriod` is 600 seconds (10 minutes)
and the default `rolloutTimeout` is 300 seconds (5 minutes).
These defaults interact poorly when static ports are in use:
the old container holds the port for 10 minutes, blocking the new
container from starting and causing the entire deployment to fail.
This behavior shouldn't be allowed.

Behavior with this PR:

```
cat helios-job.json

{
  "image": "example.net/foo/bar",
  "gracePeriod": 500,
  "ports": {
    "http": {
      "internalPort": 8080,
      "protocol": "tcp"
    }
  },
  "registration": {
    "my-cool-service/http": {
      "ports": {
        "http": {}
      }
    }
  },
  "volumes": {
    "/some/path:ro": "/another/path"
  }
}

helios -z http://localhost:5801 create dxia-test:1 -f helios-job.json

Creating job: {"addCapabilities":[],"command":[],"created":null,"creatingUser":null,"dropCapabilities":[],"env":{},"expires":null,"gracePeriod":500,"healthCheck":null,"hostname":null,"id":"dxia-test:1","image":"example.net/foo/bar","labels":{},"metadata":{},"networkMode":null,"ports":{"http":{"externalPort":8080,"internalPort":8080,"ip":null,"protocol":"tcp"}},"ramdisks":{},"registration":{"my-cool-service/http":{"ports":{"http":{}}}},"registrationDomain":"","resources":null,"rolloutOptions":null,"secondsToWaitBeforeKill":null,"securityOpt":[],"token":"","volumes":{"/some/path:ro":"/another/path"}}

Failed: CreateJobResponse{status=INVALID_JOB_DEFINITION, errors=[Job has a grace period and static/external ports. Please choose one or the other.], id='dxia-test:1:eb7f2180f0e935671b7eeed9d841584a3836e932'}
```