### PR TITLE
remove usage of deprecated Futures.catching from Guava

### DIFF
--- a/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
+++ b/helios-system-tests/src/main/java/com/spotify/helios/system/SystemTestBase.java
@@ -48,7 +48,6 @@ import static org.junit.Assert.fail;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Charsets;
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -59,6 +58,7 @@ import com.google.common.collect.Range;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerCertificates;
@@ -1019,12 +1019,8 @@ public abstract class SystemTestBase {
 
   protected <T> T getOrNull(final ListenableFuture<T> future)
       throws ExecutionException, InterruptedException {
-    return Futures.catching(future, Exception.class, new Function<Exception, T>() {
-      @Override
-      public T apply(final Exception ex) {
-        return null;
-      }
-    }).get();
+    return Futures.catching(future, Exception.class, ex -> null, MoreExecutors.directExecutor())
+        .get();
   }
 
   protected static void removeContainer(final DockerClient dockerClient, final String containerId)

--- a/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
+++ b/helios-testing/src/main/java/com/spotify/helios/testing/HeliosSoloDeployment.java
@@ -25,7 +25,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonList;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -34,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.spotify.docker.client.DefaultDockerClient;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerHost;
@@ -592,12 +592,8 @@ public class HeliosSoloDeployment implements HeliosDeployment {
 
   private <T> T getOrNull(final ListenableFuture<T> future)
       throws ExecutionException, InterruptedException {
-    return Futures.catching(future, Exception.class, new Function<Exception, T>() {
-      @Override
-      public T apply(final Exception ex) {
-        return null;
-      }
-    }).get();
+    return Futures.catching(future, Exception.class, ex -> null, MoreExecutors.directExecutor())
+        .get();
   }
 
   /**


### PR DESCRIPTION
The overload of this method that does not take an Executor as an
argument is removed from Guava starting in release 26.0.

For anyone using helios-testing in a project that uses Guava >= 26.0,
this code in helios-testing causes NoSuchMethodErrors at runtime.

This is related to #1257 which I think missing this `Futures` method.