### PR TITLE
set SUPPRESS_GCLOUD_CREDS_WARNING environment variable

### DIFF
--- a/bin/helios
+++ b/bin/helios
@@ -24,6 +24,8 @@ if [[ -n "$JDWPPORT" ]]; then
     DEBUG_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$JDWPPORT"
 fi
 
+export SUPPRESS_GCLOUD_CREDS_WARNING=true
+
 exec java \
     $JVM_ARGS \
     $DEBUG_ARGS \


### PR DESCRIPTION
to stop showing warnings about using user credentials, which as a CLI we intend.