### PR TITLE
Upgrade google-auth-library-java from 0.7.1 to 0.10.0

### DIFF
--- a/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplier.java
@@ -39,7 +39,7 @@ class GoogleCredentialsAccessTokenSupplier implements Supplier<Optional<AccessTo
   private static final Logger LOG =
       LoggerFactory.getLogger(GoogleCredentialsAccessTokenSupplier.class);
 
-  public static final List<String> DEFAULT_SCOPES = ImmutableList.of(
+  static final List<String> DEFAULT_SCOPES = ImmutableList.of(
       "https://www.googleapis.com/auth/cloud-platform.read-only",
       "https://www.googleapis.com/auth/userinfo.email"
   );
@@ -80,7 +80,7 @@ class GoogleCredentialsAccessTokenSupplier implements Supplier<Optional<AccessTo
             if (credentials == null) {
               credentials = getCredentialsWithScopes(tokenScopes);
             }
-            credentials.getRequestMetadata(null);
+            credentials.refreshAccessToken();
           }
 
           tokenOpt = Optional.of(credentials.getAccessToken());

--- a/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/client/GoogleCredentialsAccessTokenSupplierTest.java
@@ -22,7 +22,6 @@ package com.spotify.helios.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -30,7 +29,6 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Optional;
 import java.io.IOException;
-import java.net.URI;
 import org.junit.Test;
 
 public class GoogleCredentialsAccessTokenSupplierTest {
@@ -56,6 +54,6 @@ public class GoogleCredentialsAccessTokenSupplierTest {
     final GoogleCredentialsAccessTokenSupplier supplier = new GoogleCredentialsAccessTokenSupplier(
         true, null, null, credentials);
     supplier.get();
-    verify(credentials).getRequestMetadata(any(URI.class));
+    verify(credentials).refreshAccessToken();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -358,12 +358,12 @@
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-credentials</artifactId>
-                <version>0.7.1</version>
+                <version>0.10.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
-                <version>0.7.1</version>
+                <version>0.10.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
so we can use `Oauth2Credentials.refreshAccessToken()` instead of `getRequestMetadata()`.

See https://github.com/google/google-auth-library-java/issues/147.