### PR TITLE
adding post stop of 5sec to align with the upstart init file

### DIFF
--- a/src/deb/helios-agent/helios-agent.service
+++ b/src/deb/helios-agent/helios-agent.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 Restart=always
 ExecStart=/usr/bin/helios-agent-wrapper
+ExecStopPost=/bin/sleep 5
 User=helios
 
 [Install]

--- a/src/deb/helios-master/helios-master.service
+++ b/src/deb/helios-master/helios-master.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 Restart=always
 ExecStart=/usr/bin/helios-master-wrapper
+ExecStopPost=/bin/sleep 5
 User=helios
 
 [Install]


### PR DESCRIPTION
@smstone @mattnworb @davidxia 

Keeping the post stop for systemd unit file the same as in upstart init for helios agents and masters
https://github.com/spotify/helios/blob/master/src/deb/helios-agent/upstart#L35
https://github.com/spotify/helios/blob/master/src/deb/helios-master/upstart#L34