### PR TITLE
Relax volume validation requirements

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -428,7 +428,7 @@ see [volumes][] in the Docker reference for full details. The container path can
 be suffixed with "rw" or "ro" to create a read-write or read-only volume mount,
 respectively.
 
-Format: `[container-path]:[rw|ro]:[host-path|volume-name]`.
+Format: `"[container-path]:[rw|ro]": "[host-path|volume-name]"`.
 
 Examples:
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -421,13 +421,22 @@ container.
 #### volumes
 Container volumes. Optional. 
 
-Specify either a single path to create a data volume, or a source path and a
-container path to mount a file or directory from the host. 
-  
-The container path can be suffixed with "rw" or "ro" to create a read-write or
-read-only volume, respectively.
+Specify a single path to create a data volume, a container path and a source
+path to mount a directory from the host, or a container path and a name to mount
+a named volume. The named volume will be created by docker if it does not exist;
+see [volumes][] in the Docker reference for full details. The container path can
+be suffixed with "rw" or "ro" to create a read-write or read-only volume mount,
+respectively.
 
-Format: `[container-path]:[rw|ro]:[host-path]`.
+Format: `[container-path]:[rw|ro]:[host-path|volume-name]`.
+
+Examples:
+
+  * Mount a new data volume (name assigned by docker) to `/foo` in the container: `"volumes": {"/foo": ""}`
+  * Mount `/src` from the host to `/dst` in the container: `"volumes": {"/dst": "/src"}`
+  * Mount a volume named `my-vol` to `/dst` in the container: `"volumes": {"/dst": "my-vol"}`
+
+[volumes]: https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
 
 ### Health Checks
 

--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -161,6 +161,10 @@ public class JobValidator {
         errors.add("Volume path is not absolute: " + path);
         continue;
       }
+      if (source.contains("/") && !source.startsWith("/")) {
+        errors.add("Volume source is not absolute: " + source);
+        continue;
+      }
       final String[] parts = path.split(":", 3);
       if (path.isEmpty()
           || path.equals("/")

--- a/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/JobValidator.java
@@ -161,13 +161,10 @@ public class JobValidator {
         errors.add("Volume path is not absolute: " + path);
         continue;
       }
-      if (!isNullOrEmpty(source) && !source.startsWith("/")) {
-        errors.add("Volume source is not absolute: " + source);
-        continue;
-      }
       final String[] parts = path.split(":", 3);
       if (path.isEmpty()
-          || path.equals("/") | parts.length > 2
+          || path.equals("/")
+          || parts.length > 2
           || (parts.length > 1 && parts[1].isEmpty())) {
         errors.add(format("Invalid volume path: %s", path));
       }

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -421,6 +421,9 @@ public class JobValidatorTest {
 
     assertEquals(newHashSet("Volume path is not absolute: foo"),
         validator.validate(j.toBuilder().addVolume("foo", "/bar").build()));
+
+    assertEquals(newHashSet("Volume source is not absolute: bar/baz"),
+        validator.validate(j.toBuilder().addVolume("/foo", "bar/baz").build()));
   }
 
   @Test

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -169,6 +169,7 @@ public class JobValidatorTest {
   @Test
   public void testValidVolumesPass() {
     final Job j = Job.newBuilder().setName("foo").setVersion("1").setImage("foobar").build();
+    assertThat(validator.validate(j.toBuilder().addVolume("/foo", "bar").build()), is(empty()));
     assertThat(validator.validate(j.toBuilder().addVolume("/foo").build()), is(empty()));
     assertThat(validator.validate(j.toBuilder().addVolume("/foo", "/").build()), is(empty()));
     assertThat(validator.validate(j.toBuilder().addVolume("/foo:ro", "/").build()), is(empty()));
@@ -420,9 +421,6 @@ public class JobValidatorTest {
 
     assertEquals(newHashSet("Volume path is not absolute: foo"),
         validator.validate(j.toBuilder().addVolume("foo", "/bar").build()));
-
-    assertEquals(newHashSet("Volume source is not absolute: bar"),
-        validator.validate(j.toBuilder().addVolume("/foo", "bar").build()));
   }
 
   @Test

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -112,7 +112,7 @@ public class TaskConfig {
     builder.hostname(job.getHostname());
     builder.env(containerEnvStrings());
     builder.exposedPorts(containerExposedPorts());
-    builder.volumes(volumes());
+    builder.volumes(volumes().keySet());
     builder.labels(job.getLabels());
 
     for (final ContainerDecorator decorator : containerDecorators) {


### PR DESCRIPTION
This commit adds support for mounting named volumes by relaxing the
validation performed by the `JobValidator`. This allows jobs to use
options for volumes managed by a particular driver, such as:

```
docker volume create --driver local \
   --opt type=btrfs --opt device=/dev/sda2 \
   myvolume
```

The above volume can then be mounted into a container using the
following helios job configuration (full configuration omitted):

```
{
  ...
  "volumes": {
    "/mnt/myvol": "myvolume"
  }
}
```

@mattnworb @davidxia 