### PR TITLE
master: log more info on ZK error when rolling-update fails

### DIFF
--- a/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
+++ b/helios-services/src/main/java/com/spotify/helios/master/ZooKeeperMasterModel.java
@@ -676,7 +676,8 @@ public class ZooKeeperMasterModel implements MasterModel {
       throw new DeploymentGroupDoesNotExistException(deploymentGroup.getName());
     } catch (final KeeperException e) {
       throw new HeliosRuntimeException(
-          "rolling-update on deployment-group " + deploymentGroup.getName() + " failed", e);
+          "rolling-update on deployment-group " + deploymentGroup.getName() + " failed. "
+          + e.getMessage(), e);
     }
   }
 
@@ -836,7 +837,8 @@ public class ZooKeeperMasterModel implements MasterModel {
             log.info("rolling-update step on deployment-group was processed by another master"
                      + ": name={}, zookeeper operations={}", deploymentGroupName, ops);
           } catch (KeeperException e) {
-            log.error("rolling-update on deployment-group {} failed", deploymentGroupName, e);
+            log.error("rolling-update on deployment-group {} failed. {}", deploymentGroupName,
+                e.getMessage(), e);
           }
         }
       } catch (final Exception e) {


### PR DESCRIPTION
We log the stacktrace of KeeperException. But this class
extends Exception and doesn't override `toString()`.
So right now the error message and stacktrace don't state the
ZK path, if any, that the exception occurred on. Knowing the ZK path is helpful
in debugging rolling-update problems.

`KeeperException.getMessage()` returns the error code and ZK path if present.