### PR TITLE
Fix errors when building with Java 11; test compiling on Circle

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,42 @@
+# This image is used to run the tests for helios on CircleCI
+# It's published as spotify/helios-test-container:1.
+
+# Get docker CLI binary only
+FROM ubuntu:bionic as docker-cli-getter
+WORKDIR /tmp
+RUN apt-get -qq update && apt-get -qq install \
+  wget
+RUN wget --quiet https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz && \
+  tar xzvf docker-18.06.1-ce.tgz
+
+
+# Dockerfile for the container CircleCI uses to build and test helios
+FROM ubuntu:bionic
+
+RUN apt-get -qq update && apt-get -qq install \
+  # Required tools for primary containers that aren't already in bionic
+  # https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers
+  git ssh \
+  # tools we need
+  wget maven lsof jq python-minimal python-pip
+
+# Download and validate checksum of openjdk-11
+# Checksum from https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz.sha256
+RUN wget --quiet https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz && \
+  echo '3784cfc4670f0d4c5482604c7c513beb1a92b005f569df9bf100e8bef6610f2e openjdk-11_linux-x64_bin.tar.gz' > openjdk-11-sha256sum.txt && \
+  sha256sum -c openjdk-11-sha256sum.txt
+
+# Install openjdk-11
+RUN tar -xzf openjdk-11_linux-x64_bin.tar.gz && \
+  mkdir -p /usr/lib/jvm && \
+  mv jdk-11 /usr/lib/jvm/openjdk-11 && \
+  update-alternatives --install /usr/bin/java java /usr/lib/jvm/openjdk-11/bin/java 20000 && \
+  update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/openjdk-11/bin/javac 20000
+
+# Add docker CLI
+COPY --from=docker-cli-getter /tmp/docker/docker /usr/bin/docker
+
+# Install codecov
+RUN pip install codecov
+
+ENV JAVA_HOME /usr/lib/jvm/openjdk-11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ jobs:
     machine: true
     
     steps:
-    # Machine Setup
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # The following `checkout` command checks out your code to your working directory. In 1.0 this is done implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
     - checkout
 
     # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
@@ -37,7 +34,7 @@ jobs:
          if [[ $(python --version 2>&1) = *"2.7.10"* ]] || pyenv versions --bare | grep -x -q '2.7.10'; then pyenv global 2.7.10;else pyenv install --skip-existing  2.7.10 && pyenv global 2.7.10 && pyenv rehash && pip install virtualenv && pip install nose && pip install pep8 && pyenv rehash;fi
 
     # Configuring Docker to accept remote connections
-    - run: ./circle.sh pre_machine
+    - run: ./circle.sh pre_machine && ./circle.sh pre_machine_docker
 
     # Restarting docker for the changes to be applied
     - run: sudo service docker restart
@@ -64,3 +61,30 @@ jobs:
         path: /var/log/upstart/docker.log
     - store_artifacts:
         path: /tmp/circleci-test-results
+
+  build_java11:
+    docker:
+      - image: spotify/helios-test-container:1
+    working_directory: ~/spotify/helios
+    parallelism: 1
+    shell: /bin/bash --login
+    environment:
+      MAVEN_OPTS: -Xmx128m
+
+    steps:
+    - checkout
+
+    - run: ./circle.sh pre_machine
+
+    - run:
+        command: ./circle.sh dependencies
+        no_output_timeout: 20m
+
+    - run: ./circle.sh verify_no_tests
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - build_java11

--- a/circle.sh
+++ b/circle.sh
@@ -2,22 +2,16 @@
 
 case "$1" in
   pre_machine)
-    # ensure correct level of parallelism
-    expected_nodes=6
-    if [ "$CIRCLE_NODE_TOTAL" -ne "$expected_nodes" ]
-    then
-        echo "Parallelism is set to ${CIRCLE_NODE_TOTAL}x, but we need ${expected_nodes}x."
-        exit 1
-    fi
+    # Edit pom files to have correct version syntax
+    for i in $(find . -name pom.xml -not -path './.rvm*'); do sed -i 's/${revision}/0/g' $i; done
 
