### PR TITLE
Add runtime config support to CLI switch and inspect cmd

### DIFF
--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobCreateCommand.java
@@ -125,6 +125,7 @@ public class JobCreateCommand extends ControlCommand {
   private final Argument dropCapabilityArg;
   private final Argument labelsArg;
   private final Argument rolloutOptionsArg;
+  private final Argument runtimeArg;
   private final Supplier<Map<String, String>> envVarSupplier;
 
   public JobCreateCommand(final Subparser parser) {
@@ -285,6 +286,10 @@ public class JobCreateCommand extends ControlCommand {
         .help("Rollout options to use during a rolling-update. Use this switch more than once to "
               + "specify multiple options. Args should be of the form key=val. Valid keys are "
               + "migrate, parallelism, timeout, overlap, token, and ignoreFailures.");
+
+    runtimeArg = parser.addArgument("--runtime")
+        .nargs("?")
+        .help("Runtime to use with this container.");
 
     this.envVarSupplier = envVarSupplier;
   }
@@ -566,6 +571,11 @@ public class JobCreateCommand extends ControlCommand {
       rolloutOptionsMap.putAll(parseListOfPairs(rolloutOptionsList, "rollout_options"));
       final RolloutOptions rolloutOptions = Json.convert(rolloutOptionsMap, RolloutOptions.class);
       builder.setRolloutOptions(rolloutOptions);
+    }
+
+    final String runtime = options.getString(runtimeArg.getDest());
+    if (!isNullOrEmpty(runtime)) {
+      builder.setRuntime(runtime);
     }
 
     // We build without a hash here because we want the hash to be calculated server-side.

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobInspectCommand.java
@@ -26,7 +26,6 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.spotify.helios.client.HeliosClient;
@@ -35,7 +34,6 @@ import com.spotify.helios.common.descriptors.ExecHealthCheck;
 import com.spotify.helios.common.descriptors.HealthCheck;
 import com.spotify.helios.common.descriptors.HttpHealthCheck;
 import com.spotify.helios.common.descriptors.Job;
-import com.spotify.helios.common.descriptors.JobId;
 import com.spotify.helios.common.descriptors.PortMapping;
 import com.spotify.helios.common.descriptors.RolloutOptions;
 import com.spotify.helios.common.descriptors.ServicePorts;
@@ -167,6 +165,7 @@ public class JobInspectCommand extends WildcardJobCommand {
       printVolumes(out, job.getVolumes());
       out.printf("Add capabilities: %s%n", Joiner.on(", ").join(job.getAddCapabilities()));
       out.printf("Drop capabilities: %s%n", Joiner.on(", ").join(job.getDropCapabilities()));
+      out.printf("Runtime: %s%n", job.getRuntime());
       out.printf("Rollout options (null options will fallback to defaults at "
                  + "rolling-update time): %s%n", formatRolloutOptions(job.getRolloutOptions()));
     }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobCreateCommandTest.java
@@ -138,6 +138,7 @@ public class JobCreateCommandTest {
     when(options.getList("labels")).thenReturn(Lists.<Object>newArrayList("a=b", "c=d"));
     doReturn(ImmutableList.of("cap1", "cap2")).when(options).getList("add_capability");
     doReturn(ImmutableList.of("cap3", "cap4")).when(options).getList("drop_capability");
+    when(options.getString("runtime")).thenReturn("nvidia");
 
     when(options.getList("rollout_options"))
         .thenReturn(Lists.<Object>newArrayList("overlap=true", "parallelism=2", "foo=bar"));
@@ -160,6 +161,7 @@ public class JobCreateCommandTest {
     assertThat(output, containsString("\"addCapabilities\":[\"cap1\",\"cap2\"]"));
     assertThat(output, containsString("\"dropCapabilities\":[\"cap3\",\"cap4\"]"));
     assertThat(output, containsString("\"labels\":{\"a\":\"b\",\"c\":\"d\"}"));
+    assertThat(output, containsString("\"runtime\":\"nvidia\""));
     assertThat(output,
         containsString("rolloutOptions\":{\"ignoreFailures\":null,\"migrate\":null,"
                        + "\"overlap\":true,\"parallelism\":2,\"timeout\":null,\"token\":null}"));
@@ -328,6 +330,45 @@ public class JobCreateCommandTest {
       @Override
       protected boolean matchesSafely(final Job actual) {
         return Objects.equals(labels, actual.getLabels());
+      }
+    };
+  }
+
+  @Test
+  public void testRuntimeFromJsonFile() throws Exception {
+    when(options.getString("id")).thenReturn(JOB_ID);
+    when(options.getString("image")).thenReturn("foobar");
+
+    when(options.get("file"))
+        .thenReturn(new File("src/test/resources/job_config_with_runtime.json"));
+
+    assertEquals(0, runCommand());
+
+    verify(client).createJob(argThat(hasRuntime("nvidia")));
+  }
+
+  @Test
+  public void testRuntimeFromCliOverridesJsonFile() throws Exception {
+    when(options.getString("id")).thenReturn(JOB_ID);
+    when(options.getString("image")).thenReturn("foobar");
+
+    when(options.get("file"))
+        .thenReturn(new File("src/test/resources/job_config_with_runtime.json"));
+
+    when(options.getString("runtime")).thenReturn("rkt");
+
+    assertEquals(0, runCommand());
+
+    verify(client).createJob(argThat(hasRuntime("rkt")));
+  }
+
+  private Matcher<Job> hasRuntime(final String runtime) {
+    final String description = "Job with runtime=" + runtime;
+
+    return new CustomTypeSafeMatcher<Job>(description) {
+      @Override
+      protected boolean matchesSafely(final Job actual) {
+        return Objects.equals(runtime, actual.getRuntime());
       }
     };
   }

--- a/helios-tools/src/test/java/com/spotify/helios/cli/command/JobInspectCommandTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/command/JobInspectCommandTest.java
@@ -85,6 +85,7 @@ public class JobInspectCommandTest {
               .externalPort(456)
               .build()
       ))
+      .setRuntime("nvidia")
       .setRolloutOptions(ROLLOUT_OPTIONS)
       .build();
 
@@ -123,6 +124,7 @@ public class JobInspectCommandTest {
     assertThat(output, containsString("Drop capabilities: cap3, cap4"));
     assertThat(output, containsString("Ports: bar=0.0.0.0:123:456/tcp"));
     assertThat(output, containsString("foo=127.0.0.1:80:8080/udp"));
+    assertThat(output, containsString("Runtime: nvidia"));
     assertThat(output, containsString("Rollout options (null options will fallback to defaults "
                                       + "at rolling-update time): timeout: 250, parallelism: 2, "
                                       + "migrate: true, overlap: true, token: foobar, "

--- a/helios-tools/src/test/resources/job_config_with_runtime.json
+++ b/helios-tools/src/test/resources/job_config_with_runtime.json
@@ -1,0 +1,3 @@
+{
+  "runtime": "nvidia"
+}


### PR DESCRIPTION
Allow CLI to override Job config file's runtime property via `--runtime` switch.
Every other Job property has this behavior.

Show runtime value in `inspect` command's output.