### PR TITLE
Fix NPE in OldJobReaper

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/reaper/ExpiredJobReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/reaper/ExpiredJobReaper.java
@@ -80,6 +80,12 @@ public class ExpiredJobReaper extends InterruptingScheduledService {
         continue;
       } else if (job.getExpires().getTime() <= clock.now().getMillis()) {
         final JobStatus status = masterModel.getJobStatus(jobId);
+        if (status == null) {
+          log.warn("Couldn't find job status for {} because job has already been deleted."
+                   + "Skipping.", jobId);
+          return;
+        }
+
         final List<String> hosts = ImmutableList.copyOf(status.getDeployments().keySet());
 
         for (final String host : hosts) {

--- a/helios-services/src/main/java/com/spotify/helios/master/reaper/OldJobReaper.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/reaper/OldJobReaper.java
@@ -122,6 +122,12 @@ public class OldJobReaper extends RateLimitedService<Job> {
 
     try {
       final JobStatus jobStatus = masterModel.getJobStatus(jobId);
+      if (jobStatus == null) {
+        log.warn("Couldn't find job status for {} because job has already been deleted. Skipping.",
+            jobId);
+        return;
+      }
+
       final Map<String, Deployment> deployments = jobStatus.getDeployments();
       final List<TaskStatusEvent> events = masterModel.getJobHistory(jobId);
 


### PR DESCRIPTION
The primary purpose of this change is to avoid extraneous NPE errors in the
warning logs. Other than that, this PR won't affect any the helios master in
any meaningful way.

OldJobReaper periodically garbage collects old jobs that haven't been run in a
certain amount of time. It gets a list of all jobs, and slowly iterates through
each one checking when it was last run. By the time it checks, the job may have
already been deleted. This causes noisy NPE errors in the logs.