+    ;;
+
+  pre_machine_docker)
     # have docker bind to localhost
     docker_opts='DOCKER_OPTS="$DOCKER_OPTS -H tcp://0.0.0.0:2375"'
     sudo sh -c "echo '$docker_opts' >> /etc/default/docker"
-
     cat /etc/default/docker
-
-    # Edit pom files to have correct version syntax
-    for i in $(find . -name pom.xml -not -path './.rvm*'); do sed -i 's/${revision}/0/g' $i; done
 
     ;;
 
@@ -30,6 +24,11 @@ case "$1" in
   dependencies)
     mvn clean install -T 2 -Dmaven.javadoc.skip=true -DskipTests=true -B -V
     pip install codecov
+
+    ;;
+
+  verify_no_tests)
+    mvn clean verify -DskipTests
 
     ;;
 

--- a/helios-client/src/main/java/com/spotify/helios/client/EndpointIterator.java
+++ b/helios-client/src/main/java/com/spotify/helios/client/EndpointIterator.java
@@ -22,14 +22,11 @@ package com.spotify.helios.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
-import javax.annotation.Nullable;
 
 /**
  * An {@link Iterator} of {@link Endpoint} that restarts when it reaches the end.
@@ -73,19 +70,5 @@ class EndpointIterator implements Iterator<Endpoint> {
   @Override
   public void remove() {
     throw new UnsupportedOperationException();
-  }
-
-  /**
-   * @return true if any endpoints' scheme is HTTPS.
-   */
-  boolean hasHttps() {
-    return Iterables.any(endpoints, new Predicate<Endpoint>() {
-      @Override
-      public boolean apply(@Nullable Endpoint endpoint) {
-        return endpoint != null && endpoint.getUri() != null
-               && endpoint.getUri().getScheme() != null
-               && endpoint.getUri().getScheme().equalsIgnoreCase("https");
-      }
-    });
   }
 }

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/Deployment.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/Deployment.java
@@ -55,7 +55,7 @@ public class Deployment extends Descriptor {
   private final String deploymentGroupName;
 
   /**
-   * Constructor
+   * Constructor.
    *
    * @param jobId               The id of the job.
    * @param goal                The desired state (i.e. goal) of the task/deployment.

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/DockerVersion.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/DockerVersion.java
@@ -52,6 +52,8 @@ public class DockerVersion {
   private final String version;
 
   /**
+   * Constructor.
+   *
    * @param apiVersion    The Docker api version supported.
    * @param arch          The architecture of the machine.
    * @param gitCommit     The git commit from which Docker was built.

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/HostInfo.java
@@ -73,6 +73,8 @@ public class HostInfo extends Descriptor {
   private final String dockerCertPath;
 
   /**
+   * Constructor.
+   *
    * @param hostname         The hostname of the agent.
    * @param uname            The output of the uname command.
    * @param architecture     The architecture of the Agent.

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobId.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobId.java
@@ -99,7 +99,7 @@ public class JobId extends Descriptor implements Comparable<JobId> {
   }
 
   /**
-   * Private constructor for use by {@link #parse(String)}
+   * Private constructor for use by {@link #parse(String)}.
    *
    * @param name The name of the job.
    */

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/JobStatus.java
@@ -81,14 +81,14 @@ public class JobStatus {
   }
 
   /**
-   * @return a map of host to task status.
+   * Return a map of host to task status.
    */
   public Map<String, TaskStatus> getTaskStatuses() {
     return taskStatuses;
   }
 
   /**
-   * @return a map of host to deployment.
+   * Return a map of host to deployment.
    */
   public Map<String, Deployment> getDeployments() {
     return deployments;

--- a/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
+++ b/helios-client/src/main/java/com/spotify/helios/common/descriptors/TaskStatus.java
@@ -88,6 +88,8 @@ public class TaskStatus extends Descriptor {
   private final String containerError;
 
   /**
+   * Constructor.
+   *
    * @param job            The job the task is running.
    * @param goal           The desired state of the task.
    * @param state          The state of the task.

--- a/helios-client/src/test/java/com/spotify/helios/common/descriptors/RolloutOptionsTest.java
+++ b/helios-client/src/test/java/com/spotify/helios/common/descriptors/RolloutOptionsTest.java
@@ -37,9 +37,6 @@
 
 package com.spotify.helios.common.descriptors;
 
-import static com.spotify.helios.common.descriptors.RolloutOptions.DEFAULT_IGNORE_FAILURES;
-import static com.spotify.helios.common.descriptors.RolloutOptions.DEFAULT_MIGRATE;
-import static com.spotify.helios.common.descriptors.RolloutOptions.DEFAULT_TOKEN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -35,7 +35,7 @@
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.4.13</version>
+                        <version>1.2.0</version>
                         <configuration>
                             <labels>
                                 <label>com.spotify.helios.version="${project.version}"</label>
@@ -119,7 +119,7 @@
                     <plugin>
                         <groupId>com.spotify</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.4.13</version>
+                        <version>1.2.0</version>
                         <configuration>
                             <labels>
                                 <label>com.spotify.helios.version="${project.version}"</label>

--- a/helios-services/pom.xml
+++ b/helios-services/pom.xml
@@ -417,7 +417,7 @@
 
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.1.0</version>
                 <configuration>
                     <descriptors>
                         <descriptor>${project.basedir}/src/assembly/helios-solo.xml</descriptor>

--- a/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/Supervisor.java
@@ -168,7 +168,7 @@ public class Supervisor {
   }
 
   /**
-   * Get the current container id
+   * Get the current container id.
    *
    * @return The container id.
    */

--- a/helios-services/src/main/java/com/spotify/helios/master/JobDoesNotExistException.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/JobDoesNotExistException.java
@@ -20,7 +20,6 @@
 
 package com.spotify.helios.master;
 
-
 import static java.lang.String.format;
 
 import com.spotify.helios.common.HeliosException;

--- a/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/MasterService.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.spotify.helios.common.HeliosRuntimeException;
-import com.spotify.helios.common.descriptors.TaskStatusEvent;
 import com.spotify.helios.master.http.VersionResponseFilter;
 import com.spotify.helios.master.metrics.HealthCheckGauge;
 import com.spotify.helios.master.metrics.ReportingResourceMethodDispatchAdapter;

--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -50,7 +50,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/helios-services/src/main/java/com/spotify/helios/servicescommon/ZooKeeperRegistrar.java
+++ b/helios-services/src/main/java/com/spotify/helios/servicescommon/ZooKeeperRegistrar.java
@@ -27,14 +27,14 @@ import org.apache.zookeeper.KeeperException;
 public interface ZooKeeperRegistrar {
 
   /**
-   * Called upon startup
+   * Called upon startup.
    *
    * @throws Exception If an unexpected error occurs.
    */
   void startUp() throws Exception;
 
   /**
-   * Called upon shutdown
+   * Called upon shutdown.
    *
    * @throws Exception If an unexpected error occurs.
    */

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUndeployPlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUndeployPlannerTest.java
@@ -20,7 +20,6 @@
 
 package com.spotify.helios.rollingupdate;
 
-
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;

--- a/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdatePlannerTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/rollingupdate/RollingUpdatePlannerTest.java
@@ -20,7 +20,6 @@
 
 package com.spotify.helios.rollingupdate;
 
-
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/DnsServerTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/DnsServerTest.java
@@ -20,7 +20,6 @@
 
 package com.spotify.helios.system;
 
-
 import static com.spotify.docker.client.DockerClient.LogsParam.stderr;
 import static com.spotify.docker.client.DockerClient.LogsParam.stdout;
 import static com.spotify.helios.common.descriptors.HostStatus.Status.UP;

--- a/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/LabelTest.java
@@ -42,6 +42,8 @@ import org.junit.Test;
 public class LabelTest extends SystemTestBase {
 
   /**
+   * Get labels for a set of hosts.
+   *
    * @param hosts Hostnames for which to get labels.
    *
    * @return a map whose keys are hostnames and values are maps of label key-vals.

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosConfig.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosConfig.java
@@ -35,7 +35,7 @@ public class HeliosConfig {
   public static final String APP_CONFIG_FILE = "helios.conf";
 
   /**
-   * @return The root configuration loaded from the helios configuration files.
+   * Return the root configuration loaded from the helios configuration files.
    */
   static Config loadConfig() {
     final ConfigResolveOptions resolveOptions = ConfigResolveOptions
@@ -52,11 +52,11 @@ public class HeliosConfig {
   }
 
   /**
+   * Return the name of the default profile.
+   *
    * @param profilePath  The path at which the default profile is specified.
    * @param profilesPath The path at which profiles are nested.
    * @param rootConfig   The config file root to read the default profile from.
-   *
-   * @return The name of the default profile.
    */
   static Config getDefaultProfile(
       final String profilePath, final String profilesPath, final Config rootConfig) {
@@ -69,11 +69,11 @@ public class HeliosConfig {
   }
 
   /**
+   * Return the requested configuration, or an empty configuration if profile is null.
+   *
    * @param profilesPath The path at which profiles are nested.
    * @param profile      The name of the profile to load.
    * @param rootConfig   The config file root to load profiles from.
-   *
-   * @return The requested configuration, or an empty configuration if profile is null.
    */
   static Config getProfile(
       final String profilesPath, final String profile, final Config rootConfig) {

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeployment.java
@@ -28,13 +28,18 @@ import com.spotify.helios.client.HeliosClient;
  * run.
  */
 public interface HeliosDeployment extends AutoCloseable {
+
   /**
-   * @return A helios client connected to the master(s) of this helios deployment.
+   * A helios client connected to the master(s) of this helios deployment.
+   *
+   * @return {@link HeliosClient}
    */
   HeliosClient client();
 
   /**
-   * Returns the host and port information  that the deployment is available at.
+   * Returns the host and port information that the deployment is available at.
+   *
+   * @return {@link HostAndPort}
    */
   // TODO (mbrown): should this be URI to capture scheme info also?
   HostAndPort address();

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosDeploymentResource.java
@@ -49,6 +49,8 @@ public class HeliosDeploymentResource extends ExternalResource {
   private final HeliosDeployment deployment;
 
   /**
+   * Constructor.
+   *
    * @param deployment The Helios deployment to expose to your JUnit tests.
    */
   public HeliosDeploymentResource(final HeliosDeployment deployment) {
@@ -142,8 +144,10 @@ public class HeliosDeploymentResource extends ExternalResource {
   }
 
   /**
-   * @return a Helios client connected to the Helios deployment supplied when instantiating the
-   *         HeliosDeploymentResource.
+   * Return a Helios client connected to the Helios deployment supplied when instantiating the
+   * HeliosDeploymentResource.
+   *
+   * @return {@link HeliosClient}
    */
   public HeliosClient client() {
     return deployment.client();

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -375,10 +375,10 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   /**
+   * Return the container ID of the Helios Solo container.
+   *
    * @param heliosHost The address at which the Helios agent should expect to find the Helios
    *                   master.
-   *
-   * @return The container ID of the Helios Solo container.
    *
    * @throws HeliosDeploymentException if Helios Solo could not be deployed.
    */
@@ -483,14 +483,16 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   /**
-   * @return A helios client connected to the master of this HeliosSoloDeployment.
+   * Return a helios client connected to the master of this HeliosSoloDeployment.
    */
   public HeliosClient client() {
     return this.heliosClient;
   }
 
   /**
-   * @return The container ID of the Helios Solo container.
+   * Return the container ID of the Helios Solo container.
+   *
+   * @return container ID as a String
    */
   public String heliosContainerId() {
     return heliosContainerId;
@@ -599,36 +601,42 @@ public class HeliosSoloDeployment implements HeliosDeployment {
   }
 
   /**
-   * @return A Builder that can be used to instantiate a HeliosSoloDeployment.
+   * Return a Builder that can be used to instantiate a HeliosSoloDeployment.
+   *
+   * @return {@link Builder}
    */
   public static Builder builder() {
     return builder(null);
   }
 
   /**
-   * @param profile A configuration profile used to populate builder options.
+   * Return a Builder that can be used to instantiate a HeliosSoloDeployment.
    *
-   * @return A Builder that can be used to instantiate a HeliosSoloDeployment.
+   * @param profile A configuration profile used to populate builder options.
+   * @return {@link Builder}
    */
   public static Builder builder(final String profile) {
     return new Builder(profile, HeliosConfig.loadConfig());
   }
 
   /**
-   * @return a Builder with its Docker Client configured automatically using the
-   *         <code>DOCKER_HOST</code> and <code>DOCKER_CERT_PATH</code> environment variables, or
-   *         sensible defaults if they are absent.
+   * Return a Builder with its Docker Client configured automatically using the
+   * <code>DOCKER_HOST</code> and <code>DOCKER_CERT_PATH</code> environment variables, or
+   * sensible defaults if they are absent.
+   *
+   * @return {@link Builder}
    */
   public static Builder fromEnv() {
     return fromEnv(null);
   }
 
   /**
-   * @param profile A configuration profile used to populate builder options.
+   * Return a Builder with its Docker Client configured automatically using the
+   * <code>DOCKER_HOST</code> and <code>DOCKER_CERT_PATH</code> environment variables, or
+   * sensible defaults if they are absent.
    *
-   * @return a Builder with its Docker Client configured automatically using the
-   *         <code>DOCKER_HOST</code> and <code>DOCKER_CERT_PATH</code> environment variables, or
-   *         sensible defaults if they are absent.
+   * @param profile A configuration profile used to populate builder options.
+   * @return {@link Builder}
    */
   public static Builder fromEnv(final String profile) {
     try {
@@ -713,6 +721,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     /**
      * By default, the {@link #heliosSoloImage} will be checked for updates before creating a
      * container by doing a "docker pull". Call this method with "false" to disable this behavior.
+     *
+     * @return {@link Builder}
      */
     public Builder checkForNewImages(boolean enabled) {
       this.pullBeforeCreate = enabled;
@@ -724,6 +734,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
      * {@link HeliosSoloDeployment#close()} is called. Call this method with "false" to disable this
      * (which is probably only useful for developing helios-solo or this class itself and
      * inspecting logs).
+     *
+     * @return {@link Builder}
      */
     public Builder removeHeliosSoloOnExit(boolean enabled) {
       this.removeHeliosSoloContainerOnExit = enabled;
@@ -734,6 +746,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
      * Set the number of seconds Helios solo will wait for jobs to be undeployed and, as a result,
      * their associated Docker containers to stop running before shutting itself down.
      * The default is 30 seconds.
+     *
+     * @return {@link Builder}
      */
     public Builder jobUndeployWaitSeconds(int seconds) {
       this.jobUndeployWaitSeconds = seconds;
@@ -799,6 +813,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
     /**
      * Customize the image used for helios-solo. If not set defaults to
      * "spotify/helios-solo:latest".
+     *
+     * @return {@link Builder}
      */
     public Builder heliosSoloImage(String image) {
       this.heliosSoloImage = Preconditions.checkNotNull(image);
@@ -863,6 +879,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
      * Override the credentials used for Google Container Registry. If not set, then the builder
      * will default to checking to see if an entry for "googleContainerRegistryCredentials" exists
      * in the configuration profile.
+     *
+     * @return {@link Builder}
      */
     public Builder googleContainerRegistryCredentials(File credentials) {
       this.googleContainerRegistryCredentials = Optional.of(credentials);

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobBuilder.java
@@ -320,6 +320,8 @@ public class TemporaryJobBuilder {
    * Set the {@link #image(String)} field for the Docker image to use in this job from the output of
    * docker-maven-plugin (image_info.json on classpath) or dockerfile-maven-plugin
    * (docker/image-name on classpath)
+   *
+   * @return {@link TemporaryJobBuilder}
    */
   public TemporaryJobBuilder imageFromBuild() {
     final String envPath = env.get("IMAGE_INFO_PATH");

--- a/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/TemporaryJobs.java
@@ -308,7 +308,7 @@ public class TemporaryJobs implements TestRule {
    * <li>HELIOS_ENDPOINTS - If set, use one of the endpoints, which are specified as a comma
    * separated list.</li>
    * <li>Testing Profile - If a testing profile can be loaded, use either {@code domain} or
-   * <tt>endpoints</tt> if present. If both are specified, {@code domain} takes precedence.</li>
+   * {@code endpoints} if present. If both are specified, {@code domain} takes precedence.</li>
    * <li>DOCKER_HOST - If set, assume a helios master is running on this host, so connect to it on
    * port {@code 5801}.</li>
    * <li>Use {@code http://localhost:5801}</li>

--- a/helios-tools/src/main/java/com/spotify/helios/cli/Target.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/Target.java
@@ -146,7 +146,7 @@ public abstract class Target {
   }
 
   /**
-   * Create a target from an explicit endpoint
+   * Create a target from an explicit endpoint.
    *
    * @param endpoint The endpoint.
    *
@@ -157,7 +157,7 @@ public abstract class Target {
   }
 
   /**
-   * Create targets for a list of domains
+   * Create targets for a list of domains.
    *
    * @param srvName The SRV name.
    * @param domains A list of domains.

--- a/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
+++ b/helios-tools/src/test/java/com/spotify/helios/cli/CliParserTest.java
@@ -22,7 +22,6 @@ package com.spotify.helios.cli;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Charsets;
@@ -35,10 +34,8 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 public class CliParserTest {

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>
-                <version>8.14.0</version>
+                <version>8.13.0</version>
                 <classifier>shaded</classifier>
             </dependency>
 
@@ -157,32 +157,32 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-guava</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.4</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>2.9.6</version>
+                <version>2.9.4</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
@@ -323,12 +323,12 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>ssh-agent-tls</artifactId>
-                <version>0.0.3</version>
+                <version>0.0.4</version>
             </dependency>
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>ssh-agent-proxy</artifactId>
-                <version>0.1.5</version>
+                <version>0.2.0</version>
             </dependency>
 
             <!--
@@ -435,7 +435,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        <jacoco.version>0.7.1.201405082137</jacoco.version>
+        <jacoco.version>0.8.2</jacoco.version>
         <jdeb.skip>false</jdeb.skip>
         <surefire.version>2.16</surefire.version>
         <surefireArgLine>-Xmx128m -XX:+TieredCompilation -XX:TieredStopAtLevel=1</surefireArgLine>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.spotify</groupId>
         <artifactId>foss-root</artifactId>
-        <version>5</version>
+        <version>9</version>
     </parent>
 
     <licenses>
@@ -786,7 +786,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -799,7 +799,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
* Upgrade various plugins whose old versions don't work on JDK11.
* Upgrade com.spotify:foss-root pom from 5 to 9.
* Fix various checkstyle and Javadoc errors resulting from upgrades of
  above.


Add the Dockerfile for the image in which we compile helios on Java 11.
Circle CI 2.0 doesn't provide Java 11 with its machine executor. So we must
use the Docker executor with a custom environment in the form of a
container pre-installed with Java 11 and other build tools.


* run tests on Circle CI on Java 11