### PR TITLE
Set pinentry mode to loopback for gpg signing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -662,6 +662,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
This allows gpg version >=2.1 to read in the key passphrase.

More information here https://myshittycode.com/2017/08/07/maven-gpg-plugin-prevent-signing-prompt-or-gpg-signing-failed-no-such-file-or-directory-error/

We were previously using `gpg (GnuPG) 1.4.16` and now using `gpg (GnuPG) 2.2.4`

@mattnworb @davidxia @vbhavsar Can you PTAL?