### PR TITLE
Bump dockerfile-maven-plugin to 1.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-client</artifactId>
-                <version>8.14.1</version>
+                <version>8.16.0</version>
                 <classifier>shaded</classifier>
             </dependency>
 


### PR DESCRIPTION
This is to address the issue described in 1.4.9 release https://github.com/spotify/dockerfile-maven/blob/master/CHANGELOG.md#149-released-october-25-2018

@lavanyachennupati 