### PR TITLE
Add support for container runtime

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -200,6 +200,7 @@ example that uses all the available configuration keys with an explanation of ea
   "secondsToWaitBeforeKill": 120,
   "securityOpt" : [ "label:user:USER", "apparmor:PROFILE" ],
   "token": "insecure-access-token",
+  "runtime": "nvidia",
   "volumes" : {
     "/destination/path/in/container.yaml:ro" : "/source/path/in/host.yaml"
   }
@@ -400,6 +401,13 @@ Will ultimately have these options at `rolling-update` time.
 
 Since timeout, migrate, and token weren't specified either via CLI or job config, they get their
 values from the defaults in [`RolloutOptions`][rollout-options-code].
+
+#### runtime
+Optional. Container runtime to use. When specifying a runtime, you will need to ensure that 
+the docker daemon knows about the specified runtime. For example, to enable nvidia runtime,
+you will need to configure the host to install runtime.
+
+[Puppet example](https://ghe.spotify.net/puppet/spotify-puppet/blob/d2c2d8da25299ec591a7fd67d70037b5cfbb8713/modules/nvidia_docker2/manifests/init.pp).
 
 #### secondsToWaitBeforeKill
 Optional. When a job is being stopped or undeployed, the helios-agent will ask

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -407,7 +407,7 @@ Optional. Container runtime to use. When specifying a runtime, you will need to 
 the docker daemon knows about the specified runtime. For example, to enable nvidia runtime,
 you will need to configure the host to install runtime.
 
-[Puppet example](https://ghe.spotify.net/puppet/spotify-puppet/blob/d2c2d8da25299ec591a7fd67d70037b5cfbb8713/modules/nvidia_docker2/manifests/init.pp).
+[Example of setting up nvidia container runtime.](https://github.com/NVIDIA/nvidia-docker) 
 
 #### secondsToWaitBeforeKill
 Optional. When a job is being stopped or undeployed, the helios-agent will ask

--- a/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/JobValidatorTest.java
@@ -40,6 +40,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_RESOURCES;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_ROLLOUT_OPTIONS;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_RUNTIME;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECONDS_TO_WAIT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECURITY_OPT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
@@ -218,7 +219,7 @@ public class JobValidatorTest {
         EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
         EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
         EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS,
-        EMPTY_SECONDS_TO_WAIT, EMPTY_RAMDISKS, EMPTY_ROLLOUT_OPTIONS);
+        EMPTY_SECONDS_TO_WAIT, EMPTY_RAMDISKS, EMPTY_ROLLOUT_OPTIONS, EMPTY_RUNTIME);
     final JobId recomputedId = job.toBuilder().build().getId();
     assertEquals(ImmutableSet.of("Id hash mismatch: " + job.getId().getHash()
                                  + " != " + recomputedId.getHash()), validator.validate(job));

--- a/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/HealthCheckerFactory.java
@@ -105,7 +105,7 @@ public final class HealthCheckerFactory {
           handleExecStartConnectionReset(e);
         }
 
-        final int exitCode = docker.execInspect(execId).exitCode();
+        final long exitCode = docker.execInspect(execId).exitCode();
         if (exitCode != 0) {
           log.warn("exec healthcheck containerId={} cmd={} failed with exitCode={} output={}",
               containerId, Arrays.toString(cmd), exitCode, output);

--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -318,7 +318,7 @@ public class Supervisor {
       }
 
       // Check if the runner exited normally or threw an exception
-      final Result<Integer> result = runner.result();
+      final Result<Long> result = runner.result();
       if (!result.isSuccess()) {
         // Runner threw an exception, inspect it.
         final Throwable t = result.getException();

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskConfig.java
@@ -297,6 +297,7 @@ public class TaskConfig {
         .portBindings(portBindings())
         .dns(dns)
         .securityOpt(securityOpt.toArray(new String[securityOpt.size()]))
+        .runtime(job.getRuntime())
         .networkMode(job.getNetworkMode());
 
     if (!job.getRamdisks().isEmpty()) {

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskMonitor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskMonitor.java
@@ -172,7 +172,7 @@ public class TaskMonitor implements TaskRunner.Listener, Closeable {
   }
 
   @Override
-  public void exited(final int code) {
+  public void exited(final long code) {
     flapController.exited();
     updateThrottle();
     updateState(EXITED);

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -56,7 +56,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
   private static final Logger log = LoggerFactory.getLogger(TaskRunner.class);
 
   private final long delayMillis;
-  private final SettableFuture<Integer> result = SettableFuture.create();
+  private final SettableFuture<Long> result = SettableFuture.create();
   private final TaskConfig config;
   private final DockerClient docker;
   private final String existingContainerId;
@@ -83,11 +83,11 @@ class TaskRunner extends InterruptingExecutionThreadService {
     this.containerId = Optional.absent();
   }
 
-  public Result<Integer> result() {
+  public Result<Long> result() {
     return Result.of(result);
   }
 
-  public ListenableFuture<Integer> resultFuture() {
+  public ListenableFuture<Long> resultFuture() {
     return result;
   }
 
@@ -152,7 +152,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
   @Override
   protected void run() {
     try {
-      final int exitCode = run0();
+      final long exitCode = run0();
       result.set(exitCode);
     } catch (Exception e) {
       listener.failed(e, getContainerError());
@@ -160,7 +160,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
     }
   }
 
-  private int run0() throws InterruptedException, DockerException {
+  private long run0() throws InterruptedException, DockerException {
     // Delay
     Thread.sleep(delayMillis);
 
@@ -375,7 +375,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
 
     void running();
 
-    void exited(int code);
+    void exited(long code);
   }
 
   public static Builder builder() {
@@ -494,7 +494,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
     }
 
     @Override
-    public void exited(final int code) {
+    public void exited(final long code) {
 
     }
   }

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunnerFactory.java
@@ -189,7 +189,7 @@ public class TaskRunnerFactory {
     }
 
     @Override
-    public void exited(final int code) {
+    public void exited(final long code) {
       for (final TaskRunner.Listener l : listeners) {
         l.exited(code);
       }

--- a/helios-services/src/test/java/com/spotify/helios/agent/ExecHealthCheckerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/ExecHealthCheckerTest.java
@@ -65,7 +65,7 @@ public class ExecHealthCheckerTest {
     when(version.apiVersion()).thenReturn("1.18");
 
     final ExecState execState = mock(ExecState.class);
-    when(execState.exitCode()).thenReturn(0);
+    when(execState.exitCode()).thenReturn(0L);
 
     final LogStream log = mock(LogStream.class);
     when(log.readFully()).thenReturn("");
@@ -90,7 +90,7 @@ public class ExecHealthCheckerTest {
   @Test
   public void testHealthCheckFailure() throws Exception {
     final ExecState execState = mock(ExecState.class);
-    when(execState.exitCode()).thenReturn(2);
+    when(execState.exitCode()).thenReturn(2L);
     when(docker.execInspect(EXEC_ID)).thenReturn(execState);
 
     assertThat(checker.check(CONTAINER_ID), is(false));

--- a/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/SupervisorTest.java
@@ -345,7 +345,7 @@ public class SupervisorTest {
     when(docker.createContainer(any(ContainerConfig.class), any(String.class)))
         .thenReturn(createResponse2);
     when(docker.inspectContainer(eq(containerId2))).thenReturn(runningResponse);
-    waitFuture1.set(ContainerExit.create(1));
+    waitFuture1.set(ContainerExit.create(1L));
 
     // Verify that the container was restarted
     verify(docker, timeout(30000)).createContainer(any(ContainerConfig.class), any(String.class));

--- a/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/TaskConfigTest.java
@@ -130,6 +130,21 @@ public class TaskConfigTest {
   }
 
   @Test
+  public void testRuntimeHostConfig() throws Exception {
+
+    Job nvidiaRuntimeJob = JOB.toBuilder().setRuntime("nvidia").build();
+
+    final TaskConfig taskConfig = TaskConfig.builder()
+        .namespace("test")
+        .host(HOST)
+        .job(nvidiaRuntimeJob)
+        .build();
+
+    final HostConfig hostConfig = taskConfig.hostConfig(Optional.absent());
+    assertThat(hostConfig.runtime(), equalTo("nvidia"));
+  }
+
+  @Test
   public void testContainerConfig() throws Exception {
     final TaskConfig taskConfig = TaskConfig.builder()
         .namespace("test")

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/IdMismatchJobCreateTest.java
@@ -37,6 +37,7 @@ import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_REGISTRATION_DOMAIN;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_RESOURCES;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_ROLLOUT_OPTIONS;
+import static com.spotify.helios.common.descriptors.Job.EMPTY_RUNTIME;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECONDS_TO_WAIT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_SECURITY_OPT;
 import static com.spotify.helios.common.descriptors.Job.EMPTY_TOKEN;
@@ -63,7 +64,7 @@ public class IdMismatchJobCreateTest extends SystemTestBase {
             EMPTY_REGISTRATION_DOMAIN, EMPTY_CREATING_USER, EMPTY_TOKEN,
             EMPTY_HEALTH_CHECK, EMPTY_SECURITY_OPT, DEFAULT_NETWORK_MODE,
             EMPTY_METADATA, EMPTY_CAPS, EMPTY_CAPS, EMPTY_LABELS, EMPTY_SECONDS_TO_WAIT,
-            EMPTY_RAMDISKS, EMPTY_ROLLOUT_OPTIONS)
+            EMPTY_RAMDISKS, EMPTY_ROLLOUT_OPTIONS, EMPTY_RUNTIME)
     ).get();
 
     // TODO (dano): Maybe this should be ID_MISMATCH but then JobValidator must become able to

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/JobExpirationTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/JobExpirationTest.java
@@ -88,6 +88,6 @@ public class JobExpirationTest extends SystemTestBase {
 
     // Wait for the agent to kill the container
     final ContainerExit exit = docker.waitContainer(taskStatus.getContainerId());
-    assertThat(exit.statusCode(), is(0));
+    assertThat(exit.statusCode(), is(0L));
   }
 }

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/ReapingTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/ReapingTest.java
@@ -68,9 +68,9 @@ public class ReapingTest extends SystemTestBase {
     // With LXC, killing a container results in exit code 0.
     // In docker 1.5 killing a container results in exit code 137, in previous versions it's -1.
     final String executionDriver = docker.info().executionDriver();
-    final List<Integer> expectedExitCodes =
+    final List<Long> expectedExitCodes =
         (executionDriver != null && executionDriver.startsWith("lxc-"))
-        ? Collections.singletonList(0) : asList(-1, 137);
+        ? Collections.singletonList(0L) : asList(-1L, 137L);
 
     // Wait for the agent to kill the container
     final ContainerExit exit1 = docker.waitContainer(intruder1);

--- a/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
+++ b/helios-testing/src/test/java/com/spotify/helios/testing/HeliosSoloDeploymentTest.java
@@ -149,7 +149,7 @@ public class HeliosSoloDeploymentTest {
     when(containerInfo.networkSettings()).thenReturn(networkSettings);
     when(this.dockerClient.inspectContainer(CONTAINER_ID)).thenReturn(containerInfo);
 
-    when(this.dockerClient.waitContainer(CONTAINER_ID)).thenReturn(ContainerExit.create(0));
+    when(this.dockerClient.waitContainer(CONTAINER_ID)).thenReturn(ContainerExit.create(0L));
   }
 
   private HeliosSoloDeployment buildHeliosSoloDeployment() {

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>
-                <version>8.12.0</version>
+                <version>8.13.0</version>
                 <classifier>shaded</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>
-                <version>8.11.3</version>
+                <version>8.12.0</version>
                 <classifier>shaded</classifier>
             </dependency>
 


### PR DESCRIPTION
This PR enables [setting runtime](https://docs.docker.com/engine/api/v1.37/#operation/ContainerCreate) when creating a container. This allows using GPUs as container runtimes, for example.