### PR TITLE
Fix cli help text for `create --volume` flag

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -226,7 +226,7 @@ public class JobCreateCommand extends ControlCommand {
         .help("Container volumes. Specify either a single path to create a data volume, "
               + "or a source path and a container path to mount a file or directory from the host. "
               + "The container path can be suffixed with \"rw\" or \"ro\" to create a read-write "
-              + "or read-only volume, respectively. Format: [container-path]:[host-path]:[rw|ro].");
+              + "or read-only volume, respectively. Format: [host-path]:[container-path]:[rw|ro].");
 
     argsArg = parser.addArgument("args")
         .nargs("*")


### PR DESCRIPTION
This commit corrects some confusion resulting from the misordering of
volume path arguments. This was first reported in [this issue][0], then
a "fix" was [applied here][1]. In fact, as reported in [this issue][2],
the documentation from that fix was incorrect.

The `--volume` flag is inconsistent with how job configuration files are
parsed; at least the documentation will be correct.

For `--volume`, left is host source, right is container path:
https://github.com/spotify/helios/blob/dbcbe17d1a2a2da650c09deb92b1dc7f58143464/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java#L481-L483

For job config files, left is container path, right is host source:
https://github.com/spotify/helios/blob/dbcbe17d1a2a2da650c09deb92b1dc7f58143464/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java#L324-L357

@mattnworb @davidxia

[0]: https://github.com/spotify/helios/issues/486
[1]: https://github.com/spotify/helios/pull/503
[2]: https://github.com/spotify/helios/issues/789