### PR TITLE
upgrade jackson-databind and other libraries to 2.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,32 +157,32 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-guava</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
Github is showing security warnings related to versions of
jackson-databind < 2.9.10, this should fix all of them.

Some of the most critical/high warnings (there are other severities too
not listed here) are:

- https://nvd.nist.gov/vuln/detail/CVE-2019-16335
- https://nvd.nist.gov/vuln/detail/CVE-2019-14540
- https://nvd.nist.gov/vuln/detail/CVE-2019-14379
- https://nvd.nist.gov/vuln/detail/CVE-2019-14439