### PR TITLE
add error-prone for static analysis

### DIFF
--- a/helios-client/pom.xml
+++ b/helios-client/pom.xml
@@ -131,13 +131,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
                 <version>1.5.3</version>

--- a/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
+++ b/helios-services/src/main/java/com/spotify/helios/agent/TaskRunner.java
@@ -77,7 +77,7 @@ class TaskRunner extends InterruptingExecutionThreadService {
     this.listener = checkNotNull(builder.listener, "listener");
     this.existingContainerId = builder.existingContainerId;
     this.registrar = checkNotNull(builder.registrar, "registrar");
-    this.secondsToWaitBeforeKill = checkNotNull(builder.secondsToWaitBeforeKill, "waitBeforeKill");
+    this.secondsToWaitBeforeKill = builder.secondsToWaitBeforeKill;
     this.healthChecker = Optional.fromNullable(builder.healthChecker);
     this.serviceRegistrationHandle = Optional.absent();
     this.containerId = Optional.absent();

--- a/helios-services/src/test/java/com/spotify/helios/agent/AgentParserTest.java
+++ b/helios-services/src/test/java/com/spotify/helios/agent/AgentParserTest.java
@@ -34,6 +34,7 @@ public class AgentParserTest {
   public final ExpectedException exception = ExpectedException.none();
 
   @Test
+  @SuppressWarnings("ReturnValueIgnored")
   public void testValidateArgument() {
     final Predicate<Integer> isOdd = num -> num % 2 == 1;
 

--- a/helios-testing/pom.xml
+++ b/helios-testing/pom.xml
@@ -68,14 +68,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/helios-tools/pom.xml
+++ b/helios-tools/pom.xml
@@ -84,14 +84,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/helios-tools/src/main/java/com/spotify/helios/cli/command/JobHistoryCommand.java
+++ b/helios-tools/src/main/java/com/spotify/helios/cli/command/JobHistoryCommand.java
@@ -90,7 +90,7 @@ public class JobHistoryCommand extends ControlCommand {
 
     for (final TaskStatusEvent event : events) {
       final String host = checkNotNull(event.getHost());
-      final long timestamp = checkNotNull(event.getTimestamp());
+      final long timestamp = event.getTimestamp();
       final TaskStatus status = checkNotNull(event.getStatus());
       final State state = checkNotNull(status.getState());
       String containerId = status.getContainerId();

--- a/pom.xml
+++ b/pom.xml
@@ -747,7 +747,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -715,6 +715,31 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <javac.version>9+181-r4173-1</javac.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <fork>true</fork>
+                            <compilerArgs combine.children="append">
+                                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -751,6 +776,17 @@
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
+                        <compilerArgs>
+                            <arg>-XDcompilePolicy=simple</arg>
+                            <arg>-Xplugin:ErrorProne</arg>
+                        </compilerArgs>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>com.google.errorprone</groupId>
+                                <artifactId>error_prone_core</artifactId>
+                                <version>2.3.2</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
https://errorprone.info/

also fixed one warning it found:
- https://errorprone.info/bugpattern/PreconditionsCheckNotNullPrimitive

--- 

also in this change is dropping a compiler target of 1.7 for a few of the modules (as error-prone is 8+ only).

helios-client, -testing and -tools are currently built with a 1.7
target. In 0bf718b these modules were excluded from being upgraded to
a 1.8 target to not exclude people who still used 1.7 or depended on it
(with the CLI, or Hadoop-using teams that were stuck on 1.7).

I'm not 100% certain it is worth doing that, but it was needed for error-prone.